### PR TITLE
feat(core): unlock module + BIP-39 recovery KAT

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -69,6 +69,7 @@ dependencies = [
  "bitcoin_hashes",
  "serde",
  "unicode-normalization",
+ "zeroize",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -49,10 +49,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
 name = "base64ct"
 version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
+
+[[package]]
+name = "bip39"
+version = "2.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90dbd31c98227229239363921e60fcf5e558e43ec69094d46fc4996f08d1d5bc"
+dependencies = [
+ "bitcoin_hashes",
+ "serde",
+ "unicode-normalization",
+]
 
 [[package]]
 name = "bit-set"
@@ -68,6 +85,15 @@ name = "bit-vec"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
+name = "bitcoin_hashes"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26ec84b80c482df901772e931a9a681e26a1b9ee2302edeff23cb30328745c8b"
+dependencies = [
+ "hex-conservative",
+]
 
 [[package]]
 name = "bitflags"
@@ -489,6 +515,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "hex-conservative"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fda06d18ac606267c40c04e41b9947729bf8b9efe74bd4e82b61a5f26a510b9f"
+dependencies = [
+ "arrayvec",
+]
+
+[[package]]
 name = "hkdf"
 version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -894,6 +929,8 @@ name = "secretary-core"
 version = "0.1.0"
 dependencies = [
  "argon2",
+ "base64",
+ "bip39",
  "blake3",
  "chacha20poly1305",
  "ciborium",
@@ -910,6 +947,8 @@ dependencies = [
  "sha3 0.10.9",
  "subtle",
  "thiserror",
+ "toml",
+ "unicode-normalization",
  "x25519-dalek",
  "zeroize",
 ]
@@ -975,6 +1014,15 @@ dependencies = [
  "serde",
  "serde_core",
  "zmij",
+]
+
+[[package]]
+name = "serde_spanned"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -1103,6 +1151,62 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinyvec"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
+name = "toml"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_write",
+ "winnow",
+]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
+
+[[package]]
 name = "typenum"
 version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1119,6 +1223,15 @@ name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fd4f6878c9cb28d874b009da9e8d183b5abc80117c40bbd187a1fde336be6e8"
+dependencies = [
+ "tinyvec",
+]
 
 [[package]]
 name = "unicode-xid"
@@ -1222,6 +1335,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
+]
+
+[[package]]
+name = "winnow"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -8,6 +8,10 @@ rust-version.workspace = true
 description = "Secretary cryptographic core: vault format, identity, and unlock primitives."
 
 [dependencies]
+base64 = "0.22"
+bip39 = "2"
+toml = "0.8"
+unicode-normalization = "0.1"
 thiserror = "2"
 zeroize = { version = "1", features = ["zeroize_derive"] }
 subtle = "2"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -9,7 +9,7 @@ description = "Secretary cryptographic core: vault format, identity, and unlock 
 
 [dependencies]
 base64 = "0.22"
-bip39 = "2"
+bip39 = { version = "2", features = ["zeroize"] }
 toml = "0.8"
 unicode-normalization = "0.1"
 thiserror = "2"

--- a/core/src/unlock/bundle.rs
+++ b/core/src/unlock/bundle.rs
@@ -162,11 +162,12 @@ pub enum BundleError {
 /// Carries the four `(sk, pk)` pairs of the v1 hybrid suite, plus the
 /// 16-byte user UUID, a display name, and a creation timestamp.
 ///
-/// Secret-key fields are wrapped in [`Sensitive`] so they zeroize on drop.
-/// The bundle does not derive `Clone`, `Debug`, or `PartialEq`: cloning
-/// would silently duplicate secret material; a derived `Debug` would leak
-/// it (a manual redacted impl is provided below); equality is only ever
-/// asked of test code, which compares exposed contents field-by-field.
+/// Secret-key fields are wrapped in [`Sensitive`] (or [`SecretBytes`] for
+/// runtime-sized PQC keys) so they zeroize on drop. The bundle does not
+/// derive `Clone`, `Debug`, or `PartialEq`: cloning would silently
+/// duplicate secret material; a derived `Debug` would leak it; equality is
+/// only ever asked of test code, which compares exposed contents
+/// field-by-field.
 pub struct IdentityBundle {
     /// 128-bit user UUID, the same bytes as `contact_uuid` on the §6
     /// Contact Card.
@@ -365,7 +366,11 @@ impl IdentityBundle {
                 return Err(BundleError::CborDecode("non-string map key".into()));
             };
             match key.as_str() {
-                KEY_USER_UUID => set_once(&mut user_uuid, take_uuid(v)?, &key)?,
+                KEY_USER_UUID => set_once(
+                    &mut user_uuid,
+                    take_uuid(v)?,
+                    &key,
+                )?,
                 KEY_DISPLAY_NAME => set_once(&mut display_name, take_text(v)?, &key)?,
                 KEY_X25519_SK => set_once(
                     &mut x25519_sk_bytes,
@@ -489,6 +494,20 @@ fn encode_map(entries: &[(Value, Value)]) -> Result<Vec<u8>, BundleError> {
     Ok(buf)
 }
 
+/// Compute the canonical CBOR sort order for two map keys. Test-only: lets
+/// the test module build deliberately non-canonical maps that are then
+/// sorted (or deliberately not sorted) to exercise the strict-decoder
+/// branches. Production encode does the sorting itself in [`encode_map`]
+/// against materialised key bytes.
+#[cfg(test)]
+pub(super) fn canonical_key_cmp(a: &Value, b: &Value) -> std::cmp::Ordering {
+    let mut a_buf = Vec::new();
+    let mut b_buf = Vec::new();
+    let _ = ciborium::ser::into_writer(a, &mut a_buf);
+    let _ = ciborium::ser::into_writer(b, &mut b_buf);
+    a_buf.cmp(&b_buf)
+}
+
 fn set_once<T>(slot: &mut Option<T>, v: T, key: &str) -> Result<(), BundleError> {
     if slot.is_some() {
         return Err(BundleError::DuplicateField(key.to_string()));
@@ -517,9 +536,7 @@ fn take_uuid(v: Value) -> Result<[u8; USER_UUID_LEN], BundleError> {
         Value::Bytes(b) => b,
         _ => return Err(BundleError::InvalidUuid),
     };
-    bytes
-        .try_into()
-        .map_err(|_: Vec<u8>| BundleError::InvalidUuid)
+    bytes.try_into().map_err(|_: Vec<u8>| BundleError::InvalidUuid)
 }
 
 fn take_fixed_bytes<const N: usize>(
@@ -531,13 +548,11 @@ fn take_fixed_bytes<const N: usize>(
         _ => return Err(BundleError::CborDecode("expected byte string".into())),
     };
     let got = bytes.len();
-    bytes
-        .try_into()
-        .map_err(|_: Vec<u8>| BundleError::WrongKeySize {
-            field,
-            expected: N,
-            got,
-        })
+    bytes.try_into().map_err(|_: Vec<u8>| BundleError::WrongKeySize {
+        field,
+        expected: N,
+        got,
+    })
 }
 
 fn take_sized_bytes(
@@ -615,5 +630,144 @@ mod tests {
         let bytes_1 = b.to_canonical_cbor().expect("encode");
         let bytes_2 = b.to_canonical_cbor().expect("encode");
         assert_eq!(bytes_1, bytes_2, "canonical encoding must be deterministic");
+    }
+
+    #[test]
+    fn parse_rejects_unknown_field() {
+        // Build a minimal map that is canonical-shaped (keys sorted) but
+        // contains a key the spec doesn't define. The decoder must reject
+        // before the missing-field check has a chance to fire.
+        let mut entries = vec![
+            (Value::Text(KEY_USER_UUID.into()), Value::Bytes(vec![0u8; 16])),
+            (Value::Text("rogue".into()), Value::Text("payload".into())),
+        ];
+        entries.sort_by(|a, b| super::canonical_key_cmp(&a.0, &b.0));
+        let mut buf = Vec::new();
+        ciborium::ser::into_writer(&Value::Map(entries), &mut buf).unwrap();
+        let err = IdentityBundle::from_canonical_cbor(&buf).unwrap_err();
+        assert!(
+            matches!(err, BundleError::UnknownField(ref s) if s == "rogue"),
+            "unexpected error: {err:?}"
+        );
+    }
+
+    #[test]
+    fn parse_rejects_duplicate_field() {
+        // Two identical text keys. ciborium accepts duplicates on encode (it
+        // does not police map invariants for `Value::Map`); our decoder must
+        // reject them.
+        let entries = vec![
+            (
+                Value::Text(KEY_DISPLAY_NAME.into()),
+                Value::Text("Alice".into()),
+            ),
+            (
+                Value::Text(KEY_DISPLAY_NAME.into()),
+                Value::Text("Bob".into()),
+            ),
+        ];
+        let mut buf = Vec::new();
+        ciborium::ser::into_writer(&Value::Map(entries), &mut buf).unwrap();
+        let err = IdentityBundle::from_canonical_cbor(&buf).unwrap_err();
+        assert!(
+            matches!(err, BundleError::DuplicateField(ref s) if s == "display_name"),
+            "unexpected error: {err:?}"
+        );
+    }
+
+    #[test]
+    fn parse_rejects_wrong_x25519_pk_size() {
+        // Build a full-shape valid bundle, then mutate `x25519_pk` to 30
+        // bytes. Re-encoding (without the canonical-key sort) is fine here
+        // because the original bundle was canonical and we are not changing
+        // any keys.
+        let mut rng = ChaCha20Rng::from_seed([8u8; 32]);
+        let b = generate("X", 0, &mut rng);
+        let bytes = b.to_canonical_cbor().unwrap();
+        let value: Value = ciborium::de::from_reader(&bytes[..]).unwrap();
+        let Value::Map(mut entries) = value else { panic!() };
+        for (k, v) in entries.iter_mut() {
+            if let Value::Text(s) = k {
+                if s == KEY_X25519_PK {
+                    *v = Value::Bytes(vec![0u8; 30]);
+                }
+            }
+        }
+        let mut buf = Vec::new();
+        ciborium::ser::into_writer(&Value::Map(entries), &mut buf).unwrap();
+        let err = IdentityBundle::from_canonical_cbor(&buf).unwrap_err();
+        assert!(
+            matches!(
+                err,
+                BundleError::WrongKeySize {
+                    field: "x25519_pk",
+                    expected: 32,
+                    got: 30,
+                }
+            ),
+            "unexpected error: {err:?}"
+        );
+    }
+
+    #[test]
+    fn parse_rejects_non_canonical_key_order() {
+        // Emit fields in §5 listing order (which is NOT canonical: e.g.
+        // "user_uuid" sorts after "ml_*" because of length). The decoder
+        // must catch this via re-encode-and-compare.
+        let mut rng = ChaCha20Rng::from_seed([9u8; 32]);
+        let b = generate("X", 0, &mut rng);
+        let entries: Vec<(Value, Value)> = vec![
+            (
+                Value::Text(KEY_USER_UUID.into()),
+                Value::Bytes(b.user_uuid.to_vec()),
+            ),
+            (
+                Value::Text(KEY_DISPLAY_NAME.into()),
+                Value::Text(b.display_name.clone()),
+            ),
+            (
+                Value::Text(KEY_X25519_SK.into()),
+                Value::Bytes(b.x25519_sk.expose().to_vec()),
+            ),
+            (
+                Value::Text(KEY_X25519_PK.into()),
+                Value::Bytes(b.x25519_pk.to_vec()),
+            ),
+            (
+                Value::Text(KEY_ML_KEM_768_SK.into()),
+                Value::Bytes(b.ml_kem_768_sk.expose().clone()),
+            ),
+            (
+                Value::Text(KEY_ML_KEM_768_PK.into()),
+                Value::Bytes(b.ml_kem_768_pk.clone()),
+            ),
+            (
+                Value::Text(KEY_ED25519_SK.into()),
+                Value::Bytes(b.ed25519_sk.expose().to_vec()),
+            ),
+            (
+                Value::Text(KEY_ED25519_PK.into()),
+                Value::Bytes(b.ed25519_pk.to_vec()),
+            ),
+            (
+                Value::Text(KEY_ML_DSA_65_SK.into()),
+                Value::Bytes(b.ml_dsa_65_sk.expose().clone()),
+            ),
+            (
+                Value::Text(KEY_ML_DSA_65_PK.into()),
+                Value::Bytes(b.ml_dsa_65_pk.clone()),
+            ),
+            (
+                Value::Text(KEY_CREATED_AT.into()),
+                Value::Integer(b.created_at_ms.into()),
+            ),
+        ];
+        let mut buf = Vec::new();
+        ciborium::ser::into_writer(&Value::Map(entries), &mut buf).unwrap();
+        let err = IdentityBundle::from_canonical_cbor(&buf).unwrap_err();
+        assert!(
+            matches!(err, BundleError::NonCanonicalCbor),
+            "unexpected error: {err:?}"
+        );
     }
 }

--- a/core/src/unlock/bundle.rs
+++ b/core/src/unlock/bundle.rs
@@ -1,0 +1,211 @@
+//! IdentityBundle plaintext (`docs/crypto-design.md` §5).
+//!
+//! The §5 record carries the four `(sk, pk)` pairs that constitute a user's
+//! cryptographic identity, plus a 16-byte UUID, a display name, and a
+//! creation timestamp (Unix milliseconds). The wire form is canonical CBOR
+//! per §6.2 (RFC 8949 §4.2.1 deterministic encoding) — implemented in the
+//! follow-up commit; this commit lands the struct and `generate`.
+//!
+//! ## ML-DSA-65 secret-key representation (deviation from §5)
+//!
+//! The §5 listing pins `ml_dsa_65_sk` at 4032 bytes, the FIPS 204 expanded
+//! signing-key encoding. We instead store the 32-byte FIPS 204 seed (`xi` in
+//! KeyGen_internal), matching what [`crate::crypto::sig`] returns from
+//! [`crate::crypto::sig::generate_ml_dsa_65`] (and what the upstream
+//! `ml-dsa` 0.1.0-rc.8 crate now considers canonical — the 4032-byte
+//! encoding is `#[deprecated]` there). The two representations are
+//! information-equivalent: the expanded form is a deterministic function of
+//! the seed. See `crate::crypto::sig` module docs. This is a deliberate
+//! departure from `docs/crypto-design.md` §5 wording; the §5 spec
+//! antedates the upstream crate's seed-only direction. The on-disk byte
+//! length for the `ml_dsa_65_sk` CBOR field is therefore 32 in this
+//! implementation.
+
+use core::fmt;
+
+use rand_core::{CryptoRng, RngCore};
+
+use crate::crypto::kem::{
+    generate_ml_kem_768, generate_x25519, ML_KEM_768_PK_LEN, ML_KEM_768_SK_LEN, X25519_PK_LEN,
+    X25519_SK_LEN,
+};
+use crate::crypto::secret::Sensitive;
+use crate::crypto::sig::{
+    generate_ed25519, generate_ml_dsa_65, ED25519_PK_LEN, ED25519_SK_LEN, ML_DSA_65_PK_LEN,
+    ML_DSA_65_SEED_LEN,
+};
+
+// ---------------------------------------------------------------------------
+// Constants (§14)
+// ---------------------------------------------------------------------------
+
+/// User UUID length, in bytes (§5).
+pub const USER_UUID_LEN: usize = 16;
+
+/// Re-export of [`crate::crypto::kem::X25519_SK_LEN`] for callers consuming
+/// the bundle without pulling in the `kem` module directly.
+pub const BUNDLE_X25519_SK_LEN: usize = X25519_SK_LEN;
+/// Re-export of [`crate::crypto::kem::X25519_PK_LEN`].
+pub const BUNDLE_X25519_PK_LEN: usize = X25519_PK_LEN;
+/// Re-export of [`crate::crypto::kem::ML_KEM_768_SK_LEN`].
+pub const BUNDLE_ML_KEM_768_SK_LEN: usize = ML_KEM_768_SK_LEN;
+/// Re-export of [`crate::crypto::kem::ML_KEM_768_PK_LEN`].
+pub const BUNDLE_ML_KEM_768_PK_LEN: usize = ML_KEM_768_PK_LEN;
+/// Re-export of [`crate::crypto::sig::ED25519_SK_LEN`].
+pub const BUNDLE_ED25519_SK_LEN: usize = ED25519_SK_LEN;
+/// Re-export of [`crate::crypto::sig::ED25519_PK_LEN`].
+pub const BUNDLE_ED25519_PK_LEN: usize = ED25519_PK_LEN;
+/// ML-DSA-65 secret-key length as stored in the bundle, in bytes.
+///
+/// This is the FIPS 204 seed length (32), not the §5 spec's 4032-byte
+/// expanded encoding. See module docs for the rationale.
+pub const BUNDLE_ML_DSA_65_SK_LEN: usize = ML_DSA_65_SEED_LEN;
+/// Re-export of [`crate::crypto::sig::ML_DSA_65_PK_LEN`].
+pub const BUNDLE_ML_DSA_65_PK_LEN: usize = ML_DSA_65_PK_LEN;
+
+// ---------------------------------------------------------------------------
+// IdentityBundle
+// ---------------------------------------------------------------------------
+
+/// IdentityBundle plaintext per `docs/crypto-design.md` §5.
+///
+/// Carries the four `(sk, pk)` pairs of the v1 hybrid suite, plus the
+/// 16-byte user UUID, a display name, and a creation timestamp.
+///
+/// Secret-key fields are wrapped in [`Sensitive`] so they zeroize on drop.
+/// The bundle does not derive `Clone`, `Debug`, or `PartialEq`: cloning
+/// would silently duplicate secret material; a derived `Debug` would leak
+/// it (a manual redacted impl is provided below); equality is only ever
+/// asked of test code, which compares exposed contents field-by-field.
+pub struct IdentityBundle {
+    /// 128-bit user UUID, the same bytes as `contact_uuid` on the §6
+    /// Contact Card.
+    pub user_uuid: [u8; USER_UUID_LEN],
+    /// User-facing label. UTF-8; no length cap enforced here.
+    pub display_name: String,
+    /// X25519 secret key, 32 bytes.
+    pub x25519_sk: Sensitive<[u8; X25519_SK_LEN]>,
+    /// X25519 public key, 32 bytes.
+    pub x25519_pk: [u8; X25519_PK_LEN],
+    /// ML-KEM-768 secret (decapsulation) key, 2400 bytes (FIPS 203). Stored
+    /// as `Sensitive<Vec<u8>>` because the upstream `ml-kem` type is
+    /// runtime-sized via const generics.
+    pub ml_kem_768_sk: Sensitive<Vec<u8>>,
+    /// ML-KEM-768 public (encapsulation) key, 1184 bytes (FIPS 203).
+    pub ml_kem_768_pk: Vec<u8>,
+    /// Ed25519 secret key, 32 bytes.
+    pub ed25519_sk: Sensitive<[u8; ED25519_SK_LEN]>,
+    /// Ed25519 public key, 32 bytes.
+    pub ed25519_pk: [u8; ED25519_PK_LEN],
+    /// ML-DSA-65 signing-key seed, 32 bytes (FIPS 204 `xi`). Stored as
+    /// `Sensitive<Vec<u8>>` for symmetry with [`Self::ml_kem_768_sk`] —
+    /// the future suite-migration path will replace this with a different
+    /// PQC scheme whose seed length may differ. See module docs for the
+    /// deviation from §5's 4032-byte expanded encoding.
+    pub ml_dsa_65_sk: Sensitive<Vec<u8>>,
+    /// ML-DSA-65 public key, 1952 bytes (FIPS 204).
+    pub ml_dsa_65_pk: Vec<u8>,
+    /// Creation timestamp, Unix milliseconds. Encoded under the §5 CBOR key
+    /// `"created_at"`; the struct field name is more descriptive of the unit.
+    pub created_at_ms: u64,
+}
+
+/// Redacted debug representation. The four secret-key fields are sensitive;
+/// the only externally observable structure is the public-key shapes,
+/// metadata fields, and a `<redacted>` placeholder for each secret. Mirrors
+/// the policy on [`crate::unlock::mnemonic::Mnemonic`] — a derived `Debug`
+/// would defeat the zeroize-on-drop discipline by leaking through
+/// formatting.
+impl fmt::Debug for IdentityBundle {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("IdentityBundle")
+            .field("user_uuid", &self.user_uuid)
+            .field("display_name", &self.display_name)
+            .field("x25519_sk", &"<redacted>")
+            .field("x25519_pk", &self.x25519_pk)
+            .field("ml_kem_768_sk", &"<redacted>")
+            .field("ml_kem_768_pk_len", &self.ml_kem_768_pk.len())
+            .field("ed25519_sk", &"<redacted>")
+            .field("ed25519_pk", &self.ed25519_pk)
+            .field("ml_dsa_65_sk", &"<redacted>")
+            .field("ml_dsa_65_pk_len", &self.ml_dsa_65_pk.len())
+            .field("created_at_ms", &self.created_at_ms)
+            .finish()
+    }
+}
+
+/// Generate a fresh IdentityBundle using the provided CSPRNG.
+///
+/// Draws a fresh `user_uuid` and four keypairs (X25519, ML-KEM-768,
+/// Ed25519, ML-DSA-65). The caller supplies `display_name` and
+/// `created_at_ms`; both are cleartext public material in the §5 record.
+///
+/// In production, `rng` is `rand_core::OsRng` (per
+/// `docs/crypto-design.md` §13). Tests pin determinism by passing a seeded
+/// `ChaCha20Rng` instead.
+pub fn generate(
+    display_name: &str,
+    created_at_ms: u64,
+    rng: &mut (impl RngCore + CryptoRng),
+) -> IdentityBundle {
+    let mut user_uuid = [0u8; USER_UUID_LEN];
+    rng.fill_bytes(&mut user_uuid);
+
+    let (x25519_sk, x25519_pk) = generate_x25519(rng);
+    let (ml_kem_768_sk_owned, ml_kem_768_pk_owned) = generate_ml_kem_768(rng);
+    let (ed25519_sk, ed25519_pk) = generate_ed25519(rng);
+    let (ml_dsa_65_sk_owned, ml_dsa_65_pk_owned) = generate_ml_dsa_65(rng);
+
+    // The kem/sig modules wrap their PQC secrets in module-private newtypes
+    // (`MlKem768Secret`, `MlDsa65Secret`) that own a `SecretBytes`. The
+    // bundle stores a `Sensitive<Vec<u8>>` so callers see one uniform
+    // expose-style accessor across all four secret keys. We copy the bytes
+    // through `expose()` (the only public read accessor) — this is one
+    // visible secret read at construction time, and the original wrapper is
+    // dropped (and its `SecretBytes` zeroized) at the end of this function.
+    let ml_kem_768_sk = Sensitive::new(ml_kem_768_sk_owned.expose().to_vec());
+    let ml_dsa_65_sk = Sensitive::new(ml_dsa_65_sk_owned.expose().to_vec());
+
+    IdentityBundle {
+        user_uuid,
+        display_name: display_name.to_string(),
+        x25519_sk,
+        x25519_pk,
+        ml_kem_768_sk,
+        ml_kem_768_pk: ml_kem_768_pk_owned.as_bytes().to_vec(),
+        ed25519_sk,
+        ed25519_pk,
+        ml_dsa_65_sk,
+        ml_dsa_65_pk: ml_dsa_65_pk_owned.as_bytes().to_vec(),
+        created_at_ms,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rand_chacha::{rand_core::SeedableRng, ChaCha20Rng};
+
+    #[test]
+    fn generate_produces_consistent_keypairs() {
+        let mut rng = ChaCha20Rng::from_seed([5u8; 32]);
+        let b = generate("Alice", 1_714_060_800_000, &mut rng);
+
+        assert_eq!(b.display_name, "Alice");
+        assert_eq!(b.created_at_ms, 1_714_060_800_000);
+        assert_eq!(b.x25519_sk.expose().len(), X25519_SK_LEN);
+        assert_eq!(b.x25519_pk.len(), X25519_PK_LEN);
+        assert_eq!(b.ml_kem_768_sk.expose().len(), ML_KEM_768_SK_LEN);
+        assert_eq!(b.ml_kem_768_pk.len(), ML_KEM_768_PK_LEN);
+        assert_eq!(b.ed25519_sk.expose().len(), ED25519_SK_LEN);
+        assert_eq!(b.ed25519_pk.len(), ED25519_PK_LEN);
+        // Per module docs: bundle stores the FIPS 204 seed (32 B), not the
+        // §5-spec'd 4032-byte expanded encoding.
+        assert_eq!(b.ml_dsa_65_sk.expose().len(), ML_DSA_65_SEED_LEN);
+        assert_eq!(b.ml_dsa_65_pk.len(), ML_DSA_65_PK_LEN);
+    }
+}

--- a/core/src/unlock/bundle.rs
+++ b/core/src/unlock/bundle.rs
@@ -66,26 +66,15 @@ use crate::crypto::sig::{
 /// User UUID length, in bytes (§5).
 pub const USER_UUID_LEN: usize = 16;
 
-/// Re-export of [`crate::crypto::kem::X25519_SK_LEN`] for callers consuming
-/// the bundle without pulling in the `kem` module directly.
-pub const BUNDLE_X25519_SK_LEN: usize = X25519_SK_LEN;
-/// Re-export of [`crate::crypto::kem::X25519_PK_LEN`].
-pub const BUNDLE_X25519_PK_LEN: usize = X25519_PK_LEN;
-/// Re-export of [`crate::crypto::kem::ML_KEM_768_SK_LEN`].
-pub const BUNDLE_ML_KEM_768_SK_LEN: usize = ML_KEM_768_SK_LEN;
-/// Re-export of [`crate::crypto::kem::ML_KEM_768_PK_LEN`].
-pub const BUNDLE_ML_KEM_768_PK_LEN: usize = ML_KEM_768_PK_LEN;
-/// Re-export of [`crate::crypto::sig::ED25519_SK_LEN`].
-pub const BUNDLE_ED25519_SK_LEN: usize = ED25519_SK_LEN;
-/// Re-export of [`crate::crypto::sig::ED25519_PK_LEN`].
-pub const BUNDLE_ED25519_PK_LEN: usize = ED25519_PK_LEN;
+// BUNDLE_ML_DSA_65_SK_LEN intentionally re-exposes the seed-length constant under a bundle-prefixed name to make the spec/seed semantic explicit at the bundle layer.
 /// ML-DSA-65 secret-key length as stored in the bundle, in bytes.
 ///
 /// This is the FIPS 204 seed length (32), not the §5 spec's 4032-byte
-/// expanded encoding. See module docs for the rationale.
+/// expanded encoding. The bundle-prefixed name makes the seed-vs-expanded
+/// distinction explicit at the bundle layer, where the on-disk encoding
+/// is fixed at 32 B regardless of any future renaming in `crypto::sig`.
+/// See module docs for the full rationale.
 pub const BUNDLE_ML_DSA_65_SK_LEN: usize = ML_DSA_65_SEED_LEN;
-/// Re-export of [`crate::crypto::sig::ML_DSA_65_PK_LEN`].
-pub const BUNDLE_ML_DSA_65_PK_LEN: usize = ML_DSA_65_PK_LEN;
 
 // CBOR map keys (§5). String literals only used here; centralised so a typo
 // becomes a compile-time fix rather than a silent encoding drift.
@@ -109,10 +98,9 @@ const KEY_CREATED_AT: &str = "created_at";
 #[derive(Debug, thiserror::Error)]
 pub enum BundleError {
     /// CBOR encoding produced an I/O or serialization error from `ciborium`,
-    /// or the byte stream did not contain a top-level map, or trailing bytes
-    /// followed the map.
+    /// or the byte stream did not contain a top-level map.
     #[error("CBOR encode/decode error: {0}")]
-    CborDecode(String),
+    CborError(String),
 
     /// Input parsed but was not in RFC 8949 §4.2.1 canonical form (e.g. keys
     /// not in bytewise lexicographic order, non-shortest length prefixes,
@@ -137,7 +125,8 @@ pub enum BundleError {
     WrongKeySize {
         /// The §5 CBOR key whose value had the wrong length.
         field: &'static str,
-        /// Expected byte length per §5 / `BUNDLE_*_LEN`.
+        /// Expected byte length per §5 (see `crypto::kem` / `crypto::sig`
+        /// length constants and [`BUNDLE_ML_DSA_65_SK_LEN`]).
         expected: usize,
         /// Actual byte length seen on the wire.
         got: usize,
@@ -339,11 +328,11 @@ impl IdentityBundle {
     /// tampered file) is rejected loudly rather than silently accepted.
     pub fn from_canonical_cbor(bytes: &[u8]) -> Result<Self, BundleError> {
         let value: Value = ciborium::de::from_reader(bytes)
-            .map_err(|e| BundleError::CborDecode(e.to_string()))?;
+            .map_err(|e| BundleError::CborError(e.to_string()))?;
         let map = match value {
             Value::Map(m) => m,
             _ => {
-                return Err(BundleError::CborDecode(
+                return Err(BundleError::CborError(
                     "expected top-level CBOR map".into(),
                 ))
             }
@@ -363,7 +352,7 @@ impl IdentityBundle {
 
         for (k, v) in map {
             let Value::Text(key) = k else {
-                return Err(BundleError::CborDecode("non-string map key".into()));
+                return Err(BundleError::CborError("non-string map key".into()));
             };
             match key.as_str() {
                 KEY_USER_UUID => set_once(
@@ -421,34 +410,34 @@ impl IdentityBundle {
 
         let bundle = IdentityBundle {
             user_uuid: user_uuid
-                .ok_or_else(|| BundleError::CborDecode(format!("missing field {KEY_USER_UUID}")))?,
+                .ok_or_else(|| BundleError::CborError(format!("missing field {KEY_USER_UUID}")))?,
             display_name: display_name.ok_or_else(|| {
-                BundleError::CborDecode(format!("missing field {KEY_DISPLAY_NAME}"))
+                BundleError::CborError(format!("missing field {KEY_DISPLAY_NAME}"))
             })?,
             x25519_sk: Sensitive::new(x25519_sk_bytes.ok_or_else(|| {
-                BundleError::CborDecode(format!("missing field {KEY_X25519_SK}"))
+                BundleError::CborError(format!("missing field {KEY_X25519_SK}"))
             })?),
             x25519_pk: x25519_pk
-                .ok_or_else(|| BundleError::CborDecode(format!("missing field {KEY_X25519_PK}")))?,
+                .ok_or_else(|| BundleError::CborError(format!("missing field {KEY_X25519_PK}")))?,
             ml_kem_768_sk: Sensitive::new(ml_kem_768_sk_bytes.ok_or_else(|| {
-                BundleError::CborDecode(format!("missing field {KEY_ML_KEM_768_SK}"))
+                BundleError::CborError(format!("missing field {KEY_ML_KEM_768_SK}"))
             })?),
             ml_kem_768_pk: ml_kem_768_pk.ok_or_else(|| {
-                BundleError::CborDecode(format!("missing field {KEY_ML_KEM_768_PK}"))
+                BundleError::CborError(format!("missing field {KEY_ML_KEM_768_PK}"))
             })?,
             ed25519_sk: Sensitive::new(ed25519_sk_bytes.ok_or_else(|| {
-                BundleError::CborDecode(format!("missing field {KEY_ED25519_SK}"))
+                BundleError::CborError(format!("missing field {KEY_ED25519_SK}"))
             })?),
             ed25519_pk: ed25519_pk
-                .ok_or_else(|| BundleError::CborDecode(format!("missing field {KEY_ED25519_PK}")))?,
+                .ok_or_else(|| BundleError::CborError(format!("missing field {KEY_ED25519_PK}")))?,
             ml_dsa_65_sk: Sensitive::new(ml_dsa_65_sk_bytes.ok_or_else(|| {
-                BundleError::CborDecode(format!("missing field {KEY_ML_DSA_65_SK}"))
+                BundleError::CborError(format!("missing field {KEY_ML_DSA_65_SK}"))
             })?),
             ml_dsa_65_pk: ml_dsa_65_pk.ok_or_else(|| {
-                BundleError::CborDecode(format!("missing field {KEY_ML_DSA_65_PK}"))
+                BundleError::CborError(format!("missing field {KEY_ML_DSA_65_PK}"))
             })?,
             created_at_ms: created_at_ms
-                .ok_or_else(|| BundleError::CborDecode(format!("missing field {KEY_CREATED_AT}")))?,
+                .ok_or_else(|| BundleError::CborError(format!("missing field {KEY_CREATED_AT}")))?,
         };
 
         // Reject non-canonical input. Cheapest reliable check: re-encode
@@ -456,10 +445,8 @@ impl IdentityBundle {
         // pattern as `card.rs::from_canonical_cbor`.
         let canonical = bundle.to_canonical_cbor()?;
         if canonical.as_slice() != bytes {
-            // Drop the partially-decoded bundle (zeroizing its sensitive
-            // fields) before returning the error; the caller never sees
-            // these bytes.
-            drop(bundle);
+            // `bundle` drops here at scope exit, zeroizing its sensitive
+            // fields; the caller never sees the partially-decoded value.
             return Err(BundleError::NonCanonicalCbor);
         }
 
@@ -481,7 +468,7 @@ fn encode_map(entries: &[(Value, Value)]) -> Result<Vec<u8>, BundleError> {
         .map(|pair| {
             let mut key_bytes = Vec::new();
             ciborium::ser::into_writer(&pair.0, &mut key_bytes)
-                .map_err(|e| BundleError::CborDecode(e.to_string()))?;
+                .map_err(|e| BundleError::CborError(e.to_string()))?;
             Ok((key_bytes, pair.clone()))
         })
         .collect::<Result<_, BundleError>>()?;
@@ -490,7 +477,7 @@ fn encode_map(entries: &[(Value, Value)]) -> Result<Vec<u8>, BundleError> {
     let value = Value::Map(sorted.into_iter().map(|(_, pair)| pair).collect());
     let mut buf = Vec::new();
     ciborium::ser::into_writer(&value, &mut buf)
-        .map_err(|e| BundleError::CborDecode(e.to_string()))?;
+        .map_err(|e| BundleError::CborError(e.to_string()))?;
     Ok(buf)
 }
 
@@ -519,14 +506,18 @@ fn set_once<T>(slot: &mut Option<T>, v: T, key: &str) -> Result<(), BundleError>
 fn take_text(v: Value) -> Result<String, BundleError> {
     match v {
         Value::Text(s) => Ok(s),
-        _ => Err(BundleError::CborDecode("expected text string".into())),
+        _ => Err(BundleError::CborError("expected text string".into())),
     }
 }
 
 fn take_u64(v: Value) -> Result<u64, BundleError> {
+    // Mirror `card.rs::take_u64`'s split: a non-integer value is a type
+    // error (CborError), while an integer that doesn't fit `u64` is a
+    // value error (InvalidTimestamp — `created_at` is the only u64 field
+    // in the §5 record, so the variant name still describes the failure).
     let i = match v {
         Value::Integer(i) => i,
-        _ => return Err(BundleError::InvalidTimestamp),
+        _ => return Err(BundleError::CborError("expected unsigned integer".into())),
     };
     i.try_into().map_err(|_| BundleError::InvalidTimestamp)
 }
@@ -545,7 +536,7 @@ fn take_fixed_bytes<const N: usize>(
 ) -> Result<[u8; N], BundleError> {
     let bytes = match v {
         Value::Bytes(b) => b,
-        _ => return Err(BundleError::CborDecode("expected byte string".into())),
+        _ => return Err(BundleError::CborError("expected byte string".into())),
     };
     let got = bytes.len();
     bytes.try_into().map_err(|_: Vec<u8>| BundleError::WrongKeySize {
@@ -562,7 +553,7 @@ fn take_sized_bytes(
 ) -> Result<Vec<u8>, BundleError> {
     let bytes = match v {
         Value::Bytes(b) => b,
-        _ => return Err(BundleError::CborDecode("expected byte string".into())),
+        _ => return Err(BundleError::CborError("expected byte string".into())),
     };
     if bytes.len() != expected {
         return Err(BundleError::WrongKeySize {
@@ -706,6 +697,32 @@ mod tests {
                 }
             ),
             "unexpected error: {err:?}"
+        );
+    }
+
+    #[test]
+    fn parse_distinguishes_created_at_type_mismatch_from_range() {
+        // A `created_at` set to a text string must report a CBOR type
+        // error, not the misleading `InvalidTimestamp` (which is reserved
+        // for "is an integer but doesn't fit u64").
+        let mut rng = ChaCha20Rng::from_seed([10u8; 32]);
+        let b = generate("X", 0, &mut rng);
+        let bytes = b.to_canonical_cbor().unwrap();
+        let value: Value = ciborium::de::from_reader(&bytes[..]).unwrap();
+        let Value::Map(mut entries) = value else { panic!() };
+        for (k, v) in entries.iter_mut() {
+            if let Value::Text(s) = k {
+                if s == KEY_CREATED_AT {
+                    *v = Value::Text("not a timestamp".into());
+                }
+            }
+        }
+        let mut buf = Vec::new();
+        ciborium::ser::into_writer(&Value::Map(entries), &mut buf).unwrap();
+        let err = IdentityBundle::from_canonical_cbor(&buf).unwrap_err();
+        assert!(
+            matches!(err, BundleError::CborError(_)),
+            "expected CborError for non-integer created_at, got: {err:?}"
         );
     }
 

--- a/core/src/unlock/bundle.rs
+++ b/core/src/unlock/bundle.rs
@@ -3,8 +3,31 @@
 //! The §5 record carries the four `(sk, pk)` pairs that constitute a user's
 //! cryptographic identity, plus a 16-byte UUID, a display name, and a
 //! creation timestamp (Unix milliseconds). The wire form is canonical CBOR
-//! per §6.2 (RFC 8949 §4.2.1 deterministic encoding) — implemented in the
-//! follow-up commit; this commit lands the struct and `generate`.
+//! per §6.2 (RFC 8949 §4.2.1 deterministic encoding).
+//!
+//! ## Canonical CBOR
+//!
+//! Mirrors the rules also documented in [`crate::identity::card`]:
+//!
+//! 1. Map shape with text-string keys.
+//! 2. Map keys sorted bytewise lexicographically by their canonical encoded
+//!    form. For all-tstr keys this reduces to: shorter key first; among
+//!    equal-length keys, bytewise UTF-8 compare. The §5 listing order is
+//!    descriptive, not normative for byte order.
+//! 3. Shortest-form lengths and integers (default for `ciborium`'s `Value`
+//!    serializer).
+//! 4. Definite-length, no tags, no floats, no indefinite-length items.
+//! 5. Duplicate keys rejected on parse.
+//!
+//! ## Strict canonical-input rule
+//!
+//! [`IdentityBundle::from_canonical_cbor`] rejects any input that is not in
+//! RFC 8949 §4.2.1 canonical form. Unlike the contact-card case, the bundle
+//! plaintext is never directly fingerprinted; the strictness is about
+//! defending against suite drift. Anything other than the exact §5 byte
+//! shape signals either an out-of-spec encoder or a deliberately malformed
+//! file, and is rejected so a future suite migration can rely on the v1
+//! reader recognising v1 inputs only.
 //!
 //! ## ML-DSA-65 secret-key representation (deviation from §5)
 //!
@@ -23,6 +46,7 @@
 
 use core::fmt;
 
+use ciborium::Value;
 use rand_core::{CryptoRng, RngCore};
 
 use crate::crypto::kem::{
@@ -62,6 +86,72 @@ pub const BUNDLE_ED25519_PK_LEN: usize = ED25519_PK_LEN;
 pub const BUNDLE_ML_DSA_65_SK_LEN: usize = ML_DSA_65_SEED_LEN;
 /// Re-export of [`crate::crypto::sig::ML_DSA_65_PK_LEN`].
 pub const BUNDLE_ML_DSA_65_PK_LEN: usize = ML_DSA_65_PK_LEN;
+
+// CBOR map keys (§5). String literals only used here; centralised so a typo
+// becomes a compile-time fix rather than a silent encoding drift.
+const KEY_USER_UUID: &str = "user_uuid";
+const KEY_DISPLAY_NAME: &str = "display_name";
+const KEY_X25519_SK: &str = "x25519_sk";
+const KEY_X25519_PK: &str = "x25519_pk";
+const KEY_ML_KEM_768_SK: &str = "ml_kem_768_sk";
+const KEY_ML_KEM_768_PK: &str = "ml_kem_768_pk";
+const KEY_ED25519_SK: &str = "ed25519_sk";
+const KEY_ED25519_PK: &str = "ed25519_pk";
+const KEY_ML_DSA_65_SK: &str = "ml_dsa_65_sk";
+const KEY_ML_DSA_65_PK: &str = "ml_dsa_65_pk";
+const KEY_CREATED_AT: &str = "created_at";
+
+// ---------------------------------------------------------------------------
+// Errors
+// ---------------------------------------------------------------------------
+
+/// Errors from bundle CBOR encode and decode.
+#[derive(Debug, thiserror::Error)]
+pub enum BundleError {
+    /// CBOR encoding produced an I/O or serialization error from `ciborium`,
+    /// or the byte stream did not contain a top-level map, or trailing bytes
+    /// followed the map.
+    #[error("CBOR encode/decode error: {0}")]
+    CborDecode(String),
+
+    /// Input parsed but was not in RFC 8949 §4.2.1 canonical form (e.g. keys
+    /// not in bytewise lexicographic order, non-shortest length prefixes,
+    /// indefinite-length items). Strictness defends against suite drift —
+    /// the v1 bundle plaintext is fully specified, and any deviation in
+    /// shape signals an out-of-spec writer or tampering.
+    #[error("input was not in canonical CBOR form")]
+    NonCanonicalCbor,
+
+    /// A map key was present that the v1 spec does not define. The bundle is
+    /// fully-specified; an unknown field signals suite drift and is rejected.
+    #[error("unknown bundle field: {0}")]
+    UnknownField(String),
+
+    /// A map key appeared more than once. RFC 8949 §5.4 forbids duplicates
+    /// in canonical input.
+    #[error("duplicate field: {0}")]
+    DuplicateField(String),
+
+    /// A fixed-size byte string field arrived with an unexpected length.
+    #[error("wrong key size for {field}: expected {expected}, got {got}")]
+    WrongKeySize {
+        /// The §5 CBOR key whose value had the wrong length.
+        field: &'static str,
+        /// Expected byte length per §5 / `BUNDLE_*_LEN`.
+        expected: usize,
+        /// Actual byte length seen on the wire.
+        got: usize,
+    },
+
+    /// `user_uuid` was present but not the required 16 bytes.
+    #[error("invalid UUID")]
+    InvalidUuid,
+
+    /// `created_at` was present but did not fit a `u64` Unix-millisecond
+    /// timestamp.
+    #[error("invalid timestamp")]
+    InvalidTimestamp,
+}
 
 // ---------------------------------------------------------------------------
 // IdentityBundle
@@ -181,6 +271,294 @@ pub fn generate(
     }
 }
 
+impl IdentityBundle {
+    /// Canonical CBOR encoding of the §5 plaintext map. Output is
+    /// deterministic: encoding twice produces identical bytes, and any
+    /// conformant RFC 8949 §4.2.1 encoder produces the same output.
+    pub fn to_canonical_cbor(&self) -> Result<Vec<u8>, BundleError> {
+        // Build the 11 entries; they will be sorted bytewise by canonical
+        // key encoding before serialisation. The order in this `vec!` is
+        // therefore not load-bearing — the sort step is.
+        let entries: Vec<(Value, Value)> = vec![
+            (
+                Value::Text(KEY_USER_UUID.into()),
+                Value::Bytes(self.user_uuid.to_vec()),
+            ),
+            (
+                Value::Text(KEY_DISPLAY_NAME.into()),
+                Value::Text(self.display_name.clone()),
+            ),
+            (
+                Value::Text(KEY_X25519_SK.into()),
+                Value::Bytes(self.x25519_sk.expose().to_vec()),
+            ),
+            (
+                Value::Text(KEY_X25519_PK.into()),
+                Value::Bytes(self.x25519_pk.to_vec()),
+            ),
+            (
+                Value::Text(KEY_ML_KEM_768_SK.into()),
+                Value::Bytes(self.ml_kem_768_sk.expose().clone()),
+            ),
+            (
+                Value::Text(KEY_ML_KEM_768_PK.into()),
+                Value::Bytes(self.ml_kem_768_pk.clone()),
+            ),
+            (
+                Value::Text(KEY_ED25519_SK.into()),
+                Value::Bytes(self.ed25519_sk.expose().to_vec()),
+            ),
+            (
+                Value::Text(KEY_ED25519_PK.into()),
+                Value::Bytes(self.ed25519_pk.to_vec()),
+            ),
+            (
+                Value::Text(KEY_ML_DSA_65_SK.into()),
+                Value::Bytes(self.ml_dsa_65_sk.expose().clone()),
+            ),
+            (
+                Value::Text(KEY_ML_DSA_65_PK.into()),
+                Value::Bytes(self.ml_dsa_65_pk.clone()),
+            ),
+            (
+                Value::Text(KEY_CREATED_AT.into()),
+                Value::Integer(self.created_at_ms.into()),
+            ),
+        ];
+        encode_map(&entries)
+    }
+
+    /// Inverse of [`to_canonical_cbor`]. Validates that every required field
+    /// is present, fixed-size fields have the correct byte length, no
+    /// unknown fields appear, no duplicates appear, and the input was
+    /// already in RFC 8949 §4.2.1 canonical form.
+    ///
+    /// The strict canonical-input rule defends against suite drift: a v1
+    /// reader must recognise v1 inputs only, so a future v2 writer (or a
+    /// tampered file) is rejected loudly rather than silently accepted.
+    pub fn from_canonical_cbor(bytes: &[u8]) -> Result<Self, BundleError> {
+        let value: Value = ciborium::de::from_reader(bytes)
+            .map_err(|e| BundleError::CborDecode(e.to_string()))?;
+        let map = match value {
+            Value::Map(m) => m,
+            _ => {
+                return Err(BundleError::CborDecode(
+                    "expected top-level CBOR map".into(),
+                ))
+            }
+        };
+
+        let mut user_uuid: Option<[u8; USER_UUID_LEN]> = None;
+        let mut display_name: Option<String> = None;
+        let mut x25519_sk_bytes: Option<[u8; X25519_SK_LEN]> = None;
+        let mut x25519_pk: Option<[u8; X25519_PK_LEN]> = None;
+        let mut ml_kem_768_sk_bytes: Option<Vec<u8>> = None;
+        let mut ml_kem_768_pk: Option<Vec<u8>> = None;
+        let mut ed25519_sk_bytes: Option<[u8; ED25519_SK_LEN]> = None;
+        let mut ed25519_pk: Option<[u8; ED25519_PK_LEN]> = None;
+        let mut ml_dsa_65_sk_bytes: Option<Vec<u8>> = None;
+        let mut ml_dsa_65_pk: Option<Vec<u8>> = None;
+        let mut created_at_ms: Option<u64> = None;
+
+        for (k, v) in map {
+            let Value::Text(key) = k else {
+                return Err(BundleError::CborDecode("non-string map key".into()));
+            };
+            match key.as_str() {
+                KEY_USER_UUID => set_once(&mut user_uuid, take_uuid(v)?, &key)?,
+                KEY_DISPLAY_NAME => set_once(&mut display_name, take_text(v)?, &key)?,
+                KEY_X25519_SK => set_once(
+                    &mut x25519_sk_bytes,
+                    take_fixed_bytes::<X25519_SK_LEN>(v, KEY_X25519_SK)?,
+                    &key,
+                )?,
+                KEY_X25519_PK => set_once(
+                    &mut x25519_pk,
+                    take_fixed_bytes::<X25519_PK_LEN>(v, KEY_X25519_PK)?,
+                    &key,
+                )?,
+                KEY_ML_KEM_768_SK => set_once(
+                    &mut ml_kem_768_sk_bytes,
+                    take_sized_bytes(v, KEY_ML_KEM_768_SK, ML_KEM_768_SK_LEN)?,
+                    &key,
+                )?,
+                KEY_ML_KEM_768_PK => set_once(
+                    &mut ml_kem_768_pk,
+                    take_sized_bytes(v, KEY_ML_KEM_768_PK, ML_KEM_768_PK_LEN)?,
+                    &key,
+                )?,
+                KEY_ED25519_SK => set_once(
+                    &mut ed25519_sk_bytes,
+                    take_fixed_bytes::<ED25519_SK_LEN>(v, KEY_ED25519_SK)?,
+                    &key,
+                )?,
+                KEY_ED25519_PK => set_once(
+                    &mut ed25519_pk,
+                    take_fixed_bytes::<ED25519_PK_LEN>(v, KEY_ED25519_PK)?,
+                    &key,
+                )?,
+                KEY_ML_DSA_65_SK => set_once(
+                    &mut ml_dsa_65_sk_bytes,
+                    take_sized_bytes(v, KEY_ML_DSA_65_SK, ML_DSA_65_SEED_LEN)?,
+                    &key,
+                )?,
+                KEY_ML_DSA_65_PK => set_once(
+                    &mut ml_dsa_65_pk,
+                    take_sized_bytes(v, KEY_ML_DSA_65_PK, ML_DSA_65_PK_LEN)?,
+                    &key,
+                )?,
+                KEY_CREATED_AT => set_once(&mut created_at_ms, take_u64(v)?, &key)?,
+                other => {
+                    return Err(BundleError::UnknownField(other.to_string()));
+                }
+            }
+        }
+
+        let bundle = IdentityBundle {
+            user_uuid: user_uuid
+                .ok_or_else(|| BundleError::CborDecode(format!("missing field {KEY_USER_UUID}")))?,
+            display_name: display_name.ok_or_else(|| {
+                BundleError::CborDecode(format!("missing field {KEY_DISPLAY_NAME}"))
+            })?,
+            x25519_sk: Sensitive::new(x25519_sk_bytes.ok_or_else(|| {
+                BundleError::CborDecode(format!("missing field {KEY_X25519_SK}"))
+            })?),
+            x25519_pk: x25519_pk
+                .ok_or_else(|| BundleError::CborDecode(format!("missing field {KEY_X25519_PK}")))?,
+            ml_kem_768_sk: Sensitive::new(ml_kem_768_sk_bytes.ok_or_else(|| {
+                BundleError::CborDecode(format!("missing field {KEY_ML_KEM_768_SK}"))
+            })?),
+            ml_kem_768_pk: ml_kem_768_pk.ok_or_else(|| {
+                BundleError::CborDecode(format!("missing field {KEY_ML_KEM_768_PK}"))
+            })?,
+            ed25519_sk: Sensitive::new(ed25519_sk_bytes.ok_or_else(|| {
+                BundleError::CborDecode(format!("missing field {KEY_ED25519_SK}"))
+            })?),
+            ed25519_pk: ed25519_pk
+                .ok_or_else(|| BundleError::CborDecode(format!("missing field {KEY_ED25519_PK}")))?,
+            ml_dsa_65_sk: Sensitive::new(ml_dsa_65_sk_bytes.ok_or_else(|| {
+                BundleError::CborDecode(format!("missing field {KEY_ML_DSA_65_SK}"))
+            })?),
+            ml_dsa_65_pk: ml_dsa_65_pk.ok_or_else(|| {
+                BundleError::CborDecode(format!("missing field {KEY_ML_DSA_65_PK}"))
+            })?,
+            created_at_ms: created_at_ms
+                .ok_or_else(|| BundleError::CborDecode(format!("missing field {KEY_CREATED_AT}")))?,
+        };
+
+        // Reject non-canonical input. Cheapest reliable check: re-encode
+        // and compare; passes iff the input was already canonical. Same
+        // pattern as `card.rs::from_canonical_cbor`.
+        let canonical = bundle.to_canonical_cbor()?;
+        if canonical.as_slice() != bytes {
+            // Drop the partially-decoded bundle (zeroizing its sensitive
+            // fields) before returning the error; the caller never sees
+            // these bytes.
+            drop(bundle);
+            return Err(BundleError::NonCanonicalCbor);
+        }
+
+        Ok(bundle)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Encoding helpers
+// ---------------------------------------------------------------------------
+
+fn encode_map(entries: &[(Value, Value)]) -> Result<Vec<u8>, BundleError> {
+    // RFC 8949 §4.2.1: map keys must be sorted bytewise lexicographically by
+    // their deterministic CBOR encoding. We materialize each key's encoded
+    // bytes and sort by that — robust against any future key shape (text,
+    // byte, integer) without a separate code path per type.
+    let mut sorted: Vec<(Vec<u8>, (Value, Value))> = entries
+        .iter()
+        .map(|pair| {
+            let mut key_bytes = Vec::new();
+            ciborium::ser::into_writer(&pair.0, &mut key_bytes)
+                .map_err(|e| BundleError::CborDecode(e.to_string()))?;
+            Ok((key_bytes, pair.clone()))
+        })
+        .collect::<Result<_, BundleError>>()?;
+    sorted.sort_by(|a, b| a.0.cmp(&b.0));
+
+    let value = Value::Map(sorted.into_iter().map(|(_, pair)| pair).collect());
+    let mut buf = Vec::new();
+    ciborium::ser::into_writer(&value, &mut buf)
+        .map_err(|e| BundleError::CborDecode(e.to_string()))?;
+    Ok(buf)
+}
+
+fn set_once<T>(slot: &mut Option<T>, v: T, key: &str) -> Result<(), BundleError> {
+    if slot.is_some() {
+        return Err(BundleError::DuplicateField(key.to_string()));
+    }
+    *slot = Some(v);
+    Ok(())
+}
+
+fn take_text(v: Value) -> Result<String, BundleError> {
+    match v {
+        Value::Text(s) => Ok(s),
+        _ => Err(BundleError::CborDecode("expected text string".into())),
+    }
+}
+
+fn take_u64(v: Value) -> Result<u64, BundleError> {
+    let i = match v {
+        Value::Integer(i) => i,
+        _ => return Err(BundleError::InvalidTimestamp),
+    };
+    i.try_into().map_err(|_| BundleError::InvalidTimestamp)
+}
+
+fn take_uuid(v: Value) -> Result<[u8; USER_UUID_LEN], BundleError> {
+    let bytes = match v {
+        Value::Bytes(b) => b,
+        _ => return Err(BundleError::InvalidUuid),
+    };
+    bytes
+        .try_into()
+        .map_err(|_: Vec<u8>| BundleError::InvalidUuid)
+}
+
+fn take_fixed_bytes<const N: usize>(
+    v: Value,
+    field: &'static str,
+) -> Result<[u8; N], BundleError> {
+    let bytes = match v {
+        Value::Bytes(b) => b,
+        _ => return Err(BundleError::CborDecode("expected byte string".into())),
+    };
+    let got = bytes.len();
+    bytes
+        .try_into()
+        .map_err(|_: Vec<u8>| BundleError::WrongKeySize {
+            field,
+            expected: N,
+            got,
+        })
+}
+
+fn take_sized_bytes(
+    v: Value,
+    field: &'static str,
+    expected: usize,
+) -> Result<Vec<u8>, BundleError> {
+    let bytes = match v {
+        Value::Bytes(b) => b,
+        _ => return Err(BundleError::CborDecode("expected byte string".into())),
+    };
+    if bytes.len() != expected {
+        return Err(BundleError::WrongKeySize {
+            field,
+            expected,
+            got: bytes.len(),
+        });
+    }
+    Ok(bytes)
+}
+
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
@@ -207,5 +585,35 @@ mod tests {
         // §5-spec'd 4032-byte expanded encoding.
         assert_eq!(b.ml_dsa_65_sk.expose().len(), ML_DSA_65_SEED_LEN);
         assert_eq!(b.ml_dsa_65_pk.len(), ML_DSA_65_PK_LEN);
+    }
+
+    #[test]
+    fn canonical_cbor_roundtrip() {
+        let mut rng = ChaCha20Rng::from_seed([6u8; 32]);
+        let b = generate("Bob", 1_714_060_800_001, &mut rng);
+        let bytes = b.to_canonical_cbor().expect("encode");
+        let parsed = IdentityBundle::from_canonical_cbor(&bytes).expect("decode");
+        // `Sensitive` does not impl PartialEq (see crypto::secret docs), so
+        // compare exposed contents explicitly.
+        assert_eq!(parsed.user_uuid, b.user_uuid);
+        assert_eq!(parsed.display_name, b.display_name);
+        assert_eq!(parsed.x25519_sk.expose(), b.x25519_sk.expose());
+        assert_eq!(parsed.x25519_pk, b.x25519_pk);
+        assert_eq!(parsed.ml_kem_768_sk.expose(), b.ml_kem_768_sk.expose());
+        assert_eq!(parsed.ml_kem_768_pk, b.ml_kem_768_pk);
+        assert_eq!(parsed.ed25519_sk.expose(), b.ed25519_sk.expose());
+        assert_eq!(parsed.ed25519_pk, b.ed25519_pk);
+        assert_eq!(parsed.ml_dsa_65_sk.expose(), b.ml_dsa_65_sk.expose());
+        assert_eq!(parsed.ml_dsa_65_pk, b.ml_dsa_65_pk);
+        assert_eq!(parsed.created_at_ms, b.created_at_ms);
+    }
+
+    #[test]
+    fn canonical_cbor_is_byte_stable() {
+        let mut rng = ChaCha20Rng::from_seed([6u8; 32]);
+        let b = generate("Bob", 1_714_060_800_001, &mut rng);
+        let bytes_1 = b.to_canonical_cbor().expect("encode");
+        let bytes_2 = b.to_canonical_cbor().expect("encode");
+        assert_eq!(bytes_1, bytes_2, "canonical encoding must be deterministic");
     }
 }

--- a/core/src/unlock/bundle.rs
+++ b/core/src/unlock/bundle.rs
@@ -120,6 +120,13 @@ pub enum BundleError {
     #[error("duplicate field: {0}")]
     DuplicateField(String),
 
+    /// A required field was absent from the parsed top-level CBOR map. The
+    /// payload is the §5 CBOR key name (e.g. "user_uuid", "x25519_pk") to keep
+    /// errors machine-readable; sibling errors include `UnknownField` and
+    /// `WrongKeySize` for the same field-shape concerns.
+    #[error("missing required field: {0}")]
+    MissingField(&'static str),
+
     /// A fixed-size byte string field arrived with an unexpected length.
     #[error("wrong key size for {field}: expected {expected}, got {got}")]
     WrongKeySize {
@@ -409,35 +416,25 @@ impl IdentityBundle {
         }
 
         let bundle = IdentityBundle {
-            user_uuid: user_uuid
-                .ok_or_else(|| BundleError::CborError(format!("missing field {KEY_USER_UUID}")))?,
-            display_name: display_name.ok_or_else(|| {
-                BundleError::CborError(format!("missing field {KEY_DISPLAY_NAME}"))
-            })?,
-            x25519_sk: Sensitive::new(x25519_sk_bytes.ok_or_else(|| {
-                BundleError::CborError(format!("missing field {KEY_X25519_SK}"))
-            })?),
-            x25519_pk: x25519_pk
-                .ok_or_else(|| BundleError::CborError(format!("missing field {KEY_X25519_PK}")))?,
-            ml_kem_768_sk: Sensitive::new(ml_kem_768_sk_bytes.ok_or_else(|| {
-                BundleError::CborError(format!("missing field {KEY_ML_KEM_768_SK}"))
-            })?),
-            ml_kem_768_pk: ml_kem_768_pk.ok_or_else(|| {
-                BundleError::CborError(format!("missing field {KEY_ML_KEM_768_PK}"))
-            })?,
-            ed25519_sk: Sensitive::new(ed25519_sk_bytes.ok_or_else(|| {
-                BundleError::CborError(format!("missing field {KEY_ED25519_SK}"))
-            })?),
-            ed25519_pk: ed25519_pk
-                .ok_or_else(|| BundleError::CborError(format!("missing field {KEY_ED25519_PK}")))?,
-            ml_dsa_65_sk: Sensitive::new(ml_dsa_65_sk_bytes.ok_or_else(|| {
-                BundleError::CborError(format!("missing field {KEY_ML_DSA_65_SK}"))
-            })?),
-            ml_dsa_65_pk: ml_dsa_65_pk.ok_or_else(|| {
-                BundleError::CborError(format!("missing field {KEY_ML_DSA_65_PK}"))
-            })?,
-            created_at_ms: created_at_ms
-                .ok_or_else(|| BundleError::CborError(format!("missing field {KEY_CREATED_AT}")))?,
+            user_uuid: user_uuid.ok_or(BundleError::MissingField(KEY_USER_UUID))?,
+            display_name: display_name.ok_or(BundleError::MissingField(KEY_DISPLAY_NAME))?,
+            x25519_sk: Sensitive::new(
+                x25519_sk_bytes.ok_or(BundleError::MissingField(KEY_X25519_SK))?,
+            ),
+            x25519_pk: x25519_pk.ok_or(BundleError::MissingField(KEY_X25519_PK))?,
+            ml_kem_768_sk: Sensitive::new(
+                ml_kem_768_sk_bytes.ok_or(BundleError::MissingField(KEY_ML_KEM_768_SK))?,
+            ),
+            ml_kem_768_pk: ml_kem_768_pk.ok_or(BundleError::MissingField(KEY_ML_KEM_768_PK))?,
+            ed25519_sk: Sensitive::new(
+                ed25519_sk_bytes.ok_or(BundleError::MissingField(KEY_ED25519_SK))?,
+            ),
+            ed25519_pk: ed25519_pk.ok_or(BundleError::MissingField(KEY_ED25519_PK))?,
+            ml_dsa_65_sk: Sensitive::new(
+                ml_dsa_65_sk_bytes.ok_or(BundleError::MissingField(KEY_ML_DSA_65_SK))?,
+            ),
+            ml_dsa_65_pk: ml_dsa_65_pk.ok_or(BundleError::MissingField(KEY_ML_DSA_65_PK))?,
+            created_at_ms: created_at_ms.ok_or(BundleError::MissingField(KEY_CREATED_AT))?,
         };
 
         // Reject non-canonical input. Cheapest reliable check: re-encode

--- a/core/src/unlock/bundle_file.rs
+++ b/core/src/unlock/bundle_file.rs
@@ -8,10 +8,12 @@
 //! `crypto::aead::encrypt`'s combined output); the 16-byte tag is written as the
 //! separate `bundle_tag` §3 field and is NOT included in `bundle_ct_len`.
 
-/// `"SECR"` in big-endian ASCII — identifies a Secretary vault envelope.
-pub const MAGIC: u32 = 0x53454352;
-pub const FORMAT_VERSION_V1: u16 = 0x0001;
-pub const FILE_KIND_IDENTITY_BUNDLE: u16 = 0x0001;
+use crate::version::{FORMAT_VERSION, MAGIC};
+
+/// File-kind identifier for the identity bundle envelope. Distinct from
+/// FORMAT_VERSION — file kinds let multiple files (manifest, block, …) share
+/// the same FORMAT_VERSION while remaining distinguishable.
+pub(crate) const FILE_KIND_IDENTITY_BUNDLE: u16 = 0x0001;
 pub(crate) const NONCE_LEN: usize = 24;
 pub(crate) const WRAP_CT_PLUS_TAG_LEN: usize = 32 + 16;  // identity_block_key + tag
 
@@ -68,7 +70,7 @@ pub fn encode(file: &BundleFile) -> Vec<u8> {
             + NONCE_LEN + 4 + file.bundle_ct_with_tag.len()
     );
     out.extend_from_slice(&MAGIC.to_be_bytes());
-    out.extend_from_slice(&FORMAT_VERSION_V1.to_be_bytes());
+    out.extend_from_slice(&FORMAT_VERSION.to_be_bytes());
     out.extend_from_slice(&FILE_KIND_IDENTITY_BUNDLE.to_be_bytes());
     out.extend_from_slice(&file.vault_uuid);
     out.extend_from_slice(&file.created_at_ms.to_be_bytes());
@@ -104,7 +106,7 @@ pub fn decode(bytes: &[u8]) -> Result<BundleFile, BundleFileError> {
         return Err(BundleFileError::BadMagic { got: magic });
     }
     let format_version = read_u16_be(bytes, &mut pos)?;
-    if format_version != FORMAT_VERSION_V1 {
+    if format_version != FORMAT_VERSION {
         return Err(BundleFileError::UnsupportedFormatVersion(format_version));
     }
     let file_kind = read_u16_be(bytes, &mut pos)?;

--- a/core/src/unlock/bundle_file.rs
+++ b/core/src/unlock/bundle_file.rs
@@ -1,9 +1,12 @@
 //! `identity.bundle.enc` binary envelope (`docs/vault-format.md` §3).
 //!
 //! Big-endian integers throughout. Three AEAD payloads (wrap_pw, wrap_rec,
-//! bundle), each stored as `nonce || ct_len || ct_with_tag`, where
-//! ct_with_tag is the AEAD ciphertext concatenated with its 16-byte
-//! Poly1305 tag (matching `crypto::aead::encrypt`'s output format).
+//! bundle). The wrap fields are stored as `nonce || ct_len(=32) || ct || tag`.
+//! The bundle field is stored as `nonce || bundle_ct_len || bundle_ct || bundle_tag`
+//! where `bundle_ct_len` is the length of `bundle_ct` ALONE, per §3 lines 102-104.
+//! Internally we keep `bundle_ct_with_tag = bundle_ct || bundle_tag` (matching
+//! `crypto::aead::encrypt`'s combined output); the 16-byte tag is written as the
+//! separate `bundle_tag` §3 field and is NOT included in `bundle_ct_len`.
 
 pub const MAGIC: u32 = 0x53454352;             // "SECR"
 pub const FORMAT_VERSION_V1: u16 = 0x0001;
@@ -27,6 +30,8 @@ pub struct BundleFile {
 pub enum BundleFileError {
     #[error("file truncated at offset {offset}")]
     Truncated { offset: usize },
+    #[error("trailing bytes after parse at offset {offset}")]
+    TrailingBytes { offset: usize },
     #[error("bad magic: expected SECR, got {got:#010x}")]
     BadMagic { got: u32 },
     #[error("unsupported format version: {0}")]
@@ -61,10 +66,14 @@ pub fn encode(file: &BundleFile) -> Vec<u8> {
     out.extend_from_slice(&file.wrap_rec_ct_with_tag);
 
     out.extend_from_slice(&file.bundle_nonce);
-    // bundle_ct_len = length of the AEAD ciphertext including the 16-byte
-    // tag (the §3 "bundle_ct" field is the AEAD output as a single blob).
-    out.extend_from_slice(&u32::try_from(file.bundle_ct_with_tag.len())
-        .expect("bundle ct < 4 GiB").to_be_bytes());
+    // bundle_ct_len = length of bundle_ct ALONE, per vault-format §3 lines 102-104.
+    // bundle_ct_with_tag stores ct||tag (matching crypto::aead::encrypt's output);
+    // the trailing 16 bytes are bundle_tag (a separate §3 field). We write both
+    // in a single extend_from_slice — the wire layout is bundle_ct then bundle_tag,
+    // which is exactly what bundle_ct_with_tag contains in order.
+    let bundle_ct_len = u32::try_from(file.bundle_ct_with_tag.len() - 16)
+        .expect("bundle ct < 4 GiB");
+    out.extend_from_slice(&bundle_ct_len.to_be_bytes());
     out.extend_from_slice(&file.bundle_ct_with_tag);
 
     out
@@ -106,15 +115,20 @@ pub fn decode(bytes: &[u8]) -> Result<BundleFile, BundleFileError> {
     // bundle
     let bundle_nonce = read_array::<NONCE_LEN>(bytes, &mut pos)?;
     let bundle_ct_len = read_u32_be(bytes, &mut pos)? as usize;
-    if pos + bundle_ct_len > bytes.len() {
+    // §3: bundle_tag is a separate 16-byte field after bundle_ct.
+    // We read both into a single combined buffer to match crypto::aead::decrypt's
+    // expected ct||tag input shape.
+    let total = bundle_ct_len
+        .checked_add(16)
+        .ok_or(BundleFileError::Truncated { offset: pos })?;
+    if pos + total > bytes.len() {
         return Err(BundleFileError::Truncated { offset: pos });
     }
-    let bundle_ct_with_tag = bytes[pos..pos + bundle_ct_len].to_vec();
-    pos += bundle_ct_len;
+    let bundle_ct_with_tag = bytes[pos..pos + total].to_vec();
+    pos += total;
 
     if pos != bytes.len() {
-        return Err(BundleFileError::Truncated { offset: pos });
-        // Trailing bytes treated as truncation indicator — file is wrong shape.
+        return Err(BundleFileError::TrailingBytes { offset: pos });
     }
 
     Ok(BundleFile {
@@ -225,6 +239,28 @@ mod tests {
         assert!(matches!(
             err,
             BundleFileError::WrapLengthMismatch { field: "wrap_pw", declared: 64 }
+        ));
+    }
+
+    #[test]
+    fn decode_rejects_trailing_bytes() {
+        let mut bytes = encode(&sample());
+        bytes.push(0xAA);
+        let err = decode(&bytes).unwrap_err();
+        assert!(matches!(err, BundleFileError::TrailingBytes { .. }));
+    }
+
+    #[test]
+    fn decode_rejects_wrap_rec_length_mismatch() {
+        let bytes = encode(&sample());
+        // wrap_rec_ct_len starts at:
+        //   header (32) + wrap_pw section (24 + 4 + 48 = 76) + wrap_rec_nonce (24) = 132
+        let mut tampered = bytes.clone();
+        tampered[132..136].copy_from_slice(&64u32.to_be_bytes());
+        let err = decode(&tampered).unwrap_err();
+        assert!(matches!(
+            err,
+            BundleFileError::WrapLengthMismatch { field: "wrap_rec", declared: 64 }
         ));
     }
 }

--- a/core/src/unlock/bundle_file.rs
+++ b/core/src/unlock/bundle_file.rs
@@ -175,4 +175,56 @@ mod tests {
         let parsed = decode(&bytes).expect("decode");
         assert_eq!(parsed, f);
     }
+
+    #[test]
+    fn decode_rejects_bad_magic() {
+        let mut bytes = encode(&sample());
+        bytes[0] ^= 0xFF;
+        let err = decode(&bytes).unwrap_err();
+        assert!(matches!(err, BundleFileError::BadMagic { .. }));
+    }
+
+    #[test]
+    fn decode_rejects_bad_format_version() {
+        let mut bytes = encode(&sample());
+        bytes[5] = 0x02;  // bump format_version low byte from 0x01 to 0x02
+        let err = decode(&bytes).unwrap_err();
+        assert!(matches!(err, BundleFileError::UnsupportedFormatVersion(2)));
+    }
+
+    #[test]
+    fn decode_rejects_bad_file_kind() {
+        let mut bytes = encode(&sample());
+        bytes[7] = 0x02;
+        let err = decode(&bytes).unwrap_err();
+        assert!(matches!(err, BundleFileError::UnsupportedFileKind(2)));
+    }
+
+    #[test]
+    fn decode_rejects_truncated_at_every_boundary() {
+        let bytes = encode(&sample());
+        for n in 0..bytes.len() {
+            let truncated = &bytes[..n];
+            let result = decode(truncated);
+            assert!(
+                result.is_err(),
+                "decode must fail on slice [..{n}] of {} bytes",
+                bytes.len()
+            );
+        }
+        decode(&bytes).expect("full bytes decode");
+    }
+
+    #[test]
+    fn decode_rejects_wrap_pw_length_mismatch() {
+        let bytes = encode(&sample());
+        // wrap_pw_ct_len starts at offset 4+2+2+16+8 + NONCE_LEN = 32 + 24 = 56
+        let mut tampered = bytes.clone();
+        tampered[56..60].copy_from_slice(&64u32.to_be_bytes());
+        let err = decode(&tampered).unwrap_err();
+        assert!(matches!(
+            err,
+            BundleFileError::WrapLengthMismatch { field: "wrap_pw", declared: 64 }
+        ));
+    }
 }

--- a/core/src/unlock/bundle_file.rs
+++ b/core/src/unlock/bundle_file.rs
@@ -8,11 +8,12 @@
 //! `crypto::aead::encrypt`'s combined output); the 16-byte tag is written as the
 //! separate `bundle_tag` §3 field and is NOT included in `bundle_ct_len`.
 
-pub const MAGIC: u32 = 0x53454352;             // "SECR"
+/// `"SECR"` in big-endian ASCII — identifies a Secretary vault envelope.
+pub const MAGIC: u32 = 0x53454352;
 pub const FORMAT_VERSION_V1: u16 = 0x0001;
 pub const FILE_KIND_IDENTITY_BUNDLE: u16 = 0x0001;
-pub const NONCE_LEN: usize = 24;
-pub const WRAP_CT_PLUS_TAG_LEN: usize = 32 + 16;  // identity_block_key + tag
+pub(crate) const NONCE_LEN: usize = 24;
+pub(crate) const WRAP_CT_PLUS_TAG_LEN: usize = 32 + 16;  // identity_block_key + tag
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct BundleFile {
@@ -38,11 +39,28 @@ pub enum BundleFileError {
     UnsupportedFormatVersion(u16),
     #[error("unsupported file kind: {0}")]
     UnsupportedFileKind(u16),
-    #[error("declared length for {field} ({declared}) does not match expected (32)")]
-    WrapLengthMismatch { field: &'static str, declared: u32 },
+    /// A wrap length-prefix did not match the expected size.
+    #[error("declared length for {field}: expected {expected}, got {declared}")]
+    WrapLengthMismatch {
+        field: &'static str,
+        expected: u32,
+        declared: u32,
+    },
 }
 
+/// Serialize a [`BundleFile`] to its `vault-format.md` §3 byte form.
+///
+/// # Panics
+///
+/// Panics if `file.bundle_ct_with_tag.len() < 16` (a Poly1305 tag is always
+/// 16 bytes; a shorter buffer is structurally invalid). Callers should be
+/// constructing this from `crypto::aead::encrypt` output, which always
+/// includes the tag.
 pub fn encode(file: &BundleFile) -> Vec<u8> {
+    debug_assert!(
+        file.bundle_ct_with_tag.len() >= 16,
+        "bundle_ct_with_tag must include the trailing 16-byte Poly1305 tag"
+    );
     let mut out = Vec::with_capacity(
         4 + 2 + 2 + 16 + 8
             + NONCE_LEN + 4 + WRAP_CT_PLUS_TAG_LEN
@@ -100,7 +118,11 @@ pub fn decode(bytes: &[u8]) -> Result<BundleFile, BundleFileError> {
     let wrap_pw_nonce = read_array::<NONCE_LEN>(bytes, &mut pos)?;
     let wrap_pw_ct_len = read_u32_be(bytes, &mut pos)?;
     if wrap_pw_ct_len != 32 {
-        return Err(BundleFileError::WrapLengthMismatch { field: "wrap_pw", declared: wrap_pw_ct_len });
+        return Err(BundleFileError::WrapLengthMismatch {
+            field: "wrap_pw",
+            expected: 32,
+            declared: wrap_pw_ct_len,
+        });
     }
     let wrap_pw_ct_with_tag = read_array::<WRAP_CT_PLUS_TAG_LEN>(bytes, &mut pos)?;
 
@@ -108,7 +130,11 @@ pub fn decode(bytes: &[u8]) -> Result<BundleFile, BundleFileError> {
     let wrap_rec_nonce = read_array::<NONCE_LEN>(bytes, &mut pos)?;
     let wrap_rec_ct_len = read_u32_be(bytes, &mut pos)?;
     if wrap_rec_ct_len != 32 {
-        return Err(BundleFileError::WrapLengthMismatch { field: "wrap_rec", declared: wrap_rec_ct_len });
+        return Err(BundleFileError::WrapLengthMismatch {
+            field: "wrap_rec",
+            expected: 32,
+            declared: wrap_rec_ct_len,
+        });
     }
     let wrap_rec_ct_with_tag = read_array::<WRAP_CT_PLUS_TAG_LEN>(bytes, &mut pos)?;
 
@@ -191,6 +217,17 @@ mod tests {
     }
 
     #[test]
+    fn encode_decode_roundtrip_minimum_bundle_ct() {
+        // Smallest valid bundle_ct_with_tag is exactly 16 bytes (the tag with
+        // empty plaintext ciphertext) — boundary case for the encode subtraction.
+        let mut f = sample();
+        f.bundle_ct_with_tag = vec![0xAB; 16];
+        let bytes = encode(&f);
+        let parsed = decode(&bytes).expect("decode");
+        assert_eq!(parsed, f);
+    }
+
+    #[test]
     fn decode_rejects_bad_magic() {
         let mut bytes = encode(&sample());
         bytes[0] ^= 0xFF;
@@ -232,13 +269,16 @@ mod tests {
     #[test]
     fn decode_rejects_wrap_pw_length_mismatch() {
         let bytes = encode(&sample());
-        // wrap_pw_ct_len starts at offset 4+2+2+16+8 + NONCE_LEN = 32 + 24 = 56
+        // header(magic+ver+kind+uuid+ts) + wrap_pw_nonce
+        let wrap_pw_ct_len_offset = 4 + 2 + 2 + 16 + 8 + NONCE_LEN;
+        assert_eq!(wrap_pw_ct_len_offset, 56);
         let mut tampered = bytes.clone();
-        tampered[56..60].copy_from_slice(&64u32.to_be_bytes());
+        tampered[wrap_pw_ct_len_offset..wrap_pw_ct_len_offset + 4]
+            .copy_from_slice(&64u32.to_be_bytes());
         let err = decode(&tampered).unwrap_err();
         assert!(matches!(
             err,
-            BundleFileError::WrapLengthMismatch { field: "wrap_pw", declared: 64 }
+            BundleFileError::WrapLengthMismatch { field: "wrap_pw", expected: 32, declared: 64 }
         ));
     }
 
@@ -253,14 +293,17 @@ mod tests {
     #[test]
     fn decode_rejects_wrap_rec_length_mismatch() {
         let bytes = encode(&sample());
-        // wrap_rec_ct_len starts at:
-        //   header (32) + wrap_pw section (24 + 4 + 48 = 76) + wrap_rec_nonce (24) = 132
+        // header + wrap_pw_section(nonce+len+ct_with_tag) + wrap_rec_nonce
+        let wrap_rec_ct_len_offset =
+            4 + 2 + 2 + 16 + 8 + (NONCE_LEN + 4 + WRAP_CT_PLUS_TAG_LEN) + NONCE_LEN;
+        assert_eq!(wrap_rec_ct_len_offset, 132);
         let mut tampered = bytes.clone();
-        tampered[132..136].copy_from_slice(&64u32.to_be_bytes());
+        tampered[wrap_rec_ct_len_offset..wrap_rec_ct_len_offset + 4]
+            .copy_from_slice(&64u32.to_be_bytes());
         let err = decode(&tampered).unwrap_err();
         assert!(matches!(
             err,
-            BundleFileError::WrapLengthMismatch { field: "wrap_rec", declared: 64 }
+            BundleFileError::WrapLengthMismatch { field: "wrap_rec", expected: 32, declared: 64 }
         ));
     }
 }

--- a/core/src/unlock/bundle_file.rs
+++ b/core/src/unlock/bundle_file.rs
@@ -1,0 +1,178 @@
+//! `identity.bundle.enc` binary envelope (`docs/vault-format.md` §3).
+//!
+//! Big-endian integers throughout. Three AEAD payloads (wrap_pw, wrap_rec,
+//! bundle), each stored as `nonce || ct_len || ct_with_tag`, where
+//! ct_with_tag is the AEAD ciphertext concatenated with its 16-byte
+//! Poly1305 tag (matching `crypto::aead::encrypt`'s output format).
+
+pub const MAGIC: u32 = 0x53454352;             // "SECR"
+pub const FORMAT_VERSION_V1: u16 = 0x0001;
+pub const FILE_KIND_IDENTITY_BUNDLE: u16 = 0x0001;
+pub const NONCE_LEN: usize = 24;
+pub const WRAP_CT_PLUS_TAG_LEN: usize = 32 + 16;  // identity_block_key + tag
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BundleFile {
+    pub vault_uuid: [u8; 16],
+    pub created_at_ms: u64,
+    pub wrap_pw_nonce: [u8; NONCE_LEN],
+    pub wrap_pw_ct_with_tag: [u8; WRAP_CT_PLUS_TAG_LEN],
+    pub wrap_rec_nonce: [u8; NONCE_LEN],
+    pub wrap_rec_ct_with_tag: [u8; WRAP_CT_PLUS_TAG_LEN],
+    pub bundle_nonce: [u8; NONCE_LEN],
+    pub bundle_ct_with_tag: Vec<u8>,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum BundleFileError {
+    #[error("file truncated at offset {offset}")]
+    Truncated { offset: usize },
+    #[error("bad magic: expected SECR, got {got:#010x}")]
+    BadMagic { got: u32 },
+    #[error("unsupported format version: {0}")]
+    UnsupportedFormatVersion(u16),
+    #[error("unsupported file kind: {0}")]
+    UnsupportedFileKind(u16),
+    #[error("declared length for {field} ({declared}) does not match expected (32)")]
+    WrapLengthMismatch { field: &'static str, declared: u32 },
+}
+
+pub fn encode(file: &BundleFile) -> Vec<u8> {
+    let mut out = Vec::with_capacity(
+        4 + 2 + 2 + 16 + 8
+            + NONCE_LEN + 4 + WRAP_CT_PLUS_TAG_LEN
+            + NONCE_LEN + 4 + WRAP_CT_PLUS_TAG_LEN
+            + NONCE_LEN + 4 + file.bundle_ct_with_tag.len()
+    );
+    out.extend_from_slice(&MAGIC.to_be_bytes());
+    out.extend_from_slice(&FORMAT_VERSION_V1.to_be_bytes());
+    out.extend_from_slice(&FILE_KIND_IDENTITY_BUNDLE.to_be_bytes());
+    out.extend_from_slice(&file.vault_uuid);
+    out.extend_from_slice(&file.created_at_ms.to_be_bytes());
+
+    out.extend_from_slice(&file.wrap_pw_nonce);
+    // wrap_pw_ct_len: u32 = 32 (the IdentityBlockKey size). Writing the
+    // unwrapped key length, NOT the ciphertext-with-tag length, per §3.
+    out.extend_from_slice(&32u32.to_be_bytes());
+    out.extend_from_slice(&file.wrap_pw_ct_with_tag);
+
+    out.extend_from_slice(&file.wrap_rec_nonce);
+    out.extend_from_slice(&32u32.to_be_bytes());
+    out.extend_from_slice(&file.wrap_rec_ct_with_tag);
+
+    out.extend_from_slice(&file.bundle_nonce);
+    // bundle_ct_len = length of the AEAD ciphertext including the 16-byte
+    // tag (the §3 "bundle_ct" field is the AEAD output as a single blob).
+    out.extend_from_slice(&u32::try_from(file.bundle_ct_with_tag.len())
+        .expect("bundle ct < 4 GiB").to_be_bytes());
+    out.extend_from_slice(&file.bundle_ct_with_tag);
+
+    out
+}
+
+pub fn decode(bytes: &[u8]) -> Result<BundleFile, BundleFileError> {
+    let mut pos = 0;
+    let magic = read_u32_be(bytes, &mut pos)?;
+    if magic != MAGIC {
+        return Err(BundleFileError::BadMagic { got: magic });
+    }
+    let format_version = read_u16_be(bytes, &mut pos)?;
+    if format_version != FORMAT_VERSION_V1 {
+        return Err(BundleFileError::UnsupportedFormatVersion(format_version));
+    }
+    let file_kind = read_u16_be(bytes, &mut pos)?;
+    if file_kind != FILE_KIND_IDENTITY_BUNDLE {
+        return Err(BundleFileError::UnsupportedFileKind(file_kind));
+    }
+    let vault_uuid = read_array::<16>(bytes, &mut pos)?;
+    let created_at_ms = read_u64_be(bytes, &mut pos)?;
+
+    // wrap_pw
+    let wrap_pw_nonce = read_array::<NONCE_LEN>(bytes, &mut pos)?;
+    let wrap_pw_ct_len = read_u32_be(bytes, &mut pos)?;
+    if wrap_pw_ct_len != 32 {
+        return Err(BundleFileError::WrapLengthMismatch { field: "wrap_pw", declared: wrap_pw_ct_len });
+    }
+    let wrap_pw_ct_with_tag = read_array::<WRAP_CT_PLUS_TAG_LEN>(bytes, &mut pos)?;
+
+    // wrap_rec
+    let wrap_rec_nonce = read_array::<NONCE_LEN>(bytes, &mut pos)?;
+    let wrap_rec_ct_len = read_u32_be(bytes, &mut pos)?;
+    if wrap_rec_ct_len != 32 {
+        return Err(BundleFileError::WrapLengthMismatch { field: "wrap_rec", declared: wrap_rec_ct_len });
+    }
+    let wrap_rec_ct_with_tag = read_array::<WRAP_CT_PLUS_TAG_LEN>(bytes, &mut pos)?;
+
+    // bundle
+    let bundle_nonce = read_array::<NONCE_LEN>(bytes, &mut pos)?;
+    let bundle_ct_len = read_u32_be(bytes, &mut pos)? as usize;
+    if pos + bundle_ct_len > bytes.len() {
+        return Err(BundleFileError::Truncated { offset: pos });
+    }
+    let bundle_ct_with_tag = bytes[pos..pos + bundle_ct_len].to_vec();
+    pos += bundle_ct_len;
+
+    if pos != bytes.len() {
+        return Err(BundleFileError::Truncated { offset: pos });
+        // Trailing bytes treated as truncation indicator — file is wrong shape.
+    }
+
+    Ok(BundleFile {
+        vault_uuid,
+        created_at_ms,
+        wrap_pw_nonce,
+        wrap_pw_ct_with_tag,
+        wrap_rec_nonce,
+        wrap_rec_ct_with_tag,
+        bundle_nonce,
+        bundle_ct_with_tag,
+    })
+}
+
+fn read_u16_be(bytes: &[u8], pos: &mut usize) -> Result<u16, BundleFileError> {
+    let arr = read_array::<2>(bytes, pos)?;
+    Ok(u16::from_be_bytes(arr))
+}
+fn read_u32_be(bytes: &[u8], pos: &mut usize) -> Result<u32, BundleFileError> {
+    let arr = read_array::<4>(bytes, pos)?;
+    Ok(u32::from_be_bytes(arr))
+}
+fn read_u64_be(bytes: &[u8], pos: &mut usize) -> Result<u64, BundleFileError> {
+    let arr = read_array::<8>(bytes, pos)?;
+    Ok(u64::from_be_bytes(arr))
+}
+fn read_array<const N: usize>(bytes: &[u8], pos: &mut usize) -> Result<[u8; N], BundleFileError> {
+    if *pos + N > bytes.len() {
+        return Err(BundleFileError::Truncated { offset: *pos });
+    }
+    let mut out = [0u8; N];
+    out.copy_from_slice(&bytes[*pos..*pos + N]);
+    *pos += N;
+    Ok(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample() -> BundleFile {
+        BundleFile {
+            vault_uuid: [0x11; 16],
+            created_at_ms: 1_714_060_800_000,
+            wrap_pw_nonce: [0x22; NONCE_LEN],
+            wrap_pw_ct_with_tag: [0x33; WRAP_CT_PLUS_TAG_LEN],
+            wrap_rec_nonce: [0x44; NONCE_LEN],
+            wrap_rec_ct_with_tag: [0x55; WRAP_CT_PLUS_TAG_LEN],
+            bundle_nonce: [0x66; NONCE_LEN],
+            bundle_ct_with_tag: vec![0x77; 200],
+        }
+    }
+
+    #[test]
+    fn encode_decode_roundtrip() {
+        let f = sample();
+        let bytes = encode(&f);
+        let parsed = decode(&bytes).expect("decode");
+        assert_eq!(parsed, f);
+    }
+}

--- a/core/src/unlock/mnemonic.rs
+++ b/core/src/unlock/mnemonic.rs
@@ -15,8 +15,9 @@
 
 use core::fmt;
 
-use bip39::Mnemonic as Bip39Mnemonic;
+use bip39::{Language, Mnemonic as Bip39Mnemonic};
 use rand_core::{CryptoRng, RngCore};
+use unicode_normalization::UnicodeNormalization;
 use zeroize::Zeroize;
 
 use crate::crypto::secret::Sensitive;
@@ -109,6 +110,72 @@ pub fn generate(rng: &mut (impl RngCore + CryptoRng)) -> Mnemonic {
     }
 }
 
+/// Parse a mnemonic phrase, validating the wordlist and the BIP-39 checksum.
+///
+/// Input handling mirrors BIP-39 §3.1: the string is Unicode NFKD-normalized,
+/// split on whitespace, and lowercased before lookup. This means the function
+/// accepts mixed-case input, multiple/tabular whitespace separators, and
+/// composed/decomposed Unicode forms equivalently.
+///
+/// Returns:
+/// - [`MnemonicError::WrongLength`] if the normalized phrase is not exactly
+///   24 words (other BIP-39 sizes are intentionally rejected — see §4).
+/// - [`MnemonicError::UnknownWord`] if any token is not in the English
+///   wordlist.
+/// - [`MnemonicError::BadChecksum`] if the trailing checksum bits do not match
+///   the entropy.
+pub fn parse(words: &str) -> Result<Mnemonic, MnemonicError> {
+    // BIP-39 §3.1: phrases are compared in Unicode NFKD form. We also
+    // lowercase and collapse internal whitespace so that the canonicalized
+    // string matches exactly what the bip39 crate expects.
+    let nfkd: String = words.nfkd().collect();
+    let normalized = nfkd
+        .split_whitespace()
+        .map(str::to_lowercase)
+        .collect::<Vec<_>>()
+        .join(" ");
+
+    let word_count = normalized.split_whitespace().count();
+    if word_count != 24 {
+        return Err(MnemonicError::WrongLength { got: word_count });
+    }
+
+    let bip = Bip39Mnemonic::parse_in_normalized(Language::English, &normalized)
+        .map_err(map_bip39_error)?;
+
+    let (full, len) = bip.to_entropy_array();
+    debug_assert_eq!(len, 32, "24-word BIP-39 must produce 32 bytes of entropy");
+    let mut entropy = [0u8; 32];
+    entropy.copy_from_slice(&full[..32]);
+
+    Ok(Mnemonic {
+        phrase: bip.to_string(),
+        entropy: Sensitive::new(entropy),
+    })
+}
+
+/// Map the bip39 crate's error enum onto our caller-facing variant set.
+///
+/// The crate reports an unknown word by *index* (position in the phrase),
+/// not by content; we surface a placeholder string for now. A future
+/// enhancement could re-tokenize the input to recover the offending word.
+fn map_bip39_error(e: bip39::Error) -> MnemonicError {
+    use bip39::Error::{
+        AmbiguousLanguages, BadEntropyBitCount, BadWordCount, InvalidChecksum, UnknownWord,
+    };
+    match e {
+        UnknownWord(_idx) => MnemonicError::UnknownWord("(unknown)".to_string()),
+        InvalidChecksum => MnemonicError::BadChecksum,
+        BadWordCount(n) => MnemonicError::WrongLength { got: n },
+        // BadEntropyBitCount cannot arise from `parse_in_normalized` (it's a
+        // from-entropy constructor failure); AmbiguousLanguages cannot arise
+        // because we pin the language to English. Both are folded into
+        // BadChecksum as a safe catch-all rejection — a parse failure is a
+        // parse failure regardless of which structural rule was broken.
+        BadEntropyBitCount(_) | AmbiguousLanguages(_) => MnemonicError::BadChecksum,
+    }
+}
+
 /// Redacted debug representation. Both the phrase and the entropy are
 /// secrets; the only externally observable property is "this is a 24-word
 /// mnemonic". A real `Debug` impl on the contents would defeat the
@@ -142,5 +209,30 @@ mod tests {
         let b = generate(&mut rng_b);
         assert_eq!(a.phrase(), b.phrase());
         assert_eq!(a.entropy().expose(), b.entropy().expose());
+    }
+
+    #[test]
+    fn parse_roundtrips_generated_mnemonic() {
+        let mut rng = ChaCha20Rng::from_seed([42u8; 32]);
+        let original = generate(&mut rng);
+        let parsed = parse(original.phrase()).expect("valid mnemonic");
+        assert_eq!(parsed.entropy().expose(), original.entropy().expose());
+        assert_eq!(parsed.phrase(), original.phrase());
+    }
+
+    #[test]
+    fn parse_normalizes_whitespace_and_case() {
+        let mut rng = ChaCha20Rng::from_seed([1u8; 32]);
+        let m = generate(&mut rng);
+        // Reformat: extra whitespace, mixed case
+        let messy: String = m
+            .phrase()
+            .split_whitespace()
+            .enumerate()
+            .map(|(i, w)| if i % 2 == 0 { w.to_uppercase() } else { w.to_string() })
+            .collect::<Vec<_>>()
+            .join("   \t  ");
+        let parsed = parse(&messy).expect("messy input must normalize");
+        assert_eq!(parsed.entropy().expose(), m.entropy().expose());
     }
 }

--- a/core/src/unlock/mnemonic.rs
+++ b/core/src/unlock/mnemonic.rs
@@ -1,0 +1,146 @@
+//! BIP-39 24-word mnemonic wrapper for the recovery-key path
+//! (`docs/crypto-design.md` §4).
+//!
+//! At vault creation we draw 256 bits of OS-CSPRNG entropy and encode it as a
+//! 24-word BIP-39 phrase from the standard English wordlist. That same 256-bit
+//! entropy is the input keying material to [`crate::crypto::kdf::derive_recovery_kek`].
+//! The phrase is the user-facing artefact (printed, written down, never stored
+//! by the application); the entropy is what the cryptography consumes.
+//!
+//! The entropy lives inside [`Sensitive`] (zeroize-on-drop). The phrase
+//! string is treated as sensitive too; explicit zeroization on drop is added
+//! in a later task. There is no `Clone`, `Copy`, `Debug`, or `Display` on
+//! [`Mnemonic`] derived publicly — callers that need the phrase use
+//! [`Mnemonic::phrase`], which keeps every read of the secret grep-able.
+
+use core::fmt;
+
+use bip39::Mnemonic as Bip39Mnemonic;
+use rand_core::{CryptoRng, RngCore};
+use zeroize::Zeroize;
+
+use crate::crypto::secret::Sensitive;
+
+/// 24-word BIP-39 mnemonic carrying 256 bits of entropy.
+pub struct Mnemonic {
+    phrase: String,
+    entropy: Sensitive<[u8; 32]>,
+}
+
+/// Errors returned by mnemonic parsing.
+///
+/// The variants describe what was wrong with the input phrase. They are
+/// `PartialEq`/`Eq` so call sites can match on a specific failure mode in
+/// tests; the string payload of [`MnemonicError::UnknownWord`] participates in
+/// equality.
+#[derive(Debug, thiserror::Error, PartialEq, Eq)]
+pub enum MnemonicError {
+    /// The phrase did not contain exactly 24 whitespace-separated words.
+    /// v1 fixes the word count at 24 (256-bit entropy); other valid BIP-39
+    /// lengths (12/15/18/21) are rejected.
+    #[error("expected 24 words, got {got}")]
+    WrongLength { got: usize },
+
+    /// One of the words was not in the BIP-39 English wordlist.
+    #[error("word not in BIP-39 English list: {0}")]
+    UnknownWord(String),
+
+    /// Word count and wordlist were valid but the BIP-39 checksum did not
+    /// match. Indicates a typo or a tampered phrase.
+    #[error("BIP-39 checksum failed")]
+    BadChecksum,
+}
+
+impl Mnemonic {
+    /// The 24-word phrase, space-separated, lowercase.
+    /// Reading this is reading sensitive material — keep call sites visible.
+    #[must_use]
+    pub fn phrase(&self) -> &str {
+        &self.phrase
+    }
+
+    /// The 256-bit entropy that produced (or was recovered from) the phrase.
+    /// This is the input to [`crate::crypto::kdf::derive_recovery_kek`].
+    #[must_use]
+    pub fn entropy(&self) -> &Sensitive<[u8; 32]> {
+        &self.entropy
+    }
+}
+
+/// Generate a fresh 24-word mnemonic from `rng`.
+///
+/// `rng` must be a CSPRNG; in production this is `rand_core::OsRng` (or
+/// equivalent), in tests it is typically a seeded `ChaCha20Rng` so that the
+/// generated phrase is reproducible.
+///
+/// The local 32-byte entropy buffer is zeroized after the BIP-39 mnemonic has
+/// been constructed; the entropy survives only inside the returned
+/// [`Mnemonic`]'s [`Sensitive`] field.
+pub fn generate(rng: &mut (impl RngCore + CryptoRng)) -> Mnemonic {
+    let mut entropy_buf = [0u8; 32];
+    rng.fill_bytes(&mut entropy_buf);
+
+    // `from_entropy` accepts any 16/20/24/28/32-byte input; 32 bytes always
+    // succeeds and yields a 24-word English mnemonic.
+    let bip = Bip39Mnemonic::from_entropy(&entropy_buf)
+        .expect("32 bytes is a valid BIP-39 entropy length (24 words)");
+
+    let phrase = bip.to_string();
+
+    // Re-extract the entropy from the parsed mnemonic so we can move it into
+    // a `Sensitive` wrapper. `to_entropy_array` returns a `[u8; 33]` plus the
+    // valid byte length; for 24 words the length is always 32.
+    let (full, len) = bip.to_entropy_array();
+    debug_assert_eq!(len, 32, "24-word BIP-39 must produce 32 bytes of entropy");
+    let mut entropy = [0u8; 32];
+    entropy.copy_from_slice(&full[..32]);
+
+    // `bip` is dropped at end of scope without zeroization (the bip39 crate's
+    // `zeroize` feature is off in our build, and `bip39::Mnemonic` therefore
+    // implements no `Drop`). The entropy bytes still live in its `[u16; 24]`
+    // words array on the stack until the slot is reused. Acceptable for the
+    // recovery path: the user is expected to be staring at the phrase on
+    // screen at this moment anyway. Best-effort within current dep choices.
+    entropy_buf.zeroize();
+
+    Mnemonic {
+        phrase,
+        entropy: Sensitive::new(entropy),
+    }
+}
+
+/// Redacted debug representation. Both the phrase and the entropy are
+/// secrets; the only externally observable property is "this is a 24-word
+/// mnemonic". A real `Debug` impl on the contents would defeat the
+/// zeroize-on-drop discipline by leaking through formatting.
+impl fmt::Debug for Mnemonic {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Mnemonic")
+            .field("phrase", &"<redacted>")
+            .field("entropy", &"<redacted>")
+            .finish()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rand_chacha::{rand_core::SeedableRng, ChaCha20Rng};
+
+    #[test]
+    fn generate_produces_24_words() {
+        let mut rng = ChaCha20Rng::from_seed([0u8; 32]);
+        let m = generate(&mut rng);
+        assert_eq!(m.phrase().split_whitespace().count(), 24);
+    }
+
+    #[test]
+    fn generate_is_deterministic_with_seeded_rng() {
+        let mut rng_a = ChaCha20Rng::from_seed([7u8; 32]);
+        let mut rng_b = ChaCha20Rng::from_seed([7u8; 32]);
+        let a = generate(&mut rng_a);
+        let b = generate(&mut rng_b);
+        assert_eq!(a.phrase(), b.phrase());
+        assert_eq!(a.entropy().expose(), b.entropy().expose());
+    }
+}

--- a/core/src/unlock/mnemonic.rs
+++ b/core/src/unlock/mnemonic.rs
@@ -101,12 +101,10 @@ pub fn generate(rng: &mut (impl RngCore + CryptoRng)) -> Mnemonic {
     let mut entropy = [0u8; 32];
     entropy.copy_from_slice(&full[..32]);
 
-    // `bip` is dropped at end of scope without zeroization (the bip39 crate's
-    // `zeroize` feature is off in our build, and `bip39::Mnemonic` therefore
-    // implements no `Drop`). The entropy bytes still live in its `[u16; 24]`
-    // words array on the stack until the slot is reused. Acceptable for the
-    // recovery path: the user is expected to be staring at the phrase on
-    // screen at this moment anyway. Best-effort within current dep choices.
+    // The bip39 crate's `zeroize` feature is enabled in our build, so the
+    // local `bip` value's internal `[u16; 24]` words array is wiped when it
+    // goes out of scope. We still zeroize the local entropy buffer here as
+    // defense in depth (DRY-violating but harmless).
     entropy_buf.zeroize();
 
     Mnemonic {

--- a/core/src/unlock/mnemonic.rs
+++ b/core/src/unlock/mnemonic.rs
@@ -235,4 +235,43 @@ mod tests {
         let parsed = parse(&messy).expect("messy input must normalize");
         assert_eq!(parsed.entropy().expose(), m.entropy().expose());
     }
+
+    #[test]
+    fn parse_rejects_wrong_word_count() {
+        let err = parse("abandon abandon abandon").unwrap_err();
+        assert_eq!(err, MnemonicError::WrongLength { got: 3 });
+    }
+
+    #[test]
+    fn parse_rejects_unknown_word() {
+        // 24 words, all "valid-looking" syntactically but one is not in the list.
+        // Take a real generated mnemonic and replace one word.
+        let mut rng = ChaCha20Rng::from_seed([99u8; 32]);
+        let m = generate(&mut rng);
+        let mut words: Vec<&str> = m.phrase().split_whitespace().collect();
+        words[5] = "notarealbip39word";
+        let bad = words.join(" ");
+        let err = parse(&bad).unwrap_err();
+        assert!(matches!(err, MnemonicError::UnknownWord(_)));
+    }
+
+    #[test]
+    fn parse_rejects_bad_checksum() {
+        // Take a valid mnemonic and swap two words from the wordlist — words
+        // remain in the list but the checksum no longer matches.
+        let mut rng = ChaCha20Rng::from_seed([100u8; 32]);
+        let m = generate(&mut rng);
+        let mut words: Vec<String> =
+            m.phrase().split_whitespace().map(String::from).collect();
+        words.swap(0, 1);
+        let bad = words.join(" ");
+        // It's possible the swap yields a still-valid checksum; for a fixed
+        // seed this is deterministic. The asserted failure mode is "either
+        // BadChecksum or UnknownWord", never Ok.
+        let err = parse(&bad).unwrap_err();
+        assert!(
+            matches!(err, MnemonicError::BadChecksum | MnemonicError::UnknownWord(_)),
+            "expected BadChecksum or UnknownWord, got {err:?}",
+        );
+    }
 }

--- a/core/src/unlock/mnemonic.rs
+++ b/core/src/unlock/mnemonic.rs
@@ -138,13 +138,25 @@ pub fn parse(words: &str) -> Result<Mnemonic, MnemonicError> {
         .collect::<Vec<_>>()
         .join(" ");
 
-    let word_count = normalized.split_whitespace().count();
-    if word_count != 24 {
-        return Err(MnemonicError::WrongLength { got: word_count });
+    let tokens: Vec<&str> = normalized.split_whitespace().collect();
+    if tokens.len() != 24 {
+        return Err(MnemonicError::WrongLength { got: tokens.len() });
     }
 
-    let bip = Bip39Mnemonic::parse_in_normalized(Language::English, &normalized)
-        .map_err(map_bip39_error)?;
+    // The bip39 crate reports `UnknownWord` by index into the phrase, not by
+    // content. We resolve the index against our local token list here so the
+    // caller-facing error variant carries the actual offending word.
+    let bip = Bip39Mnemonic::parse_in_normalized(Language::English, &normalized).map_err(|e| {
+        match e {
+            bip39::Error::UnknownWord(idx) => MnemonicError::UnknownWord(
+                tokens
+                    .get(idx)
+                    .map(|s| (*s).to_string())
+                    .unwrap_or_else(|| "(unknown)".to_string()),
+            ),
+            other => map_bip39_error(other),
+        }
+    })?;
 
     let (full, len) = bip.to_entropy_array();
     debug_assert_eq!(len, 32, "24-word BIP-39 must produce 32 bytes of entropy");
@@ -159,23 +171,25 @@ pub fn parse(words: &str) -> Result<Mnemonic, MnemonicError> {
 
 /// Map the bip39 crate's error enum onto our caller-facing variant set.
 ///
-/// The crate reports an unknown word by *index* (position in the phrase),
-/// not by content; we surface a placeholder string for now. A future
-/// enhancement could re-tokenize the input to recover the offending word.
+/// The `UnknownWord` arm is handled at the call site in [`parse`] (it needs
+/// the local token list to resolve an index back to the word) and therefore
+/// does not appear here.
 fn map_bip39_error(e: bip39::Error) -> MnemonicError {
     use bip39::Error::{
         AmbiguousLanguages, BadEntropyBitCount, BadWordCount, InvalidChecksum, UnknownWord,
     };
     match e {
-        UnknownWord(_idx) => MnemonicError::UnknownWord("(unknown)".to_string()),
         InvalidChecksum => MnemonicError::BadChecksum,
         BadWordCount(n) => MnemonicError::WrongLength { got: n },
         // BadEntropyBitCount cannot arise from `parse_in_normalized` (it's a
         // from-entropy constructor failure); AmbiguousLanguages cannot arise
-        // because we pin the language to English. Both are folded into
-        // BadChecksum as a safe catch-all rejection — a parse failure is a
-        // parse failure regardless of which structural rule was broken.
-        BadEntropyBitCount(_) | AmbiguousLanguages(_) => MnemonicError::BadChecksum,
+        // because we pin the language to English. UnknownWord is handled by
+        // the caller. All other arms are folded into BadChecksum as a safe
+        // catch-all rejection — a parse failure is a parse failure regardless
+        // of which structural rule was broken.
+        UnknownWord(_) | BadEntropyBitCount(_) | AmbiguousLanguages(_) => {
+            MnemonicError::BadChecksum
+        }
     }
 }
 
@@ -269,7 +283,8 @@ mod tests {
         words[5] = "notarealbip39word";
         let bad = words.join(" ");
         let err = parse(&bad).unwrap_err();
-        assert!(matches!(err, MnemonicError::UnknownWord(_)));
+        // The payload must carry the actual offending word, not a placeholder.
+        assert_eq!(err, MnemonicError::UnknownWord("notarealbip39word".to_string()));
     }
 
     #[test]

--- a/core/src/unlock/mnemonic.rs
+++ b/core/src/unlock/mnemonic.rs
@@ -7,11 +7,12 @@
 //! The phrase is the user-facing artefact (printed, written down, never stored
 //! by the application); the entropy is what the cryptography consumes.
 //!
-//! The entropy lives inside [`Sensitive`] (zeroize-on-drop). The phrase
-//! string is treated as sensitive too; explicit zeroization on drop is added
-//! in a later task. There is no `Clone`, `Copy`, `Debug`, or `Display` on
-//! [`Mnemonic`] derived publicly — callers that need the phrase use
-//! [`Mnemonic::phrase`], which keeps every read of the secret grep-able.
+//! Both the phrase and the entropy are treated as sensitive: the entropy
+//! lives inside [`Sensitive`] (zeroize-on-drop) and the phrase string is
+//! zeroized in this module's [`Drop`] impl. There is no `Clone`, `Copy`,
+//! `Display`, or content-revealing `Debug` on [`Mnemonic`] — callers that
+//! need the phrase use [`Mnemonic::phrase`], which keeps every read of the
+//! secret grep-able.
 
 use core::fmt;
 
@@ -23,6 +24,10 @@ use zeroize::Zeroize;
 use crate::crypto::secret::Sensitive;
 
 /// 24-word BIP-39 mnemonic carrying 256 bits of entropy.
+///
+/// Owns both the human-readable phrase and the raw entropy. Both are
+/// zeroized when the value is dropped: the entropy via [`Sensitive`]'s
+/// `ZeroizeOnDrop`, the phrase via this type's explicit [`Drop`] impl.
 pub struct Mnemonic {
     phrase: String,
     entropy: Sensitive<[u8; 32]>,
@@ -189,6 +194,20 @@ impl fmt::Debug for Mnemonic {
     }
 }
 
+impl Drop for Mnemonic {
+    fn drop(&mut self) {
+        // `zeroize` 1.4+ provides a `Zeroize` impl for `String` that
+        // overwrites the heap allocation in place (using isolated `unsafe`
+        // inside the zeroize crate — this crate has `#![forbid(unsafe_code)]`
+        // and does not introduce its own).
+        //
+        // The `entropy` field is a `Sensitive<[u8; 32]>`, which derives
+        // `ZeroizeOnDrop` and is wiped automatically as part of this struct's
+        // drop glue.
+        self.phrase.zeroize();
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -253,6 +272,17 @@ mod tests {
         let bad = words.join(" ");
         let err = parse(&bad).unwrap_err();
         assert!(matches!(err, MnemonicError::UnknownWord(_)));
+    }
+
+    #[test]
+    fn mnemonic_drop_compiles() {
+        // Compile-time check that `Mnemonic` has a Drop impl that runs on
+        // scope exit. There is no observable behavior to assert without
+        // reading freed memory; the value of this test is the implicit
+        // "must call Drop" requirement on the type.
+        let mut rng = ChaCha20Rng::from_seed([0u8; 32]);
+        let _m = generate(&mut rng);
+        // _m drops here — Drop runs.
     }
 
     #[test]

--- a/core/src/unlock/mnemonic.rs
+++ b/core/src/unlock/mnemonic.rs
@@ -171,9 +171,13 @@ pub fn parse(words: &str) -> Result<Mnemonic, MnemonicError> {
 
 /// Map the bip39 crate's error enum onto our caller-facing variant set.
 ///
-/// The `UnknownWord` arm is handled at the call site in [`parse`] (it needs
-/// the local token list to resolve an index back to the word) and therefore
-/// does not appear here.
+/// The `UnknownWord` arm IS listed in the match below for exhaustiveness,
+/// but it is intercepted at the call site in [`parse`] before reaching
+/// this function (the call site needs the local token list to resolve the
+/// crate's word *index* back to the offending word *content*). The match
+/// arm here is therefore unreachable in normal operation — see the
+/// comment on that arm for why mapping to `BadChecksum` is the right
+/// fallback if the bip39 crate's behaviour ever changes.
 fn map_bip39_error(e: bip39::Error) -> MnemonicError {
     use bip39::Error::{
         AmbiguousLanguages, BadEntropyBitCount, BadWordCount, InvalidChecksum, UnknownWord,
@@ -181,12 +185,22 @@ fn map_bip39_error(e: bip39::Error) -> MnemonicError {
     match e {
         InvalidChecksum => MnemonicError::BadChecksum,
         BadWordCount(n) => MnemonicError::WrongLength { got: n },
-        // BadEntropyBitCount cannot arise from `parse_in_normalized` (it's a
-        // from-entropy constructor failure); AmbiguousLanguages cannot arise
-        // because we pin the language to English. UnknownWord is handled by
-        // the caller. All other arms are folded into BadChecksum as a safe
-        // catch-all rejection — a parse failure is a parse failure regardless
-        // of which structural rule was broken.
+
+        // The three remaining variants are unreachable from
+        // `parse_in_normalized` in [`parse`]'s call pattern but must be
+        // listed for exhaustiveness:
+        //
+        // - `UnknownWord`: caught and converted to `MnemonicError::UnknownWord`
+        //   (carrying the actual offending word, not the crate's index)
+        //   at the [`parse`] call site BEFORE the result reaches this
+        //   function. If the bip39 crate's contract ever changes such that
+        //   `UnknownWord` slips past the call site, mapping to
+        //   `BadChecksum` is a safe fallback — bad input is bad input.
+        // - `BadEntropyBitCount`: only constructable by from-entropy
+        //   constructors (e.g. `Mnemonic::from_entropy_in`), not by the
+        //   parser.
+        // - `AmbiguousLanguages`: only constructable when the language is
+        //   auto-detected; we pin to English via `parse_in_normalized`.
         UnknownWord(_) | BadEntropyBitCount(_) | AmbiguousLanguages(_) => {
             MnemonicError::BadChecksum
         }

--- a/core/src/unlock/mod.rs
+++ b/core/src/unlock/mod.rs
@@ -7,6 +7,7 @@ pub mod bundle_file;
 pub mod mnemonic;
 pub mod vault_toml;
 
+use core::fmt;
 use rand_core::{CryptoRng, RngCore};
 
 use crate::crypto::aead::{encrypt, AeadError};
@@ -68,6 +69,32 @@ pub struct UnlockedIdentity {
     pub identity: bundle::IdentityBundle,
 }
 
+/// Redacted Debug for CreatedVault — mirrors IdentityBundle / Mnemonic policy.
+/// Secret fields are replaced with `<redacted>`; byte-vector lengths and the
+/// non-secret display_name are shown so logs remain useful.
+impl fmt::Debug for CreatedVault {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("CreatedVault")
+            .field("vault_toml_bytes_len", &self.vault_toml_bytes.len())
+            .field("identity_bundle_bytes_len", &self.identity_bundle_bytes.len())
+            .field("recovery_mnemonic", &self.recovery_mnemonic) // delegates to Mnemonic's redacting Debug
+            .field("identity_block_key", &"<redacted>")
+            .field("identity", &self.identity) // delegates to IdentityBundle's redacting Debug
+            .finish()
+    }
+}
+
+/// Redacted Debug for UnlockedIdentity — same no-leak-via-Debug policy as
+/// CreatedVault; the identity_block_key is the symmetric root secret.
+impl fmt::Debug for UnlockedIdentity {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("UnlockedIdentity")
+            .field("identity_block_key", &"<redacted>")
+            .field("identity", &self.identity)
+            .finish()
+    }
+}
+
 // ---------------------------------------------------------------------------
 // create_vault orchestrator (§3 Master KEK, §4 Recovery KEK, §5 bundle wrap)
 // ---------------------------------------------------------------------------
@@ -92,7 +119,14 @@ pub fn create_vault(
     let recovery_mnemonic = mnemonic::generate(rng);
     let recovery_kek = derive_recovery_kek(recovery_mnemonic.entropy());
 
-    // Step 4: Identity Block Key (32 random bytes)
+    // Step 4: Identity Block Key — fresh CSPRNG bytes wrapped in Sensitive.
+    // SECURITY: rng.fill_bytes writes into a stack array, then Sensitive::new
+    // MOVES that array into the Sensitive wrapper — the original stack slot
+    // is logically dead but its bytes are not zeroized. This is a known Rust
+    // limitation (no MaybeUninit-aware fill_bytes). The Sensitive wrapper's
+    // Drop impl handles zeroization for the wrapped copy; the residual stack
+    // bytes persist briefly until the next stack frame overwrites them.
+    // Same pattern as bundle::generate's Identity Bundle keys.
     let mut ibk = [0u8; 32];
     rng.fill_bytes(&mut ibk);
     let identity_block_key = Sensitive::new(ibk);
@@ -101,7 +135,10 @@ pub fn create_vault(
     let identity = bundle::generate(display_name, created_at_ms, rng);
     let bundle_plaintext = identity.to_canonical_cbor()?;
 
-    // Step 6: three independent 24-byte AEAD nonces
+    // Step 6: three independent 24-byte AEAD nonces — one per AEAD call below.
+    // Each key (IBK, master_kek, recovery_kek) is used exactly once, but
+    // independent draws make the "never reuse nonce+key" §13 mandate visible
+    // rather than implicit, and survive future refactors that might share keys.
     let mut nonce_id = [0u8; 24];
     rng.fill_bytes(&mut nonce_id);
     let mut nonce_pw = [0u8; 24];
@@ -154,8 +191,8 @@ pub fn create_vault(
     };
     let identity_bundle_bytes = bundle_file::encode(&bf);
 
-    // Step 11: pack into VaultToml → vault_toml_bytes.
-    // Argon2idParams fields (memory_kib, iterations, parallelism) are pub.
+    // Step 11: emit vault.toml (§2) — KDF params mirror kdf_params so the
+    // vault is portable across devices that open with derive_master_kek (§3).
     let vt = vault_toml::VaultToml {
         format_version: 1,
         suite_id: 1,
@@ -198,7 +235,10 @@ fn compose_aad(tag: &[u8], vault_uuid: &[u8; 16]) -> Vec<u8> {
 #[cfg(test)]
 mod create_tests {
     use super::*;
-    use crate::crypto::kdf::Argon2idParams;
+    // NOTE: Argon2idParams is visible here via `super::*` because it is imported
+    // at module scope in mod.rs (`use crate::crypto::kdf::{..., Argon2idParams, ...}`).
+    // The explicit `use crate::crypto::kdf::Argon2idParams` import was therefore
+    // redundant and has been removed.
     use rand_chacha::{rand_core::SeedableRng, ChaCha20Rng};
 
     #[test]
@@ -213,5 +253,16 @@ mod create_tests {
         assert!(!v.identity_bundle_bytes.is_empty());
         assert_eq!(v.recovery_mnemonic.phrase().split_whitespace().count(), 24);
         assert_eq!(v.identity.display_name, "Alice");
+
+        // Confirm vault_toml_bytes parses back to valid TOML with our kdf params.
+        let parsed_vt = vault_toml::decode(
+            std::str::from_utf8(&v.vault_toml_bytes).expect("vault_toml is utf-8"),
+        )
+        .expect("vault_toml decode");
+        assert_eq!(parsed_vt.kdf.memory_kib, 8);
+        assert_eq!(parsed_vt.kdf.iterations, 1);
+        assert_eq!(parsed_vt.kdf.parallelism, 1);
+        assert_eq!(parsed_vt.format_version, 1);
+        assert_eq!(parsed_vt.suite_id, 1);
     }
 }

--- a/core/src/unlock/mod.rs
+++ b/core/src/unlock/mod.rs
@@ -6,3 +6,41 @@ pub mod bundle;
 pub mod bundle_file;
 pub mod mnemonic;
 pub mod vault_toml;
+
+use crate::crypto::aead::AeadError;
+use crate::crypto::kdf::KdfError;
+
+#[derive(Debug, thiserror::Error)]
+pub enum UnlockError {
+    #[error("wrong password or vault corruption")]
+    WrongPasswordOrCorrupt,
+    #[error("wrong recovery mnemonic or vault corruption")]
+    WrongMnemonicOrCorrupt,
+    #[error("invalid mnemonic: {0}")]
+    InvalidMnemonic(#[from] mnemonic::MnemonicError),
+    #[error("vault data integrity failure")]
+    CorruptVault,
+    #[error("vault.toml and identity.bundle.enc reference different vaults")]
+    VaultMismatch,
+
+    #[error("malformed vault.toml: {0}")]
+    MalformedVaultToml(#[from] vault_toml::VaultTomlError),
+    #[error("malformed identity.bundle.enc: {0}")]
+    MalformedBundleFile(#[from] bundle_file::BundleFileError),
+    #[error("malformed identity bundle plaintext: {0}")]
+    MalformedBundle(#[from] bundle::BundleError),
+
+    #[error("KDF failure: {0}")]
+    KdfFailure(#[from] KdfError),
+    #[error("AEAD primitive failure")]
+    AeadFailure,
+}
+
+impl From<AeadError> for UnlockError {
+    fn from(_: AeadError) -> Self {
+        // AEAD primitive errors collapse to AeadFailure — see spec §Error model.
+        // Position-specific user-facing variants (WrongPasswordOrCorrupt etc.)
+        // are produced explicitly at call sites, not via From.
+        UnlockError::AeadFailure
+    }
+}

--- a/core/src/unlock/mod.rs
+++ b/core/src/unlock/mod.rs
@@ -5,3 +5,4 @@
 pub mod bundle;
 pub mod bundle_file;
 pub mod mnemonic;
+pub mod vault_toml;

--- a/core/src/unlock/mod.rs
+++ b/core/src/unlock/mod.rs
@@ -7,8 +7,14 @@ pub mod bundle_file;
 pub mod mnemonic;
 pub mod vault_toml;
 
-use crate::crypto::aead::AeadError;
-use crate::crypto::kdf::KdfError;
+use rand_core::{CryptoRng, RngCore};
+
+use crate::crypto::aead::{encrypt, AeadError};
+use crate::crypto::kdf::{
+    derive_master_kek, derive_recovery_kek, Argon2idParams, KdfError, TAG_ID_BUNDLE,
+    TAG_ID_WRAP_PW, TAG_ID_WRAP_REC,
+};
+use crate::crypto::secret::{SecretBytes, Sensitive};
 
 #[derive(Debug, thiserror::Error)]
 pub enum UnlockError {
@@ -42,5 +48,170 @@ impl From<AeadError> for UnlockError {
         // Position-specific user-facing variants (WrongPasswordOrCorrupt etc.)
         // are produced explicitly at call sites, not via From.
         UnlockError::AeadFailure
+    }
+}
+
+// ---------------------------------------------------------------------------
+// create_vault output types
+// ---------------------------------------------------------------------------
+
+pub struct CreatedVault {
+    pub vault_toml_bytes: Vec<u8>,
+    pub identity_bundle_bytes: Vec<u8>,
+    pub recovery_mnemonic: mnemonic::Mnemonic,
+    pub identity_block_key: Sensitive<[u8; 32]>,
+    pub identity: bundle::IdentityBundle,
+}
+
+pub struct UnlockedIdentity {
+    pub identity_block_key: Sensitive<[u8; 32]>,
+    pub identity: bundle::IdentityBundle,
+}
+
+// ---------------------------------------------------------------------------
+// create_vault orchestrator (§3 Master KEK, §4 Recovery KEK, §5 bundle wrap)
+// ---------------------------------------------------------------------------
+
+pub fn create_vault(
+    password: &SecretBytes,
+    display_name: &str,
+    created_at_ms: u64,
+    kdf_params: Argon2idParams,
+    rng: &mut (impl RngCore + CryptoRng),
+) -> Result<CreatedVault, UnlockError> {
+    // Step 1: identifiers and salt
+    let mut vault_uuid = [0u8; 16];
+    rng.fill_bytes(&mut vault_uuid);
+    let mut argon2_salt = [0u8; 32];
+    rng.fill_bytes(&mut argon2_salt);
+
+    // Step 2: Master KEK
+    let master_kek = derive_master_kek(password, &argon2_salt, &kdf_params)?;
+
+    // Step 3: mnemonic + Recovery KEK
+    let recovery_mnemonic = mnemonic::generate(rng);
+    let recovery_kek = derive_recovery_kek(recovery_mnemonic.entropy());
+
+    // Step 4: Identity Block Key (32 random bytes)
+    let mut ibk = [0u8; 32];
+    rng.fill_bytes(&mut ibk);
+    let identity_block_key = Sensitive::new(ibk);
+
+    // Step 5: generate identity + canonical CBOR
+    let identity = bundle::generate(display_name, created_at_ms, rng);
+    let bundle_plaintext = identity.to_canonical_cbor()?;
+
+    // Step 6: three independent 24-byte AEAD nonces
+    let mut nonce_id = [0u8; 24];
+    rng.fill_bytes(&mut nonce_id);
+    let mut nonce_pw = [0u8; 24];
+    rng.fill_bytes(&mut nonce_pw);
+    let mut nonce_rec = [0u8; 24];
+    rng.fill_bytes(&mut nonce_rec);
+
+    // Step 7: AEAD-encrypt bundle under IBK.
+    // identity_block_key: Sensitive<[u8;32]> == AeadKey, pass by reference.
+    let bundle_aad = compose_aad(TAG_ID_BUNDLE, &vault_uuid);
+    let bundle_ct_with_tag = encrypt(&identity_block_key, &nonce_id, &bundle_aad, &bundle_plaintext)?;
+
+    // Step 8: wrap_pw — AEAD-encrypt the IBK bytes under master_kek.
+    // identity_block_key.expose() -> &[u8; 32] coerces to &[u8] (plaintext).
+    let wrap_pw_aad = compose_aad(TAG_ID_WRAP_PW, &vault_uuid);
+    let wrap_pw_with_tag = encrypt(
+        &master_kek,
+        &nonce_pw,
+        &wrap_pw_aad,
+        identity_block_key.expose(),
+    )?;
+    let wrap_pw_arr: [u8; 48] = wrap_pw_with_tag
+        .as_slice()
+        .try_into()
+        .expect("32-byte plaintext + 16-byte tag = 48 bytes");
+
+    // Step 9: wrap_rec — AEAD-encrypt the IBK bytes under recovery_kek.
+    let wrap_rec_aad = compose_aad(TAG_ID_WRAP_REC, &vault_uuid);
+    let wrap_rec_with_tag = encrypt(
+        &recovery_kek,
+        &nonce_rec,
+        &wrap_rec_aad,
+        identity_block_key.expose(),
+    )?;
+    let wrap_rec_arr: [u8; 48] = wrap_rec_with_tag
+        .as_slice()
+        .try_into()
+        .expect("32-byte plaintext + 16-byte tag = 48 bytes");
+
+    // Step 10: pack into BundleFile → identity_bundle_bytes
+    let bf = bundle_file::BundleFile {
+        vault_uuid,
+        created_at_ms,
+        wrap_pw_nonce: nonce_pw,
+        wrap_pw_ct_with_tag: wrap_pw_arr,
+        wrap_rec_nonce: nonce_rec,
+        wrap_rec_ct_with_tag: wrap_rec_arr,
+        bundle_nonce: nonce_id,
+        bundle_ct_with_tag,
+    };
+    let identity_bundle_bytes = bundle_file::encode(&bf);
+
+    // Step 11: pack into VaultToml → vault_toml_bytes.
+    // Argon2idParams fields (memory_kib, iterations, parallelism) are pub.
+    let vt = vault_toml::VaultToml {
+        format_version: 1,
+        suite_id: 1,
+        vault_uuid,
+        created_at_ms,
+        kdf: vault_toml::KdfSection {
+            algorithm: "argon2id".to_string(),
+            version: "1.3".to_string(),
+            memory_kib: kdf_params.memory_kib,
+            iterations: kdf_params.iterations,
+            parallelism: kdf_params.parallelism,
+            salt: argon2_salt,
+        },
+    };
+    let vault_toml_bytes = vault_toml::encode(&vt).into_bytes();
+
+    // master_kek and recovery_kek go out of scope here → Sensitive Drop zeroizes.
+
+    Ok(CreatedVault {
+        vault_toml_bytes,
+        identity_bundle_bytes,
+        recovery_mnemonic,
+        identity_block_key,
+        identity,
+    })
+}
+
+/// Concatenate a domain-separation tag with a vault UUID to form the AEAD AAD.
+fn compose_aad(tag: &[u8], vault_uuid: &[u8; 16]) -> Vec<u8> {
+    let mut out = Vec::with_capacity(tag.len() + vault_uuid.len());
+    out.extend_from_slice(tag);
+    out.extend_from_slice(vault_uuid);
+    out
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod create_tests {
+    use super::*;
+    use crate::crypto::kdf::Argon2idParams;
+    use rand_chacha::{rand_core::SeedableRng, ChaCha20Rng};
+
+    #[test]
+    fn create_vault_produces_well_formed_artifacts() {
+        let mut rng = ChaCha20Rng::from_seed([42u8; 32]);
+        let password = SecretBytes::new(b"correct horse battery staple".to_vec());
+        // Use minimal Argon2id params for test speed (memory floor relaxed via ::new).
+        let params = Argon2idParams::new(8, 1, 1);
+        let v = create_vault(&password, "Alice", 1_714_060_800_000, params, &mut rng)
+            .expect("create_vault");
+        assert!(!v.vault_toml_bytes.is_empty());
+        assert!(!v.identity_bundle_bytes.is_empty());
+        assert_eq!(v.recovery_mnemonic.phrase().split_whitespace().count(), 24);
+        assert_eq!(v.identity.display_name, "Alice");
     }
 }

--- a/core/src/unlock/mod.rs
+++ b/core/src/unlock/mod.rs
@@ -10,7 +10,7 @@ pub mod vault_toml;
 use core::fmt;
 use rand_core::{CryptoRng, RngCore};
 
-use crate::crypto::aead::{decrypt, encrypt, AeadError};
+use crate::crypto::aead::{decrypt, encrypt};
 use crate::crypto::kdf::{
     derive_master_kek, derive_recovery_kek, Argon2idParams, KdfError, TAG_ID_BUNDLE,
     TAG_ID_WRAP_PW, TAG_ID_WRAP_REC,
@@ -40,8 +40,6 @@ pub enum UnlockError {
 
     #[error("KDF failure: {0}")]
     KdfFailure(#[from] KdfError),
-    #[error("AEAD primitive failure")]
-    AeadFailure,
 
     /// `kdf_params.memory_kib` is below the §1.2 v1 floor (currently 64 MiB).
     /// Returned by [`create_vault`] to prevent silent production of weak
@@ -51,14 +49,17 @@ pub enum UnlockError {
     WeakKdfParams { memory_kib: u32, min_memory_kib: u32 },
 }
 
-impl From<AeadError> for UnlockError {
-    fn from(_: AeadError) -> Self {
-        // AEAD primitive errors collapse to AeadFailure — see spec §Error model.
-        // Position-specific user-facing variants (WrongPasswordOrCorrupt etc.)
-        // are produced explicitly at call sites, not via From.
-        UnlockError::AeadFailure
-    }
-}
+// AEAD failures are mapped at every call site:
+//   - decrypt failures → WrongPasswordOrCorrupt / WrongMnemonicOrCorrupt /
+//     CorruptVault depending on which payload failed (position-specific).
+//   - encrypt failures → infallible for §5 input sizes (max ~5 KB bundle
+//     plaintext, exactly 32 B IBK wraps) — handled with .expect rather
+//     than ? at the create_vault_unchecked call sites.
+//
+// There is therefore deliberately NO `From<AeadError> for UnlockError`
+// impl. A `?` on an aead::encrypt call inside this module would be a
+// compile error, which is the right outcome — every aead error site is
+// position-specific and must be mapped explicitly.
 
 // ---------------------------------------------------------------------------
 // create_vault output types
@@ -196,18 +197,23 @@ pub fn create_vault_unchecked(
 
     // Step 7: AEAD-encrypt bundle under IBK.
     // identity_block_key: Sensitive<[u8;32]> == AeadKey, pass by reference.
+    // .expect() is safe: AEAD encrypt fails only on absurd plaintext sizes
+    // (~2^36 bytes); §5 IdentityBundle CBOR is bounded at a few KB.
     let bundle_aad = compose_aad(TAG_ID_BUNDLE, &vault_uuid);
-    let bundle_ct_with_tag = encrypt(&identity_block_key, &nonce_id, &bundle_aad, &bundle_plaintext)?;
+    let bundle_ct_with_tag = encrypt(&identity_block_key, &nonce_id, &bundle_aad, &bundle_plaintext)
+        .expect("AEAD encrypt of §5 bundle plaintext is structurally infallible");
 
     // Step 8: wrap_pw — AEAD-encrypt the IBK bytes under master_kek.
     // identity_block_key.expose() -> &[u8; 32] coerces to &[u8] (plaintext).
+    // .expect() safe: encrypt of a fixed 32-byte plaintext cannot fail.
     let wrap_pw_aad = compose_aad(TAG_ID_WRAP_PW, &vault_uuid);
     let wrap_pw_with_tag = encrypt(
         &master_kek,
         &nonce_pw,
         &wrap_pw_aad,
         identity_block_key.expose(),
-    )?;
+    )
+    .expect("AEAD encrypt of 32-byte IBK is structurally infallible");
     let wrap_pw_arr: [u8; 48] = wrap_pw_with_tag
         .as_slice()
         .try_into()
@@ -220,7 +226,8 @@ pub fn create_vault_unchecked(
         &nonce_rec,
         &wrap_rec_aad,
         identity_block_key.expose(),
-    )?;
+    )
+    .expect("AEAD encrypt of 32-byte IBK is structurally infallible");
     let wrap_rec_arr: [u8; 48] = wrap_rec_with_tag
         .as_slice()
         .try_into()

--- a/core/src/unlock/mod.rs
+++ b/core/src/unlock/mod.rs
@@ -258,9 +258,15 @@ pub fn open_with_password(
     let vt_str = std::str::from_utf8(vault_toml_bytes).map_err(|_| vault_toml_not_utf8())?;
     let vt = vault_toml::decode(vt_str)?;
 
-    // Step 2: parse identity.bundle.enc; check vault_uuid match across both files.
+    // Step 2: parse identity.bundle.enc; cross-check both `vault_uuid` and
+    // `created_at_ms` between the two files. Mismatch on either points at a
+    // file swap (a vault.toml from one vault paired with an identity bundle
+    // from another) — `vault.toml` is cleartext so it is the more easily
+    // tampered side. AEAD tags still protect the IBK and bundle plaintext,
+    // but cross-checking both metadata fields here gives a clear, early
+    // typed error before any KDF work.
     let bf = bundle_file::decode(identity_bundle_bytes)?;
-    if bf.vault_uuid != vt.vault_uuid {
+    if bf.vault_uuid != vt.vault_uuid || bf.created_at_ms != vt.created_at_ms {
         return Err(UnlockError::VaultMismatch);
     }
 
@@ -321,7 +327,7 @@ pub fn open_with_recovery(
     let vt_str = std::str::from_utf8(vault_toml_bytes).map_err(|_| vault_toml_not_utf8())?;
     let vt = vault_toml::decode(vt_str)?;
     let bf = bundle_file::decode(identity_bundle_bytes)?;
-    if bf.vault_uuid != vt.vault_uuid {
+    if bf.vault_uuid != vt.vault_uuid || bf.created_at_ms != vt.created_at_ms {
         return Err(UnlockError::VaultMismatch);
     }
 

--- a/core/src/unlock/mod.rs
+++ b/core/src/unlock/mod.rs
@@ -1,3 +1,5 @@
 //! Master-password and recovery-key unlock paths.
-//!
-//! Populated by build-sequence step 5.
+//! See `docs/crypto-design.md` §3 (Master KEK), §4 (Recovery KEK), §5 (Identity Bundle wrap)
+//! and `docs/vault-format.md` §2 (vault.toml), §3 (identity.bundle.enc).
+
+pub mod mnemonic;

--- a/core/src/unlock/mod.rs
+++ b/core/src/unlock/mod.rs
@@ -228,6 +228,16 @@ fn compose_aad(tag: &[u8], vault_uuid: &[u8; 16]) -> Vec<u8> {
     out
 }
 
+/// Construct the layered error returned when vault.toml bytes aren't UTF-8.
+/// Used by both open paths; the underlying `MalformedToml` variant is the
+/// right inner error since "non-UTF-8 bytes" is a parse failure, not a
+/// missing field.
+fn vault_toml_not_utf8() -> UnlockError {
+    UnlockError::MalformedVaultToml(vault_toml::VaultTomlError::MalformedToml(
+        "non-UTF-8 input".to_string(),
+    ))
+}
+
 // ---------------------------------------------------------------------------
 // open_with_password (§3 Master KEK unlock path)
 // ---------------------------------------------------------------------------
@@ -244,10 +254,7 @@ pub fn open_with_password(
     // structured errors, leaving MalformedToml for genuine parse failures.
     // Non-UTF-8 input IS a parse failure, so the inner MalformedToml is
     // appropriate here.
-    let vt_str = std::str::from_utf8(vault_toml_bytes)
-        .map_err(|_| UnlockError::MalformedVaultToml(vault_toml::VaultTomlError::MalformedToml(
-            "non-UTF-8 input".to_string(),
-        )))?;
+    let vt_str = std::str::from_utf8(vault_toml_bytes).map_err(|_| vault_toml_not_utf8())?;
     let vt = vault_toml::decode(vt_str)?;
 
     // Step 2: parse identity.bundle.enc; check vault_uuid match across both files.
@@ -275,6 +282,9 @@ pub fn open_with_password(
 
     // ibk_bytes is SecretBytes wrapping a Vec<u8>. The wrap_pw plaintext
     // is exactly 32 bytes (an IBK). Anything else is a corrupt vault.
+    // SECURITY: ibk_arr leaves a residual copy of the IBK on the stack after
+    // Sensitive::new moves it. Same limitation as create_vault's IBK
+    // construction — see the SECURITY note there for details.
     let ibk_arr: [u8; 32] = ibk_bytes.expose().try_into()
         .map_err(|_| UnlockError::CorruptVault)?;
     let identity_block_key = Sensitive::new(ibk_arr);
@@ -307,10 +317,7 @@ pub fn open_with_recovery(
     mnemonic_words: &str,
 ) -> Result<UnlockedIdentity, UnlockError> {
     // Steps 1-2: vault.toml + bundle file (mirror open_with_password)
-    let vt_str = std::str::from_utf8(vault_toml_bytes)
-        .map_err(|_| UnlockError::MalformedVaultToml(vault_toml::VaultTomlError::MalformedToml(
-            "non-UTF-8 input".to_string(),
-        )))?;
+    let vt_str = std::str::from_utf8(vault_toml_bytes).map_err(|_| vault_toml_not_utf8())?;
     let vt = vault_toml::decode(vt_str)?;
     let bf = bundle_file::decode(identity_bundle_bytes)?;
     if bf.vault_uuid != vt.vault_uuid {
@@ -321,12 +328,15 @@ pub fn open_with_recovery(
     // surfaces as InvalidMnemonic via the From impl — distinct from
     // WrongMnemonicOrCorrupt because the failure mode is "this isn't a
     // valid BIP-39 phrase at all" rather than "valid phrase, wrong vault."
-    let parsed = mnemonic::parse(mnemonic_words)?;
+    let parsed_mnemonic = mnemonic::parse(mnemonic_words)?;
 
     // Step 4: derive Recovery KEK from the parsed entropy.
-    let recovery_kek = derive_recovery_kek(parsed.entropy());
+    let recovery_kek = derive_recovery_kek(parsed_mnemonic.entropy());
 
-    // Step 5: AEAD-decrypt wrap_rec → IBK bytes.
+    // Step 5: AEAD-decrypt wrap_rec → IBK bytes. AEAD failure here means wrong
+    // mnemonic (or vault corruption — indistinguishable on auth-tag failure,
+    // matching the §13 "wrong key looks like corruption" property). UI surfaces
+    // this as wrong-mnemonic.
     let wrap_rec_aad = compose_aad(TAG_ID_WRAP_REC, &vt.vault_uuid);
     let ibk_bytes = decrypt(
         &recovery_kek,
@@ -336,11 +346,15 @@ pub fn open_with_recovery(
     )
     .map_err(|_| UnlockError::WrongMnemonicOrCorrupt)?;
 
+    // SECURITY: ibk_arr leaves a residual copy of the IBK on the stack after
+    // Sensitive::new moves it. Same limitation as create_vault's IBK
+    // construction — see the SECURITY note there for details.
     let ibk_arr: [u8; 32] = ibk_bytes.expose().try_into()
         .map_err(|_| UnlockError::CorruptVault)?;
     let identity_block_key = Sensitive::new(ibk_arr);
 
-    // Step 6: AEAD-decrypt bundle.
+    // Step 6: AEAD-decrypt the bundle plaintext under IBK. Post-IBK-recovery
+    // failure is unequivocally tampering, not user error.
     let bundle_aad = compose_aad(TAG_ID_BUNDLE, &vt.vault_uuid);
     let bundle_plaintext = decrypt(
         &identity_block_key,
@@ -432,6 +446,8 @@ mod create_tests {
             .expect("open");
         assert_eq!(opened.identity_block_key.expose(), v.identity_block_key.expose());
         assert_eq!(opened.identity.user_uuid, v.identity.user_uuid);
+        assert_eq!(opened.identity.display_name, v.identity.display_name);
+        assert_eq!(opened.identity.x25519_sk.expose(), v.identity.x25519_sk.expose());
     }
 
     #[test]

--- a/core/src/unlock/mod.rs
+++ b/core/src/unlock/mod.rs
@@ -10,7 +10,7 @@ pub mod vault_toml;
 use core::fmt;
 use rand_core::{CryptoRng, RngCore};
 
-use crate::crypto::aead::{encrypt, AeadError};
+use crate::crypto::aead::{decrypt, encrypt, AeadError};
 use crate::crypto::kdf::{
     derive_master_kek, derive_recovery_kek, Argon2idParams, KdfError, TAG_ID_BUNDLE,
     TAG_ID_WRAP_PW, TAG_ID_WRAP_REC,
@@ -229,6 +229,75 @@ fn compose_aad(tag: &[u8], vault_uuid: &[u8; 16]) -> Vec<u8> {
 }
 
 // ---------------------------------------------------------------------------
+// open_with_password (§3 Master KEK unlock path)
+// ---------------------------------------------------------------------------
+
+pub fn open_with_password(
+    vault_toml_bytes: &[u8],
+    identity_bundle_bytes: &[u8],
+    password: &SecretBytes,
+) -> Result<UnlockedIdentity, UnlockError> {
+    // Step 1: parse vault.toml. Reject non-UTF-8 input cleanly rather than
+    // letting it surface as a `MalformedVaultToml(MalformedToml(...))`
+    // double-wrap — the underlying VaultTomlError's MalformedToml carries
+    // a String, but the codebase uses MissingField / UnsupportedXxx for
+    // structured errors, leaving MalformedToml for genuine parse failures.
+    // Non-UTF-8 input IS a parse failure, so the inner MalformedToml is
+    // appropriate here.
+    let vt_str = std::str::from_utf8(vault_toml_bytes)
+        .map_err(|_| UnlockError::MalformedVaultToml(vault_toml::VaultTomlError::MalformedToml(
+            "non-UTF-8 input".to_string(),
+        )))?;
+    let vt = vault_toml::decode(vt_str)?;
+
+    // Step 2: parse identity.bundle.enc; check vault_uuid match across both files.
+    let bf = bundle_file::decode(identity_bundle_bytes)?;
+    if bf.vault_uuid != vt.vault_uuid {
+        return Err(UnlockError::VaultMismatch);
+    }
+
+    // Step 3: derive Master KEK using parameters from vault.toml.
+    let kdf_params = Argon2idParams::new(vt.kdf.memory_kib, vt.kdf.iterations, vt.kdf.parallelism);
+    let master_kek = derive_master_kek(password, &vt.kdf.salt, &kdf_params)?;
+
+    // Step 4: AEAD-decrypt wrap_pw → IBK bytes. AEAD failure here means
+    // wrong password (or vault corruption — indistinguishable on auth-tag
+    // failure, which is the design for §13's "wrong key looks like
+    // corruption to crypto" property). UI surfaces this as wrong-password.
+    let wrap_pw_aad = compose_aad(TAG_ID_WRAP_PW, &vt.vault_uuid);
+    let ibk_bytes = decrypt(
+        &master_kek,
+        &bf.wrap_pw_nonce,
+        &wrap_pw_aad,
+        &bf.wrap_pw_ct_with_tag,
+    )
+    .map_err(|_| UnlockError::WrongPasswordOrCorrupt)?;
+
+    // ibk_bytes is SecretBytes wrapping a Vec<u8>. The wrap_pw plaintext
+    // is exactly 32 bytes (an IBK). Anything else is a corrupt vault.
+    let ibk_arr: [u8; 32] = ibk_bytes.expose().try_into()
+        .map_err(|_| UnlockError::CorruptVault)?;
+    let identity_block_key = Sensitive::new(ibk_arr);
+
+    // Step 5: AEAD-decrypt the bundle plaintext under the IBK. AEAD failure
+    // here is post-IBK-recovery: any failure is unequivocally corruption,
+    // not user error.
+    let bundle_aad = compose_aad(TAG_ID_BUNDLE, &vt.vault_uuid);
+    let bundle_plaintext = decrypt(
+        &identity_block_key,
+        &bf.bundle_nonce,
+        &bundle_aad,
+        &bf.bundle_ct_with_tag,
+    )
+    .map_err(|_| UnlockError::CorruptVault)?;
+
+    // Step 6: CBOR decode (the From<BundleError> impl maps malformed CBOR cleanly).
+    let identity = bundle::IdentityBundle::from_canonical_cbor(bundle_plaintext.expose())?;
+
+    Ok(UnlockedIdentity { identity_block_key, identity })
+}
+
+// ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
 
@@ -240,6 +309,34 @@ mod create_tests {
     // The explicit `use crate::crypto::kdf::Argon2idParams` import was therefore
     // redundant and has been removed.
     use rand_chacha::{rand_core::SeedableRng, ChaCha20Rng};
+
+    #[test]
+    fn create_then_open_with_password_roundtrips() {
+        let mut rng = ChaCha20Rng::from_seed([7u8; 32]);
+        let password = SecretBytes::new(b"hunter2".to_vec());
+        let params = Argon2idParams::new(8, 1, 1);
+        let v = create_vault(&password, "Alice", 0, params, &mut rng).unwrap();
+
+        let opened = open_with_password(&v.vault_toml_bytes, &v.identity_bundle_bytes, &password)
+            .expect("open");
+        assert_eq!(opened.identity_block_key.expose(), v.identity_block_key.expose());
+        assert_eq!(opened.identity.user_uuid, v.identity.user_uuid);
+        assert_eq!(opened.identity.display_name, v.identity.display_name);
+        assert_eq!(opened.identity.x25519_sk.expose(), v.identity.x25519_sk.expose());
+    }
+
+    #[test]
+    fn open_with_wrong_password_returns_wrong_password_or_corrupt() {
+        let mut rng = ChaCha20Rng::from_seed([8u8; 32]);
+        let password = SecretBytes::new(b"hunter2".to_vec());
+        let params = Argon2idParams::new(8, 1, 1);
+        let v = create_vault(&password, "Alice", 0, params, &mut rng).unwrap();
+
+        let bad = SecretBytes::new(b"hunter3".to_vec());
+        let err = open_with_password(&v.vault_toml_bytes, &v.identity_bundle_bytes, &bad)
+            .unwrap_err();
+        assert!(matches!(err, UnlockError::WrongPasswordOrCorrupt));
+    }
 
     #[test]
     fn create_vault_produces_well_formed_artifacts() {

--- a/core/src/unlock/mod.rs
+++ b/core/src/unlock/mod.rs
@@ -3,4 +3,5 @@
 //! and `docs/vault-format.md` §2 (vault.toml), §3 (identity.bundle.enc).
 
 pub mod bundle;
+pub mod bundle_file;
 pub mod mnemonic;

--- a/core/src/unlock/mod.rs
+++ b/core/src/unlock/mod.rs
@@ -42,6 +42,13 @@ pub enum UnlockError {
     KdfFailure(#[from] KdfError),
     #[error("AEAD primitive failure")]
     AeadFailure,
+
+    /// `kdf_params.memory_kib` is below the §1.2 v1 floor (currently 64 MiB).
+    /// Returned by [`create_vault`] to prevent silent production of weak
+    /// vaults. Tests that need fast Argon2id can call
+    /// [`create_vault_unchecked`] explicitly.
+    #[error("Argon2id memory_kib ({memory_kib}) is below v1 floor ({min_memory_kib})")]
+    WeakKdfParams { memory_kib: u32, min_memory_kib: u32 },
 }
 
 impl From<AeadError> for UnlockError {
@@ -100,7 +107,47 @@ impl fmt::Debug for UnlockedIdentity {
 // create_vault orchestrator (§3 Master KEK, §4 Recovery KEK, §5 bundle wrap)
 // ---------------------------------------------------------------------------
 
+/// Create a fresh v1 vault with the §1.2-compliant Argon2id floor enforced.
+///
+/// Rejects `kdf_params` whose `memory_kib` is below
+/// [`Argon2idParams::V1_MIN_MEMORY_KIB`] with [`UnlockError::WeakKdfParams`].
+/// Tests that need faster KDF can call [`create_vault_unchecked`] directly,
+/// at the cost of producing a vault that is NOT v1-conformance-compliant.
+///
+/// All other behaviour is identical to [`create_vault_unchecked`].
 pub fn create_vault(
+    password: &SecretBytes,
+    display_name: &str,
+    created_at_ms: u64,
+    kdf_params: Argon2idParams,
+    rng: &mut (impl RngCore + CryptoRng),
+) -> Result<CreatedVault, UnlockError> {
+    if kdf_params.memory_kib < Argon2idParams::V1_MIN_MEMORY_KIB {
+        return Err(UnlockError::WeakKdfParams {
+            memory_kib: kdf_params.memory_kib,
+            min_memory_kib: Argon2idParams::V1_MIN_MEMORY_KIB,
+        });
+    }
+    create_vault_unchecked(password, display_name, created_at_ms, kdf_params, rng)
+}
+
+/// Create a vault WITHOUT validating that `kdf_params` meets the §1.2 v1
+/// floor. Production code must use [`create_vault`] instead.
+///
+/// # When to use
+///
+/// Tests that exercise the full create→open round-trip and are dominated
+/// by Argon2id runtime. v1 floor (64 MiB / 3 iter / 1 par) at 256 proptest
+/// cases would cost minutes; the unchecked path with `Argon2idParams::new(8, 1, 1)`
+/// keeps a property under one second.
+///
+/// # Compatibility caveat
+///
+/// A vault produced with sub-floor params is byte-format-compatible with v1
+/// (same wire layout) but does NOT satisfy the §1.2 KDF strength contract.
+/// It will fail any `golden_vault_001/` cross-language conformance check
+/// that re-derives the Master KEK with the v1 floor.
+pub fn create_vault_unchecked(
     password: &SecretBytes,
     display_name: &str,
     created_at_ms: u64,
@@ -393,7 +440,7 @@ mod create_tests {
         let mut rng = ChaCha20Rng::from_seed([7u8; 32]);
         let password = SecretBytes::new(b"hunter2".to_vec());
         let params = Argon2idParams::new(8, 1, 1);
-        let v = create_vault(&password, "Alice", 0, params, &mut rng).unwrap();
+        let v = create_vault_unchecked(&password, "Alice", 0, params, &mut rng).unwrap();
 
         let opened = open_with_password(&v.vault_toml_bytes, &v.identity_bundle_bytes, &password)
             .expect("open");
@@ -408,7 +455,7 @@ mod create_tests {
         let mut rng = ChaCha20Rng::from_seed([8u8; 32]);
         let password = SecretBytes::new(b"hunter2".to_vec());
         let params = Argon2idParams::new(8, 1, 1);
-        let v = create_vault(&password, "Alice", 0, params, &mut rng).unwrap();
+        let v = create_vault_unchecked(&password, "Alice", 0, params, &mut rng).unwrap();
 
         let bad = SecretBytes::new(b"hunter3".to_vec());
         let err = open_with_password(&v.vault_toml_bytes, &v.identity_bundle_bytes, &bad)
@@ -417,12 +464,28 @@ mod create_tests {
     }
 
     #[test]
+    fn create_vault_rejects_sub_floor_argon2_params() {
+        // The safe create_vault entry point must refuse params below the
+        // §1.2 v1 floor; only create_vault_unchecked permits sub-floor use.
+        let mut rng = ChaCha20Rng::from_seed([1u8; 32]);
+        let password = SecretBytes::new(b"hunter2".to_vec());
+        let weak = Argon2idParams::new(8, 1, 1);
+        let err = create_vault(&password, "Alice", 0, weak, &mut rng).unwrap_err();
+        assert!(matches!(
+            err,
+            UnlockError::WeakKdfParams { memory_kib: 8, min_memory_kib }
+                if min_memory_kib == Argon2idParams::V1_MIN_MEMORY_KIB
+        ));
+    }
+
+    #[test]
     fn create_vault_produces_well_formed_artifacts() {
         let mut rng = ChaCha20Rng::from_seed([42u8; 32]);
         let password = SecretBytes::new(b"correct horse battery staple".to_vec());
-        // Use minimal Argon2id params for test speed (memory floor relaxed via ::new).
+        // Use minimal Argon2id params for test speed; create_vault_unchecked
+        // bypasses the v1 floor enforced by create_vault.
         let params = Argon2idParams::new(8, 1, 1);
-        let v = create_vault(&password, "Alice", 1_714_060_800_000, params, &mut rng)
+        let v = create_vault_unchecked(&password, "Alice", 1_714_060_800_000, params, &mut rng)
             .expect("create_vault");
         assert!(!v.vault_toml_bytes.is_empty());
         assert!(!v.identity_bundle_bytes.is_empty());
@@ -446,7 +509,7 @@ mod create_tests {
         let mut rng = ChaCha20Rng::from_seed([9u8; 32]);
         let password = SecretBytes::new(b"hunter2".to_vec());
         let params = Argon2idParams::new(8, 1, 1);
-        let v = create_vault(&password, "Alice", 0, params, &mut rng).unwrap();
+        let v = create_vault_unchecked(&password, "Alice", 0, params, &mut rng).unwrap();
 
         let words = v.recovery_mnemonic.phrase().to_string();
         let opened = open_with_recovery(&v.vault_toml_bytes, &v.identity_bundle_bytes, &words)
@@ -462,7 +525,7 @@ mod create_tests {
         let mut rng = ChaCha20Rng::from_seed([10u8; 32]);
         let password = SecretBytes::new(b"hunter2".to_vec());
         let params = Argon2idParams::new(8, 1, 1);
-        let v = create_vault(&password, "Alice", 0, params, &mut rng).unwrap();
+        let v = create_vault_unchecked(&password, "Alice", 0, params, &mut rng).unwrap();
 
         // A different fresh mnemonic — valid checksum, just not this vault's.
         let mut other_rng = ChaCha20Rng::from_seed([99u8; 32]);
@@ -475,7 +538,7 @@ mod create_tests {
     #[test]
     fn open_with_invalid_mnemonic_returns_invalid_mnemonic() {
         let mut rng = ChaCha20Rng::from_seed([11u8; 32]);
-        let v = create_vault(
+        let v = create_vault_unchecked(
             &SecretBytes::new(b"x".to_vec()), "Alice", 0,
             Argon2idParams::new(8, 1, 1), &mut rng,
         ).unwrap();
@@ -488,7 +551,7 @@ mod create_tests {
     fn both_unlock_paths_yield_same_identity_block_key() {
         let mut rng = ChaCha20Rng::from_seed([12u8; 32]);
         let password = SecretBytes::new(b"hunter2".to_vec());
-        let v = create_vault(&password, "Alice", 0, Argon2idParams::new(8, 1, 1), &mut rng).unwrap();
+        let v = create_vault_unchecked(&password, "Alice", 0, Argon2idParams::new(8, 1, 1), &mut rng).unwrap();
 
         let by_pw = open_with_password(&v.vault_toml_bytes, &v.identity_bundle_bytes, &password).unwrap();
         let by_rec = open_with_recovery(&v.vault_toml_bytes, &v.identity_bundle_bytes, v.recovery_mnemonic.phrase()).unwrap();

--- a/core/src/unlock/mod.rs
+++ b/core/src/unlock/mod.rs
@@ -2,4 +2,5 @@
 //! See `docs/crypto-design.md` §3 (Master KEK), §4 (Recovery KEK), §5 (Identity Bundle wrap)
 //! and `docs/vault-format.md` §2 (vault.toml), §3 (identity.bundle.enc).
 
+pub mod bundle;
 pub mod mnemonic;

--- a/core/src/unlock/mod.rs
+++ b/core/src/unlock/mod.rs
@@ -207,7 +207,7 @@ pub fn create_vault(
             salt: argon2_salt,
         },
     };
-    let vault_toml_bytes = vault_toml::encode(&vt).into_bytes();
+    let vault_toml_bytes = vault_toml::encode(&vt)?.into_bytes();
 
     // master_kek and recovery_kek go out of scope here → Sensitive Drop zeroizes.
 

--- a/core/src/unlock/mod.rs
+++ b/core/src/unlock/mod.rs
@@ -16,6 +16,7 @@ use crate::crypto::kdf::{
     TAG_ID_WRAP_PW, TAG_ID_WRAP_REC,
 };
 use crate::crypto::secret::{SecretBytes, Sensitive};
+use crate::version::{FORMAT_VERSION, SUITE_ID};
 
 #[derive(Debug, thiserror::Error)]
 pub enum UnlockError {
@@ -194,8 +195,8 @@ pub fn create_vault(
     // Step 11: emit vault.toml (§2) — KDF params mirror kdf_params so the
     // vault is portable across devices that open with derive_master_kek (§3).
     let vt = vault_toml::VaultToml {
-        format_version: 1,
-        suite_id: 1,
+        format_version: FORMAT_VERSION,
+        suite_id: SUITE_ID,
         vault_uuid,
         created_at_ms,
         kdf: vault_toml::KdfSection {

--- a/core/src/unlock/mod.rs
+++ b/core/src/unlock/mod.rs
@@ -298,6 +298,63 @@ pub fn open_with_password(
 }
 
 // ---------------------------------------------------------------------------
+// open_with_recovery (§4 Recovery KEK unlock path)
+// ---------------------------------------------------------------------------
+
+pub fn open_with_recovery(
+    vault_toml_bytes: &[u8],
+    identity_bundle_bytes: &[u8],
+    mnemonic_words: &str,
+) -> Result<UnlockedIdentity, UnlockError> {
+    // Steps 1-2: vault.toml + bundle file (mirror open_with_password)
+    let vt_str = std::str::from_utf8(vault_toml_bytes)
+        .map_err(|_| UnlockError::MalformedVaultToml(vault_toml::VaultTomlError::MalformedToml(
+            "non-UTF-8 input".to_string(),
+        )))?;
+    let vt = vault_toml::decode(vt_str)?;
+    let bf = bundle_file::decode(identity_bundle_bytes)?;
+    if bf.vault_uuid != vt.vault_uuid {
+        return Err(UnlockError::VaultMismatch);
+    }
+
+    // Step 3: parse mnemonic. Bad word-count / unknown word / bad checksum
+    // surfaces as InvalidMnemonic via the From impl — distinct from
+    // WrongMnemonicOrCorrupt because the failure mode is "this isn't a
+    // valid BIP-39 phrase at all" rather than "valid phrase, wrong vault."
+    let parsed = mnemonic::parse(mnemonic_words)?;
+
+    // Step 4: derive Recovery KEK from the parsed entropy.
+    let recovery_kek = derive_recovery_kek(parsed.entropy());
+
+    // Step 5: AEAD-decrypt wrap_rec → IBK bytes.
+    let wrap_rec_aad = compose_aad(TAG_ID_WRAP_REC, &vt.vault_uuid);
+    let ibk_bytes = decrypt(
+        &recovery_kek,
+        &bf.wrap_rec_nonce,
+        &wrap_rec_aad,
+        &bf.wrap_rec_ct_with_tag,
+    )
+    .map_err(|_| UnlockError::WrongMnemonicOrCorrupt)?;
+
+    let ibk_arr: [u8; 32] = ibk_bytes.expose().try_into()
+        .map_err(|_| UnlockError::CorruptVault)?;
+    let identity_block_key = Sensitive::new(ibk_arr);
+
+    // Step 6: AEAD-decrypt bundle.
+    let bundle_aad = compose_aad(TAG_ID_BUNDLE, &vt.vault_uuid);
+    let bundle_plaintext = decrypt(
+        &identity_block_key,
+        &bf.bundle_nonce,
+        &bundle_aad,
+        &bf.bundle_ct_with_tag,
+    )
+    .map_err(|_| UnlockError::CorruptVault)?;
+
+    let identity = bundle::IdentityBundle::from_canonical_cbor(bundle_plaintext.expose())?;
+    Ok(UnlockedIdentity { identity_block_key, identity })
+}
+
+// ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
 
@@ -361,5 +418,57 @@ mod create_tests {
         assert_eq!(parsed_vt.kdf.parallelism, 1);
         assert_eq!(parsed_vt.format_version, 1);
         assert_eq!(parsed_vt.suite_id, 1);
+    }
+
+    #[test]
+    fn create_then_open_with_recovery_roundtrips() {
+        let mut rng = ChaCha20Rng::from_seed([9u8; 32]);
+        let password = SecretBytes::new(b"hunter2".to_vec());
+        let params = Argon2idParams::new(8, 1, 1);
+        let v = create_vault(&password, "Alice", 0, params, &mut rng).unwrap();
+
+        let words = v.recovery_mnemonic.phrase().to_string();
+        let opened = open_with_recovery(&v.vault_toml_bytes, &v.identity_bundle_bytes, &words)
+            .expect("open");
+        assert_eq!(opened.identity_block_key.expose(), v.identity_block_key.expose());
+        assert_eq!(opened.identity.user_uuid, v.identity.user_uuid);
+    }
+
+    #[test]
+    fn open_with_wrong_mnemonic_returns_wrong_mnemonic_or_corrupt() {
+        let mut rng = ChaCha20Rng::from_seed([10u8; 32]);
+        let password = SecretBytes::new(b"hunter2".to_vec());
+        let params = Argon2idParams::new(8, 1, 1);
+        let v = create_vault(&password, "Alice", 0, params, &mut rng).unwrap();
+
+        // A different fresh mnemonic — valid checksum, just not this vault's.
+        let mut other_rng = ChaCha20Rng::from_seed([99u8; 32]);
+        let other = mnemonic::generate(&mut other_rng);
+        let err = open_with_recovery(&v.vault_toml_bytes, &v.identity_bundle_bytes, other.phrase())
+            .unwrap_err();
+        assert!(matches!(err, UnlockError::WrongMnemonicOrCorrupt));
+    }
+
+    #[test]
+    fn open_with_invalid_mnemonic_returns_invalid_mnemonic() {
+        let mut rng = ChaCha20Rng::from_seed([11u8; 32]);
+        let v = create_vault(
+            &SecretBytes::new(b"x".to_vec()), "Alice", 0,
+            Argon2idParams::new(8, 1, 1), &mut rng,
+        ).unwrap();
+        let err = open_with_recovery(&v.vault_toml_bytes, &v.identity_bundle_bytes, "abandon abandon")
+            .unwrap_err();
+        assert!(matches!(err, UnlockError::InvalidMnemonic(mnemonic::MnemonicError::WrongLength { .. })));
+    }
+
+    #[test]
+    fn both_unlock_paths_yield_same_identity_block_key() {
+        let mut rng = ChaCha20Rng::from_seed([12u8; 32]);
+        let password = SecretBytes::new(b"hunter2".to_vec());
+        let v = create_vault(&password, "Alice", 0, Argon2idParams::new(8, 1, 1), &mut rng).unwrap();
+
+        let by_pw = open_with_password(&v.vault_toml_bytes, &v.identity_bundle_bytes, &password).unwrap();
+        let by_rec = open_with_recovery(&v.vault_toml_bytes, &v.identity_bundle_bytes, v.recovery_mnemonic.phrase()).unwrap();
+        assert_eq!(by_pw.identity_block_key.expose(), by_rec.identity_block_key.expose());
     }
 }

--- a/core/src/unlock/vault_toml.rs
+++ b/core/src/unlock/vault_toml.rs
@@ -1,4 +1,14 @@
 //! `vault.toml` cleartext metadata (`docs/vault-format.md` §2).
+//!
+//! This file holds non-secret bootstrap metadata for a Secretary vault: the
+//! format version, suite identifier, vault UUID, creation timestamp, and the
+//! Argon2id KDF parameters (including the salt). It is parsed at vault open
+//! time to determine how to derive the Master KEK from the user's password.
+//!
+//! `decode` enforces v1's pinned values: `format_version = 1`, `suite_id = 1`,
+//! `kdf.algorithm = "argon2id"`, `kdf.version = "1.3"`. Forward compatibility
+//! per §2: unknown top-level keys are ignored, but unknown keys inside `[kdf]`
+//! are an error (a misinterpreted KDF parameter would derive the wrong key).
 
 use base64::{engine::general_purpose::STANDARD, Engine as _};
 use serde::Serialize;
@@ -26,6 +36,12 @@ pub struct KdfSection {
 pub enum VaultTomlError {
     #[error("malformed TOML: {0}")]
     MalformedToml(String),
+    /// A required field was absent from the parsed TOML.
+    #[error("missing field: {0}")]
+    MissingField(&'static str),
+    /// A numeric field's value was outside the allowed range for its target type.
+    #[error("field {field} value out of range")]
+    FieldOutOfRange { field: &'static str },
     #[error("unknown key in [kdf] section: {0}")]
     UnknownKdfKey(String),
     #[error("unsupported format version: {0}")]
@@ -82,8 +98,33 @@ pub fn encode(v: &VaultToml) -> String {
 
 /// Format a 16-byte UUID as the RFC 4122 textual form: 8-4-4-4-12 hex groups.
 fn format_uuid_canonical(bytes: &[u8; 16]) -> String {
-    let h = bytes.iter().map(|b| format!("{:02x}", b)).collect::<String>();
-    format!("{}-{}-{}-{}-{}", &h[0..8], &h[8..12], &h[12..16], &h[16..20], &h[20..32])
+    use std::fmt::Write as _;
+    let mut s = String::with_capacity(36);
+    for (i, b) in bytes.iter().enumerate() {
+        if matches!(i, 4 | 6 | 8 | 10) {
+            s.push('-');
+        }
+        write!(s, "{:02x}", b).expect("writing to String cannot fail");
+    }
+    s
+}
+
+/// Look up an integer field from a TOML table, returning `MissingField` if
+/// absent or not an integer.
+fn take_i64(table: &toml::value::Table, key: &'static str) -> Result<i64, VaultTomlError> {
+    table
+        .get(key)
+        .and_then(toml::Value::as_integer)
+        .ok_or(VaultTomlError::MissingField(key))
+}
+
+/// Look up a string field from a TOML table, returning `MissingField` if
+/// absent or not a string.
+fn take_str<'a>(table: &'a toml::value::Table, key: &'static str) -> Result<&'a str, VaultTomlError> {
+    table
+        .get(key)
+        .and_then(toml::Value::as_str)
+        .ok_or(VaultTomlError::MissingField(key))
 }
 
 pub fn decode(s: &str) -> Result<VaultToml, VaultTomlError> {
@@ -98,7 +139,7 @@ pub fn decode(s: &str) -> Result<VaultToml, VaultTomlError> {
     let format_version = table
         .get("format_version")
         .and_then(Value::as_integer)
-        .ok_or_else(|| VaultTomlError::MalformedToml("format_version missing".into()))?;
+        .ok_or(VaultTomlError::MissingField("format_version"))?;
     // Saturate to u16::MAX so the error variant carries a meaningful value even
     // when the raw integer is out of range (e.g. 99999 → 65535 clearly signals
     // "out of range" to a reader). Same pattern for suite_id below.
@@ -110,23 +151,18 @@ pub fn decode(s: &str) -> Result<VaultToml, VaultTomlError> {
     let suite_id = table
         .get("suite_id")
         .and_then(Value::as_integer)
-        .ok_or_else(|| VaultTomlError::MalformedToml("suite_id missing".into()))?;
+        .ok_or(VaultTomlError::MissingField("suite_id"))?;
     let suite_id = u16::try_from(suite_id).unwrap_or(u16::MAX);
     if suite_id != 1 {
         return Err(VaultTomlError::UnsupportedSuiteId(suite_id));
     }
 
-    let vault_uuid_str = table
-        .get("vault_uuid")
-        .and_then(Value::as_str)
-        .ok_or_else(|| VaultTomlError::MalformedToml("vault_uuid missing".into()))?;
+    let vault_uuid_str = take_str(table, "vault_uuid")?;
     let vault_uuid = parse_uuid_canonical(vault_uuid_str).ok_or(VaultTomlError::InvalidUuid)?;
 
-    let created_at_ms = table
-        .get("created_at_ms")
-        .and_then(Value::as_integer)
-        .ok_or_else(|| VaultTomlError::MalformedToml("created_at_ms missing".into()))?
-        as u64;
+    let created_at_ms = take_i64(table, "created_at_ms")?;
+    let created_at_ms = u64::try_from(created_at_ms)
+        .map_err(|_| VaultTomlError::FieldOutOfRange { field: "created_at_ms" })?;
 
     // Strict [kdf] decode: every key must be known. Unknown keys are a hard
     // error here because misinterpreting KDF parameters would derive a wrong key
@@ -134,7 +170,7 @@ pub fn decode(s: &str) -> Result<VaultToml, VaultTomlError> {
     let kdf_table = table
         .get("kdf")
         .and_then(Value::as_table)
-        .ok_or_else(|| VaultTomlError::MalformedToml("[kdf] missing".into()))?;
+        .ok_or(VaultTomlError::MissingField("kdf"))?;
 
     const KNOWN_KDF_KEYS: &[&str] = &[
         "algorithm", "version", "memory_kib", "iterations", "parallelism", "salt_b64",
@@ -145,44 +181,29 @@ pub fn decode(s: &str) -> Result<VaultToml, VaultTomlError> {
         }
     }
 
-    let algorithm = kdf_table
-        .get("algorithm")
-        .and_then(Value::as_str)
-        .ok_or_else(|| VaultTomlError::MalformedToml("kdf.algorithm missing".into()))?
-        .to_string();
+    let algorithm = take_str(kdf_table, "algorithm")?.to_string();
     if algorithm != "argon2id" {
         return Err(VaultTomlError::UnsupportedKdfAlgorithm(algorithm));
     }
 
-    let version = kdf_table
-        .get("version")
-        .and_then(Value::as_str)
-        .ok_or_else(|| VaultTomlError::MalformedToml("kdf.version missing".into()))?
-        .to_string();
+    let version = take_str(kdf_table, "version")?.to_string();
     if version != "1.3" {
         return Err(VaultTomlError::UnsupportedKdfVersion(version));
     }
 
-    let memory_kib = kdf_table
-        .get("memory_kib")
-        .and_then(Value::as_integer)
-        .ok_or_else(|| VaultTomlError::MalformedToml("kdf.memory_kib missing".into()))?
-        as u32;
-    let iterations = kdf_table
-        .get("iterations")
-        .and_then(Value::as_integer)
-        .ok_or_else(|| VaultTomlError::MalformedToml("kdf.iterations missing".into()))?
-        as u32;
-    let parallelism = kdf_table
-        .get("parallelism")
-        .and_then(Value::as_integer)
-        .ok_or_else(|| VaultTomlError::MalformedToml("kdf.parallelism missing".into()))?
-        as u32;
+    let memory_kib = take_i64(kdf_table, "memory_kib")?;
+    let memory_kib = u32::try_from(memory_kib)
+        .map_err(|_| VaultTomlError::FieldOutOfRange { field: "kdf.memory_kib" })?;
 
-    let salt_b64 = kdf_table
-        .get("salt_b64")
-        .and_then(Value::as_str)
-        .ok_or_else(|| VaultTomlError::MalformedToml("kdf.salt_b64 missing".into()))?;
+    let iterations = take_i64(kdf_table, "iterations")?;
+    let iterations = u32::try_from(iterations)
+        .map_err(|_| VaultTomlError::FieldOutOfRange { field: "kdf.iterations" })?;
+
+    let parallelism = take_i64(kdf_table, "parallelism")?;
+    let parallelism = u32::try_from(parallelism)
+        .map_err(|_| VaultTomlError::FieldOutOfRange { field: "kdf.parallelism" })?;
+
+    let salt_b64 = take_str(kdf_table, "salt_b64")?;
     let salt_vec = STANDARD
         .decode(salt_b64)
         .map_err(|e| VaultTomlError::MalformedToml(format!("salt_b64: {e}")))?;
@@ -233,13 +254,16 @@ fn parse_uuid_canonical(s: &str) -> Option<[u8; 16]> {
             return None;
         }
     }
+    // Walk the five hex groups directly; no intermediate Vec needed.
+    // Pre-validation above guarantees lengths and character validity.
+    let groups: [&[u8]; 5] = [&b[0..8], &b[9..13], &b[14..18], &b[19..23], &b[24..36]];
     let mut out = [0u8; 16];
-    // Walk absolute positions, skipping the four hyphen slots.
-    let hex_positions: Vec<usize> = (0..36).filter(|i| ![8, 13, 18, 23].contains(i)).collect();
-    for (byte_idx, hex_pair) in hex_positions.chunks_exact(2).enumerate() {
-        let hi = hex_nibble(b[hex_pair[0]]);
-        let lo = hex_nibble(b[hex_pair[1]]);
-        out[byte_idx] = (hi << 4) | lo;
+    let mut byte_idx = 0;
+    for group in &groups {
+        for pair in group.chunks_exact(2) {
+            out[byte_idx] = (hex_nibble(pair[0]) << 4) | hex_nibble(pair[1]);
+            byte_idx += 1;
+        }
     }
     Some(out)
 }
@@ -335,6 +359,16 @@ mod tests {
         let s = s.replace(&original_b64, &short_b64);
         let err = decode(&s).unwrap_err();
         assert!(matches!(err, VaultTomlError::InvalidSaltLength { got: 16 }));
+    }
+
+    #[test]
+    fn decode_rejects_invalid_salt_b64() {
+        let s = encode(&sample()).replace(
+            &STANDARD.encode([0xCDu8; 32]),
+            "not!valid!base64!!!",
+        );
+        let err = decode(&s).unwrap_err();
+        assert!(matches!(err, VaultTomlError::MalformedToml(ref m) if m.starts_with("salt_b64:")));
     }
 
     #[test]

--- a/core/src/unlock/vault_toml.rs
+++ b/core/src/unlock/vault_toml.rs
@@ -56,6 +56,12 @@ pub enum VaultTomlError {
     InvalidSaltLength { got: usize },
     #[error("invalid UUID")]
     InvalidUuid,
+    /// `created_at_ms` exceeds i64::MAX — TOML's signed 64-bit integer cannot
+    /// represent the value. Practically unreachable (would require a timestamp
+    /// past year 292 million) but the API accepts u64, so we surface it as a
+    /// typed error rather than a panic.
+    #[error("created_at_ms ({0}) exceeds i64::MAX")]
+    TimestampOutOfRange(u64),
 }
 
 // Wire types used for TOML serialization only.
@@ -78,7 +84,10 @@ struct KdfSectionWire {
     salt_b64: String,
 }
 
-pub fn encode(v: &VaultToml) -> String {
+pub fn encode(v: &VaultToml) -> Result<String, VaultTomlError> {
+    if v.created_at_ms > i64::MAX as u64 {
+        return Err(VaultTomlError::TimestampOutOfRange(v.created_at_ms));
+    }
     let wire = VaultTomlWire {
         format_version: v.format_version,
         suite_id: v.suite_id,
@@ -93,7 +102,7 @@ pub fn encode(v: &VaultToml) -> String {
             salt_b64: STANDARD.encode(v.kdf.salt),
         },
     };
-    toml::to_string(&wire).expect("serializing primitive types cannot fail")
+    toml::to_string(&wire).map_err(|e| VaultTomlError::MalformedToml(e.to_string()))
 }
 
 /// Format a 16-byte UUID as the RFC 4122 textual form: 8-4-4-4-12 hex groups.
@@ -298,7 +307,7 @@ mod tests {
     #[test]
     fn encode_decode_roundtrip() {
         let v = sample();
-        let s = encode(&v);
+        let s = encode(&v).expect("encode");
         let parsed = decode(&s).expect("decode");
         assert_eq!(parsed, v);
     }
@@ -308,7 +317,7 @@ mod tests {
         // Insert the unknown key before [kdf] so TOML parses it as a top-level
         // entry; appending after [kdf] would make it a kdf key (§2: unknown
         // top-level keys are ignored, unknown kdf keys are errors).
-        let s = encode(&sample()).replacen("[kdf]\n", "future_key = \"some value\"\n[kdf]\n", 1);
+        let s = encode(&sample()).expect("encode").replacen("[kdf]\n", "future_key = \"some value\"\n[kdf]\n", 1);
         let parsed = decode(&s).expect("unknown top-level key must be ignored");
         assert_eq!(parsed, sample());
     }
@@ -317,35 +326,35 @@ mod tests {
     fn decode_rejects_unknown_kdf_key() {
         // Insert rogue key directly after [kdf] header so TOML parses it into
         // the kdf table regardless of section ordering.
-        let s = encode(&sample()).replacen("[kdf]\n", "[kdf]\nrogue_param = 42\n", 1);
+        let s = encode(&sample()).expect("encode").replacen("[kdf]\n", "[kdf]\nrogue_param = 42\n", 1);
         let err = decode(&s).unwrap_err();
         assert!(matches!(err, VaultTomlError::UnknownKdfKey(ref k) if k == "rogue_param"));
     }
 
     #[test]
     fn decode_rejects_unsupported_format_version() {
-        let s = encode(&sample()).replace("format_version = 1", "format_version = 2");
+        let s = encode(&sample()).expect("encode").replace("format_version = 1", "format_version = 2");
         let err = decode(&s).unwrap_err();
         assert!(matches!(err, VaultTomlError::UnsupportedFormatVersion(2)));
     }
 
     #[test]
     fn decode_rejects_unsupported_suite_id() {
-        let s = encode(&sample()).replace("suite_id = 1", "suite_id = 2");
+        let s = encode(&sample()).expect("encode").replace("suite_id = 1", "suite_id = 2");
         let err = decode(&s).unwrap_err();
         assert!(matches!(err, VaultTomlError::UnsupportedSuiteId(2)));
     }
 
     #[test]
     fn decode_rejects_wrong_kdf_algorithm() {
-        let s = encode(&sample()).replace("algorithm = \"argon2id\"", "algorithm = \"scrypt\"");
+        let s = encode(&sample()).expect("encode").replace("algorithm = \"argon2id\"", "algorithm = \"scrypt\"");
         let err = decode(&s).unwrap_err();
         assert!(matches!(err, VaultTomlError::UnsupportedKdfAlgorithm(ref s) if s == "scrypt"));
     }
 
     #[test]
     fn decode_rejects_wrong_kdf_version() {
-        let s = encode(&sample()).replace("version = \"1.3\"", "version = \"1.0\"");
+        let s = encode(&sample()).expect("encode").replace("version = \"1.3\"", "version = \"1.0\"");
         let err = decode(&s).unwrap_err();
         assert!(matches!(err, VaultTomlError::UnsupportedKdfVersion(ref s) if s == "1.0"));
     }
@@ -353,7 +362,7 @@ mod tests {
     #[test]
     fn decode_rejects_short_salt() {
         let v = sample();
-        let s = encode(&v);
+        let s = encode(&v).expect("encode");
         let short_b64 = STANDARD.encode([0u8; 16]);
         let original_b64 = STANDARD.encode([0xCDu8; 32]);
         let s = s.replace(&original_b64, &short_b64);
@@ -363,7 +372,7 @@ mod tests {
 
     #[test]
     fn decode_rejects_invalid_salt_b64() {
-        let s = encode(&sample()).replace(
+        let s = encode(&sample()).expect("encode").replace(
             &STANDARD.encode([0xCDu8; 32]),
             "not!valid!base64!!!",
         );
@@ -373,7 +382,7 @@ mod tests {
 
     #[test]
     fn decode_rejects_uppercase_uuid() {
-        let s = encode(&sample()).replace(
+        let s = encode(&sample()).expect("encode").replace(
             "abababab-abab-abab-abab-abababababab",
             "ABABABAB-ABAB-ABAB-ABAB-ABABABABABAB",
         );
@@ -383,7 +392,7 @@ mod tests {
 
     #[test]
     fn decode_rejects_uuid_without_hyphens() {
-        let s = encode(&sample()).replace(
+        let s = encode(&sample()).expect("encode").replace(
             "abababab-abab-abab-abab-abababababab",
             "abababababababababababababababababab",
         );
@@ -393,11 +402,19 @@ mod tests {
 
     #[test]
     fn decode_rejects_uuid_with_wrong_grouping() {
-        let s = encode(&sample()).replace(
+        let s = encode(&sample()).expect("encode").replace(
             "abababab-abab-abab-abab-abababababab",
             "abab-abababab-abab-abab-abababababab",
         );
         let err = decode(&s).unwrap_err();
         assert!(matches!(err, VaultTomlError::InvalidUuid));
+    }
+
+    #[test]
+    fn encode_rejects_timestamp_out_of_range() {
+        let mut v = sample();
+        v.created_at_ms = (i64::MAX as u64) + 1;
+        let err = encode(&v).unwrap_err();
+        assert!(matches!(err, VaultTomlError::TimestampOutOfRange(t) if t == (i64::MAX as u64) + 1));
     }
 }

--- a/core/src/unlock/vault_toml.rs
+++ b/core/src/unlock/vault_toml.rs
@@ -208,19 +208,46 @@ pub fn decode(s: &str) -> Result<VaultToml, VaultTomlError> {
 }
 
 /// Parse the RFC 4122 textual UUID form ("xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx").
-/// Returns `None` on any deviation from the expected 32 hex digits plus hyphens.
+///
+/// §2's "canonical 8-4-4-4-12 hyphenated lowercase hex" form is enforced
+/// strictly: exactly 36 bytes, hyphens at indices 8/13/18/23, every other
+/// byte must be a lowercase hex digit (`0-9` or `a-f`). Uppercase and
+/// non-hyphenated forms are rejected to keep the canonical form symmetric
+/// with the encoder, which emits lowercase via `{:02x}`.
 fn parse_uuid_canonical(s: &str) -> Option<[u8; 16]> {
-    // Strip hyphens and require exactly 32 hex chars.
-    let stripped: String = s.chars().filter(|c| *c != '-').collect();
-    if stripped.len() != 32 {
+    let b = s.as_bytes();
+    if b.len() != 36 {
         return None;
     }
+    for i in [8usize, 13, 18, 23] {
+        if b[i] != b'-' {
+            return None;
+        }
+    }
+    // Every non-hyphen byte must be lowercase hex (0-9, a-f).
+    for (i, &c) in b.iter().enumerate() {
+        if i == 8 || i == 13 || i == 18 || i == 23 {
+            continue;
+        }
+        if !c.is_ascii_digit() && !(b'a'..=b'f').contains(&c) {
+            return None;
+        }
+    }
     let mut out = [0u8; 16];
-    for i in 0..16 {
-        let byte = u8::from_str_radix(&stripped[i * 2..i * 2 + 2], 16).ok()?;
-        out[i] = byte;
+    // Walk absolute positions, skipping the four hyphen slots.
+    let hex_positions: Vec<usize> = (0..36).filter(|i| ![8, 13, 18, 23].contains(i)).collect();
+    for (byte_idx, hex_pair) in hex_positions.chunks_exact(2).enumerate() {
+        let hi = hex_nibble(b[hex_pair[0]]);
+        let lo = hex_nibble(b[hex_pair[1]]);
+        out[byte_idx] = (hi << 4) | lo;
     }
     Some(out)
+}
+
+/// Convert a pre-validated lowercase hex byte to its nibble value.
+#[inline]
+fn hex_nibble(c: u8) -> u8 {
+    if c.is_ascii_digit() { c - b'0' } else { c - b'a' + 10 }
 }
 
 #[cfg(test)]
@@ -308,5 +335,35 @@ mod tests {
         let s = s.replace(&original_b64, &short_b64);
         let err = decode(&s).unwrap_err();
         assert!(matches!(err, VaultTomlError::InvalidSaltLength { got: 16 }));
+    }
+
+    #[test]
+    fn decode_rejects_uppercase_uuid() {
+        let s = encode(&sample()).replace(
+            "abababab-abab-abab-abab-abababababab",
+            "ABABABAB-ABAB-ABAB-ABAB-ABABABABABAB",
+        );
+        let err = decode(&s).unwrap_err();
+        assert!(matches!(err, VaultTomlError::InvalidUuid));
+    }
+
+    #[test]
+    fn decode_rejects_uuid_without_hyphens() {
+        let s = encode(&sample()).replace(
+            "abababab-abab-abab-abab-abababababab",
+            "abababababababababababababababababab",
+        );
+        let err = decode(&s).unwrap_err();
+        assert!(matches!(err, VaultTomlError::InvalidUuid));
+    }
+
+    #[test]
+    fn decode_rejects_uuid_with_wrong_grouping() {
+        let s = encode(&sample()).replace(
+            "abababab-abab-abab-abab-abababababab",
+            "abab-abababab-abab-abab-abababababab",
+        );
+        let err = decode(&s).unwrap_err();
+        assert!(matches!(err, VaultTomlError::InvalidUuid));
     }
 }

--- a/core/src/unlock/vault_toml.rs
+++ b/core/src/unlock/vault_toml.rs
@@ -1,0 +1,254 @@
+//! `vault.toml` cleartext metadata (`docs/vault-format.md` §2).
+
+use base64::{engine::general_purpose::STANDARD, Engine as _};
+use serde::Serialize;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct VaultToml {
+    pub format_version: u16,
+    pub suite_id: u16,
+    pub vault_uuid: [u8; 16],
+    pub created_at_ms: u64,
+    pub kdf: KdfSection,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct KdfSection {
+    pub algorithm: String,        // must be "argon2id"
+    pub version: String,          // must be "1.3"
+    pub memory_kib: u32,
+    pub iterations: u32,
+    pub parallelism: u32,
+    pub salt: [u8; 32],
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum VaultTomlError {
+    #[error("malformed TOML: {0}")]
+    MalformedToml(String),
+    #[error("unknown key in [kdf] section: {0}")]
+    UnknownKdfKey(String),
+    #[error("unsupported format version: {0}")]
+    UnsupportedFormatVersion(u16),
+    #[error("unsupported suite id: {0}")]
+    UnsupportedSuiteId(u16),
+    #[error("unsupported KDF algorithm: {0}")]
+    UnsupportedKdfAlgorithm(String),
+    #[error("unsupported KDF version: {0}")]
+    UnsupportedKdfVersion(String),
+    #[error("invalid salt length: expected 32 bytes, got {got}")]
+    InvalidSaltLength { got: usize },
+    #[error("invalid UUID")]
+    InvalidUuid,
+}
+
+// Wire types used for TOML serialization only.
+#[derive(Serialize)]
+struct VaultTomlWire {
+    format_version: u16,
+    suite_id: u16,
+    vault_uuid: String,
+    created_at_ms: u64,
+    kdf: KdfSectionWire,
+}
+
+#[derive(Serialize)]
+struct KdfSectionWire {
+    algorithm: String,
+    version: String,
+    memory_kib: u32,
+    iterations: u32,
+    parallelism: u32,
+    salt_b64: String,
+}
+
+pub fn encode(v: &VaultToml) -> String {
+    let wire = VaultTomlWire {
+        format_version: v.format_version,
+        suite_id: v.suite_id,
+        vault_uuid: format_uuid_canonical(&v.vault_uuid),
+        created_at_ms: v.created_at_ms,
+        kdf: KdfSectionWire {
+            algorithm: v.kdf.algorithm.clone(),
+            version: v.kdf.version.clone(),
+            memory_kib: v.kdf.memory_kib,
+            iterations: v.kdf.iterations,
+            parallelism: v.kdf.parallelism,
+            salt_b64: STANDARD.encode(v.kdf.salt),
+        },
+    };
+    toml::to_string(&wire).expect("serializing primitive types cannot fail")
+}
+
+/// Format a 16-byte UUID as the RFC 4122 textual form: 8-4-4-4-12 hex groups.
+fn format_uuid_canonical(bytes: &[u8; 16]) -> String {
+    let h = bytes.iter().map(|b| format!("{:02x}", b)).collect::<String>();
+    format!("{}-{}-{}-{}-{}", &h[0..8], &h[8..12], &h[12..16], &h[16..20], &h[20..32])
+}
+
+pub fn decode(s: &str) -> Result<VaultToml, VaultTomlError> {
+    use toml::Value;
+
+    let value: Value = toml::from_str(s)
+        .map_err(|e| VaultTomlError::MalformedToml(e.to_string()))?;
+    let table = value
+        .as_table()
+        .ok_or_else(|| VaultTomlError::MalformedToml("expected table".into()))?;
+
+    let format_version = table
+        .get("format_version")
+        .and_then(Value::as_integer)
+        .ok_or_else(|| VaultTomlError::MalformedToml("format_version missing".into()))?;
+    // Saturate to u16::MAX so the error variant carries a meaningful value even
+    // when the raw integer is out of range (e.g. 99999 → 65535 clearly signals
+    // "out of range" to a reader). Same pattern for suite_id below.
+    let format_version = u16::try_from(format_version).unwrap_or(u16::MAX);
+    if format_version != 1 {
+        return Err(VaultTomlError::UnsupportedFormatVersion(format_version));
+    }
+
+    let suite_id = table
+        .get("suite_id")
+        .and_then(Value::as_integer)
+        .ok_or_else(|| VaultTomlError::MalformedToml("suite_id missing".into()))?;
+    let suite_id = u16::try_from(suite_id).unwrap_or(u16::MAX);
+    if suite_id != 1 {
+        return Err(VaultTomlError::UnsupportedSuiteId(suite_id));
+    }
+
+    let vault_uuid_str = table
+        .get("vault_uuid")
+        .and_then(Value::as_str)
+        .ok_or_else(|| VaultTomlError::MalformedToml("vault_uuid missing".into()))?;
+    let vault_uuid = parse_uuid_canonical(vault_uuid_str).ok_or(VaultTomlError::InvalidUuid)?;
+
+    let created_at_ms = table
+        .get("created_at_ms")
+        .and_then(Value::as_integer)
+        .ok_or_else(|| VaultTomlError::MalformedToml("created_at_ms missing".into()))?
+        as u64;
+
+    // Strict [kdf] decode: every key must be known. Unknown keys are a hard
+    // error here because misinterpreting KDF parameters would derive a wrong key
+    // (§2 line 73).
+    let kdf_table = table
+        .get("kdf")
+        .and_then(Value::as_table)
+        .ok_or_else(|| VaultTomlError::MalformedToml("[kdf] missing".into()))?;
+
+    const KNOWN_KDF_KEYS: &[&str] = &[
+        "algorithm", "version", "memory_kib", "iterations", "parallelism", "salt_b64",
+    ];
+    for k in kdf_table.keys() {
+        if !KNOWN_KDF_KEYS.contains(&k.as_str()) {
+            return Err(VaultTomlError::UnknownKdfKey(k.clone()));
+        }
+    }
+
+    let algorithm = kdf_table
+        .get("algorithm")
+        .and_then(Value::as_str)
+        .ok_or_else(|| VaultTomlError::MalformedToml("kdf.algorithm missing".into()))?
+        .to_string();
+    if algorithm != "argon2id" {
+        return Err(VaultTomlError::UnsupportedKdfAlgorithm(algorithm));
+    }
+
+    let version = kdf_table
+        .get("version")
+        .and_then(Value::as_str)
+        .ok_or_else(|| VaultTomlError::MalformedToml("kdf.version missing".into()))?
+        .to_string();
+    if version != "1.3" {
+        return Err(VaultTomlError::UnsupportedKdfVersion(version));
+    }
+
+    let memory_kib = kdf_table
+        .get("memory_kib")
+        .and_then(Value::as_integer)
+        .ok_or_else(|| VaultTomlError::MalformedToml("kdf.memory_kib missing".into()))?
+        as u32;
+    let iterations = kdf_table
+        .get("iterations")
+        .and_then(Value::as_integer)
+        .ok_or_else(|| VaultTomlError::MalformedToml("kdf.iterations missing".into()))?
+        as u32;
+    let parallelism = kdf_table
+        .get("parallelism")
+        .and_then(Value::as_integer)
+        .ok_or_else(|| VaultTomlError::MalformedToml("kdf.parallelism missing".into()))?
+        as u32;
+
+    let salt_b64 = kdf_table
+        .get("salt_b64")
+        .and_then(Value::as_str)
+        .ok_or_else(|| VaultTomlError::MalformedToml("kdf.salt_b64 missing".into()))?;
+    let salt_vec = STANDARD
+        .decode(salt_b64)
+        .map_err(|e| VaultTomlError::MalformedToml(format!("salt_b64: {e}")))?;
+    let salt: [u8; 32] = salt_vec
+        .as_slice()
+        .try_into()
+        .map_err(|_| VaultTomlError::InvalidSaltLength { got: salt_vec.len() })?;
+
+    Ok(VaultToml {
+        format_version,
+        suite_id,
+        vault_uuid,
+        created_at_ms,
+        kdf: KdfSection {
+            algorithm,
+            version,
+            memory_kib,
+            iterations,
+            parallelism,
+            salt,
+        },
+    })
+}
+
+/// Parse the RFC 4122 textual UUID form ("xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx").
+/// Returns `None` on any deviation from the expected 32 hex digits plus hyphens.
+fn parse_uuid_canonical(s: &str) -> Option<[u8; 16]> {
+    // Strip hyphens and require exactly 32 hex chars.
+    let stripped: String = s.chars().filter(|c| *c != '-').collect();
+    if stripped.len() != 32 {
+        return None;
+    }
+    let mut out = [0u8; 16];
+    for i in 0..16 {
+        let byte = u8::from_str_radix(&stripped[i * 2..i * 2 + 2], 16).ok()?;
+        out[i] = byte;
+    }
+    Some(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample() -> VaultToml {
+        VaultToml {
+            format_version: 1,
+            suite_id: 1,
+            vault_uuid: [0xAB; 16],
+            created_at_ms: 1_714_060_800_000,
+            kdf: KdfSection {
+                algorithm: "argon2id".to_string(),
+                version: "1.3".to_string(),
+                memory_kib: 262144,
+                iterations: 3,
+                parallelism: 1,
+                salt: [0xCD; 32],
+            },
+        }
+    }
+
+    #[test]
+    fn encode_decode_roundtrip() {
+        let v = sample();
+        let s = encode(&v);
+        let parsed = decode(&s).expect("decode");
+        assert_eq!(parsed, v);
+    }
+}

--- a/core/src/unlock/vault_toml.rs
+++ b/core/src/unlock/vault_toml.rs
@@ -13,6 +13,8 @@
 use base64::{engine::general_purpose::STANDARD, Engine as _};
 use serde::Serialize;
 
+use crate::version::{FORMAT_VERSION, SUITE_ID};
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct VaultToml {
     pub format_version: u16,
@@ -153,7 +155,7 @@ pub fn decode(s: &str) -> Result<VaultToml, VaultTomlError> {
     // when the raw integer is out of range (e.g. 99999 → 65535 clearly signals
     // "out of range" to a reader). Same pattern for suite_id below.
     let format_version = u16::try_from(format_version).unwrap_or(u16::MAX);
-    if format_version != 1 {
+    if format_version != FORMAT_VERSION {
         return Err(VaultTomlError::UnsupportedFormatVersion(format_version));
     }
 
@@ -162,7 +164,7 @@ pub fn decode(s: &str) -> Result<VaultToml, VaultTomlError> {
         .and_then(Value::as_integer)
         .ok_or(VaultTomlError::MissingField("suite_id"))?;
     let suite_id = u16::try_from(suite_id).unwrap_or(u16::MAX);
-    if suite_id != 1 {
+    if suite_id != SUITE_ID {
         return Err(VaultTomlError::UnsupportedSuiteId(suite_id));
     }
 

--- a/core/src/unlock/vault_toml.rs
+++ b/core/src/unlock/vault_toml.rs
@@ -251,4 +251,62 @@ mod tests {
         let parsed = decode(&s).expect("decode");
         assert_eq!(parsed, v);
     }
+
+    #[test]
+    fn decode_ignores_unknown_top_level_key() {
+        // Insert the unknown key before [kdf] so TOML parses it as a top-level
+        // entry; appending after [kdf] would make it a kdf key (§2: unknown
+        // top-level keys are ignored, unknown kdf keys are errors).
+        let s = encode(&sample()).replacen("[kdf]\n", "future_key = \"some value\"\n[kdf]\n", 1);
+        let parsed = decode(&s).expect("unknown top-level key must be ignored");
+        assert_eq!(parsed, sample());
+    }
+
+    #[test]
+    fn decode_rejects_unknown_kdf_key() {
+        // Insert rogue key directly after [kdf] header so TOML parses it into
+        // the kdf table regardless of section ordering.
+        let s = encode(&sample()).replacen("[kdf]\n", "[kdf]\nrogue_param = 42\n", 1);
+        let err = decode(&s).unwrap_err();
+        assert!(matches!(err, VaultTomlError::UnknownKdfKey(ref k) if k == "rogue_param"));
+    }
+
+    #[test]
+    fn decode_rejects_unsupported_format_version() {
+        let s = encode(&sample()).replace("format_version = 1", "format_version = 2");
+        let err = decode(&s).unwrap_err();
+        assert!(matches!(err, VaultTomlError::UnsupportedFormatVersion(2)));
+    }
+
+    #[test]
+    fn decode_rejects_unsupported_suite_id() {
+        let s = encode(&sample()).replace("suite_id = 1", "suite_id = 2");
+        let err = decode(&s).unwrap_err();
+        assert!(matches!(err, VaultTomlError::UnsupportedSuiteId(2)));
+    }
+
+    #[test]
+    fn decode_rejects_wrong_kdf_algorithm() {
+        let s = encode(&sample()).replace("algorithm = \"argon2id\"", "algorithm = \"scrypt\"");
+        let err = decode(&s).unwrap_err();
+        assert!(matches!(err, VaultTomlError::UnsupportedKdfAlgorithm(ref s) if s == "scrypt"));
+    }
+
+    #[test]
+    fn decode_rejects_wrong_kdf_version() {
+        let s = encode(&sample()).replace("version = \"1.3\"", "version = \"1.0\"");
+        let err = decode(&s).unwrap_err();
+        assert!(matches!(err, VaultTomlError::UnsupportedKdfVersion(ref s) if s == "1.0"));
+    }
+
+    #[test]
+    fn decode_rejects_short_salt() {
+        let v = sample();
+        let s = encode(&v);
+        let short_b64 = STANDARD.encode([0u8; 16]);
+        let original_b64 = STANDARD.encode([0xCDu8; 32]);
+        let s = s.replace(&original_b64, &short_b64);
+        let err = decode(&s).unwrap_err();
+        assert!(matches!(err, VaultTomlError::InvalidSaltLength { got: 16 }));
+    }
 }

--- a/core/tests/common/mod.rs
+++ b/core/tests/common/mod.rs
@@ -335,3 +335,20 @@ pub struct MlDsa65SigverVector {
     #[serde(deserialize_with = "de_hex")]
     pub sig: Vec<u8>,
 }
+
+#[derive(Debug, Deserialize)]
+pub struct Bip39RecoveryKat {
+    pub vectors: Vec<Bip39RecoveryVector>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct Bip39RecoveryVector {
+    pub name: String,
+    pub mnemonic: String,
+    #[serde(deserialize_with = "de_hex_array::<32, _>")]
+    pub entropy: [u8; 32],
+    #[serde(deserialize_with = "de_hex")]
+    pub info_tag: Vec<u8>,
+    #[serde(deserialize_with = "de_hex_array::<32, _>")]
+    pub expected_recovery_kek: [u8; 32],
+}

--- a/core/tests/data/bip39_recovery_kat.json
+++ b/core/tests/data/bip39_recovery_kat.json
@@ -16,17 +16,24 @@
     },
     {
       "name": "trezor_vector_24w_1",
-      "mnemonic": "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon art",
-      "entropy": "0000000000000000000000000000000000000000000000000000000000000000",
-      "info_tag": "7365637265746172792d76312d7265636f766572792d6b656b",
-      "expected_recovery_kek": "32267cba4b0f75fcd6204457687526dce5e381e28878323b3e550ccff0898da8"
-    },
-    {
-      "name": "trezor_vector_24w_2",
       "mnemonic": "letter advice cage absurd amount doctor acoustic avoid letter advice cage absurd amount doctor acoustic avoid letter advice cage absurd amount doctor acoustic bless",
       "entropy": "8080808080808080808080808080808080808080808080808080808080808080",
       "info_tag": "7365637265746172792d76312d7265636f766572792d6b656b",
       "expected_recovery_kek": "949d57f2d0895b860b7a61d097842103e9b8859df57c57e988a267e0a8756429"
+    },
+    {
+      "name": "trezor_vector_24w_2",
+      "mnemonic": "panda eyebrow bullet gorilla call smoke muffin taste mesh discover soft ostrich alcohol speed nation flash devote level hobby quick inner drive ghost inside",
+      "entropy": "9f6a2878b2520799a44ef18bc7df394e7061a224d2c33cd015b157d746869863",
+      "info_tag": "7365637265746172792d76312d7265636f766572792d6b656b",
+      "expected_recovery_kek": "8288b1b1b78eef4e775ba2f8be747fc4478a874eb006f06cb5f7563c7604f3b5"
+    },
+    {
+      "name": "trezor_vector_24w_3",
+      "mnemonic": "all hour make first leader extend hole alien behind guard gospel lava path output census museum junior mass reopen famous sing advance salt reform",
+      "entropy": "066dca1a2bb7e8a1db2832148ce9933eea0f3ac9548d793112d9a95c9407efad",
+      "info_tag": "7365637265746172792d76312d7265636f766572792d6b656b",
+      "expected_recovery_kek": "948dc81be09d85f0a174ecc54cd1129ef85c8861ff3ab875c7acac75da5ea4ae"
     }
   ]
 }

--- a/core/tests/data/bip39_recovery_kat.json
+++ b/core/tests/data/bip39_recovery_kat.json
@@ -1,0 +1,32 @@
+{
+  "vectors": [
+    {
+      "name": "all_zero_entropy",
+      "mnemonic": "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon art",
+      "entropy": "0000000000000000000000000000000000000000000000000000000000000000",
+      "info_tag": "7365637265746172792d76312d7265636f766572792d6b656b",
+      "expected_recovery_kek": "32267cba4b0f75fcd6204457687526dce5e381e28878323b3e550ccff0898da8"
+    },
+    {
+      "name": "all_ff_entropy",
+      "mnemonic": "zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo vote",
+      "entropy": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+      "info_tag": "7365637265746172792d76312d7265636f766572792d6b656b",
+      "expected_recovery_kek": "8232bcb4f3b104b9ca3b74119c4035e1d424ac2ca08cf78b7aa50e611d71bf2b"
+    },
+    {
+      "name": "trezor_vector_24w_1",
+      "mnemonic": "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon art",
+      "entropy": "0000000000000000000000000000000000000000000000000000000000000000",
+      "info_tag": "7365637265746172792d76312d7265636f766572792d6b656b",
+      "expected_recovery_kek": "32267cba4b0f75fcd6204457687526dce5e381e28878323b3e550ccff0898da8"
+    },
+    {
+      "name": "trezor_vector_24w_2",
+      "mnemonic": "letter advice cage absurd amount doctor acoustic avoid letter advice cage absurd amount doctor acoustic avoid letter advice cage absurd amount doctor acoustic bless",
+      "entropy": "8080808080808080808080808080808080808080808080808080808080808080",
+      "info_tag": "7365637265746172792d76312d7265636f766572792d6b656b",
+      "expected_recovery_kek": "949d57f2d0895b860b7a61d097842103e9b8859df57c57e988a267e0a8756429"
+    }
+  ]
+}

--- a/core/tests/proptest.proptest-regressions
+++ b/core/tests/proptest.proptest-regressions
@@ -1,7 +1,0 @@
-# Seeds for failure cases proptest has generated in the past. It is
-# automatically read and these particular cases re-run before any
-# novel cases are generated.
-#
-# It is recommended to check this file in to source control so that
-# everyone who runs the test benefits from these saved cases.
-cc d0d4ec69271e2ba3636466fc63ba8e7205e0f5181147ad3554c6b60245f8e6e4 # shrinks to vault_uuid = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], created_at_ms = 9223372036854775808, memory_kib = 8, iterations = 1, parallelism = 1, salt = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]

--- a/core/tests/proptest.proptest-regressions
+++ b/core/tests/proptest.proptest-regressions
@@ -1,0 +1,7 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc d0d4ec69271e2ba3636466fc63ba8e7205e0f5181147ad3554c6b60245f8e6e4 # shrinks to vault_uuid = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], created_at_ms = 9223372036854775808, memory_kib = 8, iterations = 1, parallelism = 1, salt = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]

--- a/core/tests/proptest.rs
+++ b/core/tests/proptest.rs
@@ -329,7 +329,7 @@ mod unlock {
     use secretary_core::crypto::kdf::Argon2idParams;
     use secretary_core::crypto::secret::SecretBytes;
     use secretary_core::unlock::{
-        bundle, bundle_file, create_vault, open_with_password, vault_toml,
+        bundle, bundle_file, create_vault_unchecked, open_with_password, vault_toml,
     };
 
     proptest! {
@@ -432,13 +432,14 @@ mod unlock {
             prop_assert!(matches!(err, vault_toml::VaultTomlError::TimestampOutOfRange(_)));
         }
 
-        /// `open_with_password(create_vault(...)) ` recovers the same IBK and
-        /// user UUID. Uses weak Argon2id params for speed.
+        /// `open_with_password(create_vault_unchecked(...))` recovers the
+        /// same IBK and user UUID. Uses sub-floor Argon2id params (only
+        /// permitted via the unchecked path) for proptest speed.
         #[test]
         fn create_then_open_roundtrip_preserves_identity(seed: [u8; 32], pw_seed: [u8; 16]) {
             let mut rng = ChaCha20Rng::from_seed(seed);
             let pw = SecretBytes::new(pw_seed.to_vec());
-            let v = create_vault(&pw, "X", 0, Argon2idParams::new(8, 1, 1), &mut rng).unwrap();
+            let v = create_vault_unchecked(&pw, "X", 0, Argon2idParams::new(8, 1, 1), &mut rng).unwrap();
             let opened = open_with_password(
                 &v.vault_toml_bytes, &v.identity_bundle_bytes, &pw,
             ).unwrap();

--- a/core/tests/proptest.rs
+++ b/core/tests/proptest.rs
@@ -376,11 +376,9 @@ mod unlock {
 
         /// `decode(encode(v)) == v` for any well-formed VaultToml.
         ///
-        /// `created_at_ms` is constrained to `0..=i64::MAX as u64` because the
-        /// TOML integer type is a signed 64-bit value; the `toml` crate panics
-        /// on serialising a `u64` that exceeds `i64::MAX`. Values beyond that
-        /// range are unreachable in practice (> year 292 million) and are not
-        /// representable in the vault-format.md §2 wire form.
+        /// `created_at_ms` is bounded to `0..=i64::MAX as u64` — the representable
+        /// range for TOML's signed 64-bit integer. Values above i64::MAX are covered
+        /// by the `vault_toml_encode_rejects_timestamp_out_of_range` property below.
         #[test]
         fn vault_toml_roundtrip(
             vault_uuid in any::<[u8; 16]>(),
@@ -404,9 +402,34 @@ mod unlock {
                     salt,
                 },
             };
-            let s = vault_toml::encode(&v);
+            let s = vault_toml::encode(&v).unwrap();
             let parsed = vault_toml::decode(&s).unwrap();
             prop_assert_eq!(parsed, v);
+        }
+
+        /// `encode` returns `TimestampOutOfRange` — not a panic — for any
+        /// `created_at_ms` above i64::MAX. Documents and pins the typed-error
+        /// path that replaced the old `expect` panic.
+        #[test]
+        fn vault_toml_encode_rejects_timestamp_out_of_range(
+            created_at_ms in (i64::MAX as u64 + 1)..=u64::MAX,
+        ) {
+            let v = vault_toml::VaultToml {
+                format_version: 1,
+                suite_id: 1,
+                vault_uuid: [0u8; 16],
+                created_at_ms,
+                kdf: vault_toml::KdfSection {
+                    algorithm: "argon2id".to_string(),
+                    version: "1.3".to_string(),
+                    memory_kib: 8,
+                    iterations: 1,
+                    parallelism: 1,
+                    salt: [0u8; 32],
+                },
+            };
+            let err = vault_toml::encode(&v).unwrap_err();
+            prop_assert!(matches!(err, vault_toml::VaultTomlError::TimestampOutOfRange(_)));
         }
 
         /// `open_with_password(create_vault(...)) ` recovers the same IBK and

--- a/core/tests/proptest.rs
+++ b/core/tests/proptest.rs
@@ -316,3 +316,111 @@ proptest! {
         );
     }
 }
+
+// ---------------------------------------------------------------------------
+// Properties — unlock module (bundle CBOR, bundle-file wire, vault.toml,
+// and the full create/open path)
+// ---------------------------------------------------------------------------
+
+mod unlock {
+    use proptest::prelude::*;
+    use rand_chacha::{rand_core::SeedableRng, ChaCha20Rng};
+
+    use secretary_core::crypto::kdf::Argon2idParams;
+    use secretary_core::crypto::secret::SecretBytes;
+    use secretary_core::unlock::{
+        bundle, bundle_file, create_vault, open_with_password, vault_toml,
+    };
+
+    proptest! {
+        /// `from_canonical_cbor(to_canonical_cbor(b)) == b` for any seed.
+        /// Also checks that encoding twice yields identical bytes (determinism).
+        #[test]
+        fn identity_bundle_canonical_cbor_roundtrip(seed: [u8; 32]) {
+            let mut rng = ChaCha20Rng::from_seed(seed);
+            let b = bundle::generate("X", 0, &mut rng);
+            let bytes_1 = b.to_canonical_cbor().unwrap();
+            let bytes_2 = b.to_canonical_cbor().unwrap();
+            prop_assert_eq!(&bytes_1, &bytes_2, "encoding non-deterministic");
+            let parsed = bundle::IdentityBundle::from_canonical_cbor(&bytes_1).unwrap();
+            prop_assert_eq!(parsed.user_uuid, b.user_uuid);
+            prop_assert_eq!(parsed.x25519_pk, b.x25519_pk);
+        }
+
+        /// `decode(encode(f)) == f` for any well-formed BundleFile.
+        #[test]
+        fn bundle_file_roundtrip(
+            vault_uuid in any::<[u8; 16]>(),
+            created_at_ms in any::<u64>(),
+            wpw_nonce in any::<[u8; 24]>(),
+            wpw_ct in any::<[u8; 48]>(),
+            wrec_nonce in any::<[u8; 24]>(),
+            wrec_ct in any::<[u8; 48]>(),
+            bundle_nonce in any::<[u8; 24]>(),
+            bundle_ct in proptest::collection::vec(any::<u8>(), 16..1024),
+        ) {
+            let f = bundle_file::BundleFile {
+                vault_uuid,
+                created_at_ms,
+                wrap_pw_nonce: wpw_nonce,
+                wrap_pw_ct_with_tag: wpw_ct,
+                wrap_rec_nonce: wrec_nonce,
+                wrap_rec_ct_with_tag: wrec_ct,
+                bundle_nonce,
+                bundle_ct_with_tag: bundle_ct,
+            };
+            let bytes = bundle_file::encode(&f);
+            let parsed = bundle_file::decode(&bytes).unwrap();
+            prop_assert_eq!(parsed, f);
+        }
+
+        /// `decode(encode(v)) == v` for any well-formed VaultToml.
+        ///
+        /// `created_at_ms` is constrained to `0..=i64::MAX as u64` because the
+        /// TOML integer type is a signed 64-bit value; the `toml` crate panics
+        /// on serialising a `u64` that exceeds `i64::MAX`. Values beyond that
+        /// range are unreachable in practice (> year 292 million) and are not
+        /// representable in the vault-format.md §2 wire form.
+        #[test]
+        fn vault_toml_roundtrip(
+            vault_uuid in any::<[u8; 16]>(),
+            created_at_ms in 0u64..=(i64::MAX as u64),
+            memory_kib in 8u32..1024u32,
+            iterations in 1u32..16u32,
+            parallelism in 1u32..8u32,
+            salt in any::<[u8; 32]>(),
+        ) {
+            let v = vault_toml::VaultToml {
+                format_version: 1,
+                suite_id: 1,
+                vault_uuid,
+                created_at_ms,
+                kdf: vault_toml::KdfSection {
+                    algorithm: "argon2id".to_string(),
+                    version: "1.3".to_string(),
+                    memory_kib,
+                    iterations,
+                    parallelism,
+                    salt,
+                },
+            };
+            let s = vault_toml::encode(&v);
+            let parsed = vault_toml::decode(&s).unwrap();
+            prop_assert_eq!(parsed, v);
+        }
+
+        /// `open_with_password(create_vault(...)) ` recovers the same IBK and
+        /// user UUID. Uses weak Argon2id params for speed.
+        #[test]
+        fn create_then_open_roundtrip_preserves_identity(seed: [u8; 32], pw_seed: [u8; 16]) {
+            let mut rng = ChaCha20Rng::from_seed(seed);
+            let pw = SecretBytes::new(pw_seed.to_vec());
+            let v = create_vault(&pw, "X", 0, Argon2idParams::new(8, 1, 1), &mut rng).unwrap();
+            let opened = open_with_password(
+                &v.vault_toml_bytes, &v.identity_bundle_bytes, &pw,
+            ).unwrap();
+            prop_assert_eq!(opened.identity_block_key.expose(), v.identity_block_key.expose());
+            prop_assert_eq!(opened.identity.user_uuid, v.identity.user_uuid);
+        }
+    }
+}

--- a/core/tests/unlock.rs
+++ b/core/tests/unlock.rs
@@ -65,6 +65,27 @@ fn swapped_bundle_file_returns_vault_mismatch() {
 }
 
 #[test]
+fn mismatched_created_at_ms_returns_vault_mismatch() {
+    // Tamper the bundle file's created_at_ms while leaving vault_uuid intact —
+    // the cross-check should reject this as a swap-like attack on the
+    // cleartext vault.toml metadata.
+    let pw = b"hunter2";
+    let v = create(7, pw);
+
+    let mut bf = bundle_file::decode(&v.identity_bundle_bytes).unwrap();
+    bf.created_at_ms = bf.created_at_ms.wrapping_add(1);
+    let tampered = bundle_file::encode(&bf);
+
+    let err = open_with_password(
+        &v.vault_toml_bytes,
+        &tampered,
+        &SecretBytes::new(pw.to_vec()),
+    )
+    .unwrap_err();
+    assert!(matches!(err, UnlockError::VaultMismatch));
+}
+
+#[test]
 fn mnemonic_not_24_words_returns_invalid_mnemonic() {
     let v = create(3, b"x");
     let err = open_with_recovery(

--- a/core/tests/unlock.rs
+++ b/core/tests/unlock.rs
@@ -9,25 +9,26 @@ use rand_chacha::{rand_core::SeedableRng, ChaCha20Rng};
 use secretary_core::crypto::kdf::{Argon2idParams, derive_recovery_kek, TAG_RECOVERY_KEK};
 use secretary_core::crypto::secret::SecretBytes;
 use secretary_core::unlock::{
-    self, bundle_file, create_vault, open_with_password, open_with_recovery, UnlockError,
+    self, bundle_file, create_vault_unchecked, open_with_password, open_with_recovery, UnlockError,
 };
 
 fn fast_params() -> Argon2idParams {
-    // Below v1 floor — only legal via Argon2idParams::new (not try_new_v1).
-    // Used here to keep tests fast (~ms instead of seconds).
+    // Below v1 floor — used with create_vault_unchecked to keep integration
+    // tests at ~ms instead of seconds. The safe create_vault entry point
+    // would reject these as UnlockError::WeakKdfParams.
     Argon2idParams::new(8, 1, 1)
 }
 
 fn create(seed: u8, pw: &[u8]) -> unlock::CreatedVault {
     let mut rng = ChaCha20Rng::from_seed([seed; 32]);
-    create_vault(
+    create_vault_unchecked(
         &SecretBytes::new(pw.to_vec()),
         "Alice",
         1_714_060_800_000,
         fast_params(),
         &mut rng,
     )
-    .expect("create_vault")
+    .expect("create_vault_unchecked")
 }
 
 #[test]

--- a/core/tests/unlock.rs
+++ b/core/tests/unlock.rs
@@ -1,0 +1,77 @@
+//! Integration tests for the unlock module — exercises the public surface
+//! across realistic scenarios: corruption detection, vault mismatch, and the
+//! full create→open round-trip with both unlock paths.
+
+mod common;
+
+use rand_chacha::{rand_core::SeedableRng, ChaCha20Rng};
+
+use secretary_core::crypto::kdf::Argon2idParams;
+use secretary_core::crypto::secret::SecretBytes;
+use secretary_core::unlock::{
+    self, bundle_file, create_vault, open_with_password, open_with_recovery, UnlockError,
+};
+
+fn fast_params() -> Argon2idParams {
+    // Below v1 floor — only legal via Argon2idParams::new (not try_new_v1).
+    // Used here to keep tests fast (~ms instead of seconds).
+    Argon2idParams::new(8, 1, 1)
+}
+
+fn create(seed: u8, pw: &[u8]) -> unlock::CreatedVault {
+    let mut rng = ChaCha20Rng::from_seed([seed; 32]);
+    create_vault(
+        &SecretBytes::new(pw.to_vec()),
+        "Alice",
+        1_714_060_800_000,
+        fast_params(),
+        &mut rng,
+    )
+    .expect("create_vault")
+}
+
+#[test]
+fn flipped_bundle_ct_byte_returns_corrupt_vault() {
+    let pw = b"hunter2";
+    let v = create(1, pw);
+
+    // Decode the bundle file, flip a byte deep in bundle_ct_with_tag, re-encode.
+    let mut bf = bundle_file::decode(&v.identity_bundle_bytes).unwrap();
+    let mid = bf.bundle_ct_with_tag.len() / 2;
+    bf.bundle_ct_with_tag[mid] ^= 0xFF;
+    let tampered = bundle_file::encode(&bf);
+
+    let err = open_with_password(&v.vault_toml_bytes, &tampered, &SecretBytes::new(pw.to_vec()))
+        .unwrap_err();
+    // wrap_pw decrypts fine (we didn't touch it) → bundle AEAD fails →
+    // CorruptVault.
+    assert!(matches!(err, UnlockError::CorruptVault));
+}
+
+#[test]
+fn swapped_bundle_file_returns_vault_mismatch() {
+    let pw = b"hunter2";
+    let a = create(1, pw);
+    let b = create(2, pw);
+
+    // Open vault A's vault.toml with vault B's identity.bundle.enc.
+    let err = open_with_password(
+        &a.vault_toml_bytes,
+        &b.identity_bundle_bytes,
+        &SecretBytes::new(pw.to_vec()),
+    )
+    .unwrap_err();
+    assert!(matches!(err, UnlockError::VaultMismatch));
+}
+
+#[test]
+fn mnemonic_not_24_words_returns_invalid_mnemonic() {
+    let v = create(3, b"x");
+    let err = open_with_recovery(
+        &v.vault_toml_bytes,
+        &v.identity_bundle_bytes,
+        "abandon abandon abandon",
+    )
+    .unwrap_err();
+    assert!(matches!(err, UnlockError::InvalidMnemonic(_)));
+}

--- a/core/tests/unlock.rs
+++ b/core/tests/unlock.rs
@@ -6,7 +6,7 @@ mod common;
 
 use rand_chacha::{rand_core::SeedableRng, ChaCha20Rng};
 
-use secretary_core::crypto::kdf::Argon2idParams;
+use secretary_core::crypto::kdf::{Argon2idParams, derive_recovery_kek, TAG_RECOVERY_KEK};
 use secretary_core::crypto::secret::SecretBytes;
 use secretary_core::unlock::{
     self, bundle_file, create_vault, open_with_password, open_with_recovery, UnlockError,
@@ -74,4 +74,37 @@ fn mnemonic_not_24_words_returns_invalid_mnemonic() {
     )
     .unwrap_err();
     assert!(matches!(err, UnlockError::InvalidMnemonic(_)));
+}
+
+#[test]
+fn bip39_recovery_kat_vectors() {
+    use common::{load_kat, Bip39RecoveryKat};
+    use secretary_core::crypto::secret::Sensitive;
+    use secretary_core::unlock::mnemonic;
+
+    let kat: Bip39RecoveryKat = load_kat("bip39_recovery_kat.json");
+    assert!(!kat.vectors.is_empty(), "KAT file has no vectors");
+    for v in &kat.vectors {
+        // Pin 1: mnemonic → entropy (BIP-39 English wordlist + checksum).
+        let parsed = mnemonic::parse(&v.mnemonic).unwrap_or_else(|e| {
+            panic!("vector {}: parse failed: {e}", v.name)
+        });
+        assert_eq!(
+            parsed.entropy().expose(), &v.entropy,
+            "vector {}: mnemonic→entropy mismatch", v.name,
+        );
+
+        // Pin 2: info_tag is exactly TAG_RECOVERY_KEK bytes.
+        assert_eq!(
+            v.info_tag, TAG_RECOVERY_KEK,
+            "vector {}: info_tag does not match TAG_RECOVERY_KEK", v.name,
+        );
+
+        // Pin 3: entropy → recovery_kek (HKDF-SHA-256, 32-zero-byte salt, info=tag).
+        let kek = derive_recovery_kek(&Sensitive::new(v.entropy));
+        assert_eq!(
+            kek.expose(), &v.expected_recovery_kek,
+            "vector {}: HKDF output mismatch", v.name,
+        );
+    }
 }

--- a/core/tests/unlock.rs
+++ b/core/tests/unlock.rs
@@ -77,6 +77,41 @@ fn mnemonic_not_24_words_returns_invalid_mnemonic() {
 }
 
 #[test]
+fn flipped_bundle_ct_byte_returns_corrupt_vault_via_recovery() {
+    let pw = b"hunter2";
+    let v = create(4, pw);
+
+    let mut bf = bundle_file::decode(&v.identity_bundle_bytes).unwrap();
+    let mid = bf.bundle_ct_with_tag.len() / 2;
+    bf.bundle_ct_with_tag[mid] ^= 0xFF;
+    let tampered = bundle_file::encode(&bf);
+
+    let err = open_with_recovery(
+        &v.vault_toml_bytes,
+        &tampered,
+        v.recovery_mnemonic.phrase(),
+    ).unwrap_err();
+    // wrap_rec decrypts fine → bundle AEAD fails → CorruptVault.
+    assert!(matches!(err, UnlockError::CorruptVault));
+}
+
+#[test]
+fn non_utf8_vault_toml_returns_malformed_vault_toml() {
+    use secretary_core::unlock::vault_toml::VaultTomlError;
+
+    // Create a valid vault, then submit garbage non-UTF-8 bytes as vault.toml.
+    let v = create(5, b"hunter2");
+    let invalid: &[u8] = &[0xFF, 0xFE, 0x00, 0x80];
+
+    let err = open_with_password(invalid, &v.identity_bundle_bytes, &SecretBytes::new(b"hunter2".to_vec()))
+        .unwrap_err();
+    assert!(matches!(
+        err,
+        UnlockError::MalformedVaultToml(VaultTomlError::MalformedToml(ref m)) if m.contains("non-UTF-8")
+    ));
+}
+
+#[test]
 fn bip39_recovery_kat_vectors() {
     use common::{load_kat, Bip39RecoveryKat};
     use secretary_core::crypto::secret::Sensitive;

--- a/docs/crypto-design.md
+++ b/docs/crypto-design.md
@@ -162,11 +162,13 @@ The Identity Bundle is the AEAD-encrypted CBOR-serialized record:
   "ml_kem_768_pk":   <bstr 1184>,
   "ed25519_sk":      <bstr 32>,
   "ed25519_pk":      <bstr 32>,
-  "ml_dsa_65_sk":    <bstr 4032>,
+  "ml_dsa_65_sk":    <bstr 32>,    ; FIPS 204 seed (xi); see note below
   "ml_dsa_65_pk":    <bstr 1952>,
   "created_at":      <u64 unix-millis>,
 }
 ```
+
+**Note on `ml_dsa_65_sk`:** The on-disk encoding is the 32-byte FIPS 204 KeyGen seed (`xi`), not the 4032-byte expanded signing-key form. The expanded form is a deterministic function of the seed (`MlDsa65::from_seed(xi)` recomputes it identically every time), so the seed is information-equivalent and 4 KiB smaller per identity bundle. We chose the seed because the upstream `ml-dsa` crate marks the 4032-byte expanded encoding `#[deprecated]` and our build runs `cargo clippy --all-targets -- -D warnings`. See `core/src/crypto/sig.rs` module docs for the full rationale, and §14 for the size-summary entry.
 
 Encryption proceeds as follows:
 
@@ -514,7 +516,8 @@ ed25519_sk                  = 32 bytes
 ed25519_sig                 = 64 bytes
 
 ml_dsa_65_pk                = 1952 bytes
-ml_dsa_65_sk                = 4032 bytes
+ml_dsa_65_sk_expanded       = 4032 bytes (FIPS 204 expanded form; not stored on disk in v1)
+ml_dsa_65_sk_seed           = 32 bytes   (FIPS 204 KeyGen seed xi; this is what §5 stores)
 ml_dsa_65_sig               = 3309 bytes (FIPS 204 fixed; length-prefixed on disk for forward compatibility)
 
 blake3_fingerprint_full     = 32 bytes

--- a/docs/manual/hardening-security.md
+++ b/docs/manual/hardening-security.md
@@ -1,0 +1,78 @@
+# Hardening security when needed
+
+Secretary's default settings already give you strong protection: your master password is stretched with Argon2id, your identity keys are encrypted at rest with XChaCha20-Poly1305, and your data is post-quantum-hybrid-encrypted to every recipient. For most personal and family use, the defaults are appropriate.
+
+This chapter is for situations where you want to push further — high-value secrets, threat models that include physical device theft or sophisticated forensic recovery, or simply careful operational hygiene. Nothing here is required; everything here is a layered improvement on a baseline that is already meant to be good.
+
+## What Secretary already does for you
+
+When Secretary unlocks your vault, it loads cryptographic keys into memory just long enough to decrypt the data you're working with. The moment those keys are no longer needed, Secretary explicitly **zeroes** the memory that held them — overwriting the bytes with zeros and instructing the compiler not to optimize that overwrite away. The same goes for your master password and your recovery mnemonic: they are scrubbed from RAM as soon as Secretary is done with them. Long-lived material (the per-vault Identity Block Key) survives only as long as your session, and is zeroed when the application exits or the vault is locked.
+
+This handles the in-memory part of the problem completely. There is, however, a layer below the running application that Secretary cannot reach on its own: **what your operating system does with the memory pages Secretary uses.**
+
+## The swap-file concern
+
+Modern operating systems move idle memory pages to disk when RAM gets tight — this is called *swap* (Linux, macOS) or the *paging file* (Windows). If a key was sitting in a memory page that the OS swapped to disk before Secretary got a chance to zero it, the on-disk swap copy still contains that key. After Secretary zeroes the in-RAM copy, the swap copy is unaffected — and it persists on disk until that swap slot is reused.
+
+An adversary with physical access to your unencrypted swap file (laptop theft, drive forensics on a discarded SSD, sophisticated cold-storage attack) could in principle recover keys from there.
+
+The same concern applies, more strongly, to **hibernation**: when a computer hibernates (suspend-to-disk), the *entire* contents of RAM are written to disk. Secretary's in-memory zeroing happens too late for any key that was live at the moment of hibernation.
+
+## What you can do
+
+The good news is that all the meaningful mitigations are layered into the operating system, not into Secretary itself, and most modern systems already do the right thing by default. You just need to verify and, in a few cases, opt in.
+
+### macOS and iOS
+
+- **Swap encryption is on by default** on macOS 10.11 and later, and always-on on iOS. There is nothing to configure.
+- **FileVault** (full-disk encryption) is opt-in but recommended for any device holding a Secretary vault. With FileVault on, your swap file is part of an encrypted volume, and even a stolen drive yields no plaintext.
+- **Hibernation**: macOS uses "safe sleep" by default — RAM contents are written to an encrypted file (`/var/vm/sleepimage`) on the FileVault volume. Acceptable when FileVault is on; otherwise, consider disabling hibernation.
+
+### Linux
+
+- **Encrypted swap is opt-in** but standard in security-conscious distributions. The cleanest setup is to put swap on a LUKS-encrypted partition (most installers offer this); alternatives include `systemd-cryptsetup`'s ephemeral random-keyed swap, or skipping swap entirely (set `vm.swappiness=0` and have enough RAM, or use ZRAM for compressed in-memory swap).
+- **Full-disk encryption** with LUKS is recommended for any device holding a Secretary vault.
+- **Hibernation**: requires careful configuration if you have encrypted swap (the kernel needs to resume from the encrypted partition); for high-assurance use, disabling hibernation entirely is simpler.
+
+### Windows
+
+- **BitLocker** (full-disk encryption) is recommended; on Windows 10/11 Pro and Enterprise it's well-integrated. With BitLocker on, the paging file is on the encrypted volume.
+- **Paging-file encryption** can be enabled separately even without BitLocker (`fsutil behavior set encryptpagingfile 1`, then reboot).
+- **Hibernation**: as above, encrypted only if BitLocker is on. To disable: `powercfg /hibernate off`.
+
+### Android
+
+- Full-device encryption has been mandatory since Android 6.0. Encrypted swap (when present) is part of the encrypted volume. Generally nothing to configure.
+
+## Operational practices
+
+For high-value vaults, a few habits matter as much as the OS settings:
+
+- **Lock the vault when you walk away.** A locked vault has no keys in memory; an unlocked one does, regardless of how good your zeroization is.
+- **Don't unlock a high-value vault on devices you don't fully trust.** No amount of memory hygiene helps if a keylogger captures your master password as you type it.
+- **Reboot occasionally**, especially after working with sensitive blocks. RAM pages get reused; swap slots get reclaimed; the longer a system runs, the more it accumulates traces.
+- **Avoid hibernating immediately after using a high-value vault.** Either lock the vault first, or shut down rather than hibernate.
+
+## Future improvements within Secretary
+
+A planned enhancement is to use the operating system's "lock this page in physical RAM" facility (`mlock` on Unix, `VirtualLock` on Windows) on the small number of pages that hold key material. This would prevent those pages from ever being swapped to disk, eliminating the swap-file concern at the source rather than relying on swap encryption.
+
+This is a focused change and is on the roadmap, but it has trade-offs worth flagging:
+
+- **Page granularity.** Operating systems lock memory in 4 KiB pages; a 32-byte key consumes a whole locked page. Cost in RAM is small but non-zero.
+- **Quota limits.** Linux limits unprivileged processes to roughly 64 KiB of locked memory by default (`RLIMIT_MEMLOCK`); we would need to be careful to fit within that without elevated privileges.
+- **Hibernation.** Even locked pages are written to disk on hibernation. So `mlock` is complementary to, not a replacement for, the operational practices above.
+
+When this lands, the chapter will be updated; nothing about your existing vaults will change, and you will not need to do anything.
+
+## Threat model boundary
+
+Secretary's defenses assume:
+
+- The operating system is functioning normally and has not been compromised below the user-process boundary (no kernel rootkit, no firmware implant, no malicious hypervisor).
+- Disk encryption and swap encryption are configured according to the platform-specific guidance above.
+- The user is not under coercion at the moment they unlock the vault.
+
+If your threat model includes adversaries who can defeat all three of those assumptions — for instance, a state-level adversary with physical access and unlimited time — Secretary alone is not the answer; you need an air-gapped device, hardware-token-only authentication, and a great deal more besides. That is outside the scope of what a software-only personal secrets manager can promise.
+
+What Secretary *does* promise, and what the rest of this manual will help you make full use of, is strong protection against the realistic adversaries faced by individuals, families, and small teams: a stolen laptop, a compromised cloud-folder host, a future quantum computer attempting to decrypt material harvested today. The defaults handle those. The hardening in this chapter pushes further, when you want it.

--- a/docs/superpowers/plans/2026-04-27-unlock-module.md
+++ b/docs/superpowers/plans/2026-04-27-unlock-module.md
@@ -1,0 +1,2470 @@
+# `core/src/unlock/` Module Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Implement the `unlock` module (`core/src/unlock/`) — five files providing pure-function APIs for vault creation, master-password unlock, and recovery-mnemonic unlock; plus the §15 BIP-39 recovery KAT.
+
+**Architecture:** Bytes-in / bytes-out, no filesystem I/O, no clock reads. Five files split by purpose: `mnemonic.rs` (BIP-39 wrapper), `bundle.rs` (`IdentityBundle` plaintext + canonical CBOR), `bundle_file.rs` (`identity.bundle.enc` binary framing), `vault_toml.rs` (TOML ser/de), `mod.rs` (composition + `UnlockError`). Each submodule exposes free functions; `mod.rs` composes them into `create_vault`, `open_with_password`, `open_with_recovery`. RNG is injected — production passes `OsRng`, tests pass seeded `ChaCha20Rng`.
+
+**Tech Stack:** Rust 2021 (stable). New crates: `bip39 = "2"`, `toml = "0.8"`, `base64 = "0.22"`. Existing primitives reused: `crypto::kdf::{derive_master_kek, derive_recovery_kek, Argon2idParams, TAG_*}`, `crypto::aead::{encrypt, decrypt, AeadKey, AeadNonce, AEAD_TAG_LEN}`, `crypto::secret::{SecretBytes, Sensitive}`, `crypto::sig::{generate_ed25519, generate_ml_dsa_65}`, `crypto::kem::{generate_x25519, generate_ml_kem_768}` (look up exact names per existing module).
+
+**Spec:** `docs/superpowers/specs/2026-04-27-unlock-module-design.md`. Spec sections referenced as e.g. "spec §Error model" below.
+
+**Verification at the end:** `cargo test --release --workspace` green; `cargo clippy --all-targets -- -D warnings` clean.
+
+---
+
+## Task 1: Add Cargo dependencies
+
+**Files:**
+- Modify: `core/Cargo.toml`
+
+- [ ] **Step 1.1: Add three production dependencies**
+
+In `core/Cargo.toml`, add to the `[dependencies]` table (alphabetical insertion in the existing list):
+
+```toml
+base64 = "0.22"
+bip39 = "2"
+toml = "0.8"
+```
+
+- [ ] **Step 1.2: Verify the dependency graph resolves**
+
+Run: `cargo check -p secretary-core`
+Expected: clean compile, three new crates appear in `Cargo.lock`. No code changes yet so no warnings other than the existing ones.
+
+- [ ] **Step 1.3: Commit**
+
+```bash
+git add core/Cargo.toml Cargo.lock
+git commit -m "feat(core): add bip39, toml, base64 deps for unlock module"
+```
+
+---
+
+## Task 2: `mnemonic.rs` — Mnemonic type + generate
+
+**Files:**
+- Create: `core/src/unlock/mnemonic.rs`
+- Modify: `core/src/unlock/mod.rs` (add `pub mod mnemonic;`)
+
+- [ ] **Step 2.1: Write the failing test**
+
+Create `core/src/unlock/mnemonic.rs` with module skeleton + a test that exercises generate.
+
+> **Note on `bip39` crate API:** Method names below assume the public API of the `bip39` crate v2.x — specifically a constructor that takes 32 bytes of entropy and produces a 24-word English mnemonic, and a parser that validates a phrase string against the English wordlist with checksum. If the actual crate exposes different names (`from_entropy_in`, `parse_in`, `to_entropy`, etc.), substitute the correct ones — the spec is "convert between 32-byte entropy and 24-word phrase" regardless of how the crate spells it. Run `cargo doc --open -p bip39` if uncertain.
+
+```rust
+//! BIP-39 mnemonic wrapper for the recovery-key path (`docs/crypto-design.md` §4).
+//!
+//! The mnemonic is generated as 256 bits of OS-CSPRNG entropy at vault creation
+//! and encoded as a 24-word BIP-39 phrase from the standard English wordlist.
+//! The 256-bit entropy is the input to `derive_recovery_kek` (`crypto::kdf`).
+
+use bip39::Mnemonic as Bip39Mnemonic;
+use rand_core::{CryptoRng, RngCore};
+use unicode_normalization::UnicodeNormalization;
+use zeroize::Zeroize;
+
+use crate::crypto::secret::Sensitive;
+
+/// 24-word BIP-39 mnemonic carrying 256 bits of entropy.
+pub struct Mnemonic {
+    phrase: String,
+    entropy: Sensitive<[u8; 32]>,
+}
+
+#[derive(Debug, thiserror::Error, PartialEq, Eq)]
+pub enum MnemonicError {
+    #[error("expected 24 words, got {got}")]
+    WrongLength { got: usize },
+    #[error("word not in BIP-39 English list: {0}")]
+    UnknownWord(String),
+    #[error("BIP-39 checksum failed")]
+    BadChecksum,
+}
+
+pub fn generate(rng: &mut (impl RngCore + CryptoRng)) -> Mnemonic {
+    let mut entropy = [0u8; 32];
+    rng.fill_bytes(&mut entropy);
+    let bip = Bip39Mnemonic::from_entropy(&entropy)
+        .expect("32 bytes is a valid BIP-39 entropy length (24 words)");
+    let phrase = bip.to_string();
+    entropy.zeroize();
+    Mnemonic {
+        phrase,
+        entropy: Sensitive::new(*bip.to_entropy_array().0.as_ref()
+            .first_chunk::<32>()
+            .expect("BIP-39 24-word produces 32 bytes")),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rand_chacha::{rand_core::SeedableRng, ChaCha20Rng};
+
+    #[test]
+    fn generate_produces_24_words() {
+        let mut rng = ChaCha20Rng::from_seed([0u8; 32]);
+        let m = generate(&mut rng);
+        assert_eq!(m.phrase().split_whitespace().count(), 24);
+    }
+}
+```
+
+Add `pub fn phrase(&self) -> &str { &self.phrase }` accessor.
+
+In `core/src/unlock/mod.rs`, replace the stub with:
+
+```rust
+//! Master-password and recovery-key unlock paths.
+//! See `docs/crypto-design.md` §3 (Master KEK), §4 (Recovery KEK), §5 (Identity Bundle wrap)
+//! and `docs/vault-format.md` §2 (vault.toml), §3 (identity.bundle.enc).
+
+pub mod mnemonic;
+```
+
+Also add `unicode-normalization = "0.1"` to `core/Cargo.toml` (needed by Step 4) — fold this into a single dep-update commit if Task 1 is still recent, or commit separately.
+
+- [ ] **Step 2.2: Run test — verify it compiles and passes**
+
+Run: `cargo test -p secretary-core --release unlock::mnemonic::tests::generate_produces_24_words`
+Expected: PASS.
+
+- [ ] **Step 2.3: Add a determinism assertion**
+
+Append to `mod tests`:
+
+```rust
+#[test]
+fn generate_is_deterministic_with_seeded_rng() {
+    let mut rng_a = ChaCha20Rng::from_seed([7u8; 32]);
+    let mut rng_b = ChaCha20Rng::from_seed([7u8; 32]);
+    let a = generate(&mut rng_a);
+    let b = generate(&mut rng_b);
+    assert_eq!(a.phrase(), b.phrase());
+    assert_eq!(a.entropy().expose(), b.entropy().expose());
+}
+```
+
+Add `pub fn entropy(&self) -> &Sensitive<[u8; 32]> { &self.entropy }` accessor.
+
+Run: `cargo test -p secretary-core --release unlock::mnemonic::tests::generate_is_deterministic_with_seeded_rng`
+Expected: PASS.
+
+- [ ] **Step 2.4: Commit**
+
+```bash
+git add core/Cargo.toml core/src/unlock/
+git commit -m "feat(unlock): mnemonic::generate (BIP-39 24-word from CSPRNG)"
+```
+
+---
+
+## Task 3: `mnemonic::parse` — happy path with NFKD normalization
+
+**Files:**
+- Modify: `core/src/unlock/mnemonic.rs`
+
+- [ ] **Step 3.1: Write the failing test**
+
+Append to `mod tests`:
+
+```rust
+#[test]
+fn parse_roundtrips_generated_mnemonic() {
+    let mut rng = ChaCha20Rng::from_seed([42u8; 32]);
+    let original = generate(&mut rng);
+    let parsed = parse(original.phrase()).expect("valid mnemonic");
+    assert_eq!(parsed.entropy().expose(), original.entropy().expose());
+    assert_eq!(parsed.phrase(), original.phrase());
+}
+
+#[test]
+fn parse_normalizes_whitespace_and_case() {
+    let mut rng = ChaCha20Rng::from_seed([1u8; 32]);
+    let m = generate(&mut rng);
+    // Reformat: extra whitespace, mixed case
+    let messy: String = m.phrase()
+        .split_whitespace()
+        .enumerate()
+        .map(|(i, w)| if i % 2 == 0 { w.to_uppercase() } else { w.to_string() })
+        .collect::<Vec<_>>()
+        .join("   \t  ");
+    let parsed = parse(&messy).expect("messy input must normalize");
+    assert_eq!(parsed.entropy().expose(), m.entropy().expose());
+}
+```
+
+Run: `cargo test -p secretary-core --release unlock::mnemonic::tests::parse_roundtrips`
+Expected: FAIL (`parse` not defined).
+
+- [ ] **Step 3.2: Implement `parse`**
+
+Add to `mnemonic.rs` (above `#[cfg(test)]`):
+
+```rust
+pub fn parse(words: &str) -> Result<Mnemonic, MnemonicError> {
+    // BIP-39 §3.1 standardizes Unicode NFKD normalization on the phrase.
+    let nfkd: String = words.nfkd().collect();
+    let normalized = nfkd
+        .split_whitespace()
+        .map(|w| w.to_lowercase())
+        .collect::<Vec<_>>()
+        .join(" ");
+
+    let word_count = normalized.split_whitespace().count();
+    if word_count != 24 {
+        return Err(MnemonicError::WrongLength { got: word_count });
+    }
+
+    let bip = Bip39Mnemonic::parse_in_normalized(bip39::Language::English, &normalized)
+        .map_err(map_bip39_error)?;
+
+    let entropy_bytes = bip.to_entropy_array().0;
+    let entropy: [u8; 32] = entropy_bytes
+        .as_ref()
+        .first_chunk::<32>()
+        .copied()
+        .expect("24-word BIP-39 produces 32 bytes of entropy");
+
+    Ok(Mnemonic {
+        phrase: bip.to_string(),
+        entropy: Sensitive::new(entropy),
+    })
+}
+
+fn map_bip39_error(e: bip39::Error) -> MnemonicError {
+    use bip39::Error::*;
+    match e {
+        UnknownWord(_idx) => {
+            // The bip39 crate reports the index of the bad word, not the word
+            // itself. Caller can re-tokenize to find the offending word if
+            // needed; for now we surface a generic placeholder.
+            MnemonicError::UnknownWord("(unknown)".to_string())
+        }
+        InvalidChecksum => MnemonicError::BadChecksum,
+        BadWordCount(n) => MnemonicError::WrongLength { got: n },
+        // Any other variant in this version of bip39: treat as checksum
+        // failure (the catch-all is safe — bad-input means rejection).
+        _ => MnemonicError::BadChecksum,
+    }
+}
+```
+
+- [ ] **Step 3.3: Run tests**
+
+Run: `cargo test -p secretary-core --release unlock::mnemonic::tests`
+Expected: all four tests PASS.
+
+- [ ] **Step 3.4: Commit**
+
+```bash
+git add core/src/unlock/mnemonic.rs
+git commit -m "feat(unlock): mnemonic::parse with NFKD normalization"
+```
+
+---
+
+## Task 4: `mnemonic::parse` — error variants
+
+**Files:**
+- Modify: `core/src/unlock/mnemonic.rs`
+
+- [ ] **Step 4.1: Write the failing tests**
+
+Append to `mod tests`:
+
+```rust
+#[test]
+fn parse_rejects_wrong_word_count() {
+    let err = parse("abandon abandon abandon").unwrap_err();
+    assert_eq!(err, MnemonicError::WrongLength { got: 3 });
+}
+
+#[test]
+fn parse_rejects_unknown_word() {
+    // 24 words, all "valid-looking" syntactically but one is not in the list.
+    // Take a real generated mnemonic and replace one word.
+    let mut rng = ChaCha20Rng::from_seed([99u8; 32]);
+    let m = generate(&mut rng);
+    let mut words: Vec<&str> = m.phrase().split_whitespace().collect();
+    words[5] = "notarealbip39word";
+    let bad = words.join(" ");
+    let err = parse(&bad).unwrap_err();
+    assert!(matches!(err, MnemonicError::UnknownWord(_)));
+}
+
+#[test]
+fn parse_rejects_bad_checksum() {
+    // Take a valid mnemonic and swap two words from the wordlist — words
+    // remain in the list but the checksum no longer matches.
+    let mut rng = ChaCha20Rng::from_seed([100u8; 32]);
+    let m = generate(&mut rng);
+    let mut words: Vec<String> = m.phrase().split_whitespace().map(String::from).collect();
+    words.swap(0, 1);
+    let bad = words.join(" ");
+    // It's possible the swap yields a still-valid checksum; if so, swap a
+    // different pair. For a fixed seed this is deterministic; the asserted
+    // failure mode is "either BadChecksum or UnknownWord", never Ok.
+    let err = parse(&bad).unwrap_err();
+    assert!(
+        matches!(err, MnemonicError::BadChecksum | MnemonicError::UnknownWord(_)),
+        "expected BadChecksum or UnknownWord, got {err:?}",
+    );
+}
+```
+
+Run: `cargo test -p secretary-core --release unlock::mnemonic::tests::parse_rejects`
+Expected: PASS (the implementation in Task 3 already returns these variants).
+
+- [ ] **Step 4.2: Verify and commit**
+
+Run: `cargo test -p secretary-core --release unlock::mnemonic::tests`
+Expected: all 7 tests PASS.
+
+```bash
+git add core/src/unlock/mnemonic.rs
+git commit -m "test(unlock): mnemonic::parse error variants"
+```
+
+---
+
+## Task 5: `mnemonic` — entropy zeroization on drop
+
+**Files:**
+- Modify: `core/src/unlock/mnemonic.rs`
+
+- [ ] **Step 5.1: Add Drop impl for phrase zeroization**
+
+The `entropy` field is already `Sensitive<[u8;32]>` which zeroizes on drop. The `phrase` field is a `String` containing the human-readable mnemonic — it should also be zeroed when the `Mnemonic` is dropped (treating the phrase as sensitive).
+
+Add to `mnemonic.rs`:
+
+```rust
+impl Drop for Mnemonic {
+    fn drop(&mut self) {
+        // String doesn't have a stable zeroize-on-drop in std, but its
+        // backing Vec<u8> can be zeroed via the underlying buffer.
+        // SAFETY: we own the String; replacing its bytes does not affect
+        // any outstanding &str borrow because Drop runs after all borrows
+        // have ended.
+        let bytes = unsafe { self.phrase.as_bytes_mut() };
+        bytes.zeroize();
+    }
+}
+```
+
+Wait — `as_bytes_mut` is `unsafe` because writing arbitrary bytes can break UTF-8 invariants. We use it here for zeroization where `0x00` is valid UTF-8 (ASCII NUL), so the resulting String becomes a string of NULs — a valid (if odd) UTF-8 string. But the crate has `#![forbid(unsafe_code)]` at the root.
+
+Replace with a safe alternative — use the `zeroize` crate's String support (which does the same thing internally with the unsafe block scoped):
+
+```rust
+impl Drop for Mnemonic {
+    fn drop(&mut self) {
+        // `zeroize` provides a Zeroize impl for String that overwrites the
+        // underlying bytes. `Sensitive<[u8;32]>` handles the entropy field
+        // automatically.
+        self.phrase.zeroize();
+    }
+}
+```
+
+`zeroize::Zeroize` is implemented for `String` in zeroize ≥ 1.4. Verify in the existing `Cargo.lock` that the version supports it.
+
+- [ ] **Step 5.2: Add a smoke test for Drop semantics**
+
+This is a structural test — we can't directly observe zeroization without unsafe pointer reads, so the test only confirms the impl compiles and behaves on a fresh value:
+
+```rust
+#[test]
+fn mnemonic_drop_compiles() {
+    // Compile-time check that `Mnemonic` has a Drop impl that runs on
+    // scope exit. There is no observable behavior to assert without
+    // reading freed memory; the value of this test is the implicit
+    // "must call Drop" requirement on the type.
+    let mut rng = ChaCha20Rng::from_seed([0u8; 32]);
+    let _m = generate(&mut rng);
+    // _m drops here — Drop runs.
+}
+```
+
+- [ ] **Step 5.3: Run all mnemonic tests + clippy**
+
+Run: `cargo test -p secretary-core --release unlock::mnemonic::tests`
+Expected: 8 tests PASS.
+
+Run: `cargo clippy -p secretary-core --all-targets -- -D warnings`
+Expected: clean.
+
+- [ ] **Step 5.4: Commit**
+
+```bash
+git add core/src/unlock/mnemonic.rs
+git commit -m "feat(unlock): zeroize Mnemonic phrase + entropy on drop"
+```
+
+---
+
+## Task 6: `bundle.rs` — `IdentityBundle` struct + generate
+
+**Files:**
+- Create: `core/src/unlock/bundle.rs`
+- Modify: `core/src/unlock/mod.rs` (add `pub mod bundle;`)
+
+- [ ] **Step 6.1: Inspect existing keypair generators**
+
+Read `core/src/crypto/sig.rs` and `core/src/crypto/kem.rs` to find the exact names and return types of:
+- X25519 keypair generation
+- ML-KEM-768 keypair generation
+- Ed25519 keypair generation
+- ML-DSA-65 keypair generation
+
+Pin those names; use them in Step 6.2. Do not invent names.
+
+- [ ] **Step 6.2: Write the failing test + struct**
+
+Create `core/src/unlock/bundle.rs`:
+
+```rust
+//! IdentityBundle plaintext (`docs/crypto-design.md` §5).
+//!
+//! The §5 record carries the four (sk, pk) pairs that constitute a user's
+//! cryptographic identity, plus a UUID, a display name, and a creation
+//! timestamp. Encoded as canonical CBOR per §6.2 (RFC 8949 §4.2.1).
+
+use rand_core::{CryptoRng, RngCore};
+
+use crate::crypto::secret::Sensitive;
+// ... import the keypair generators identified in Step 6.1 ...
+
+pub const USER_UUID_LEN: usize = 16;
+pub const X25519_SK_LEN: usize = 32;
+pub const X25519_PK_LEN: usize = 32;
+pub const ML_KEM_768_SK_LEN: usize = 2400;
+pub const ML_KEM_768_PK_LEN: usize = 1184;
+pub const ED25519_SK_LEN: usize = 32;
+pub const ED25519_PK_LEN: usize = 32;
+pub const ML_DSA_65_SK_LEN: usize = 4032;
+pub const ML_DSA_65_PK_LEN: usize = 1952;
+
+pub struct IdentityBundle {
+    pub user_uuid: [u8; USER_UUID_LEN],
+    pub display_name: String,
+    pub x25519_sk: Sensitive<[u8; X25519_SK_LEN]>,
+    pub x25519_pk: [u8; X25519_PK_LEN],
+    pub ml_kem_768_sk: Sensitive<Vec<u8>>,   // 2400 bytes; Vec since the
+                                              // RustCrypto type is sized via
+                                              // generic params, not const
+    pub ml_kem_768_pk: Vec<u8>,               // 1184 bytes
+    pub ed25519_sk: Sensitive<[u8; ED25519_SK_LEN]>,
+    pub ed25519_pk: [u8; ED25519_PK_LEN],
+    pub ml_dsa_65_sk: Sensitive<Vec<u8>>,     // 4032 bytes
+    pub ml_dsa_65_pk: Vec<u8>,                // 1952 bytes
+    pub created_at_ms: u64,
+}
+
+pub fn generate(
+    display_name: &str,
+    created_at_ms: u64,
+    rng: &mut (impl RngCore + CryptoRng),
+) -> IdentityBundle {
+    let mut user_uuid = [0u8; USER_UUID_LEN];
+    rng.fill_bytes(&mut user_uuid);
+
+    // Use the existing crypto::sig and crypto::kem generators identified
+    // in Step 6.1. Each returns (sk, pk) in some form; convert to the
+    // byte-array shape declared above.
+    todo!("call generate_x25519, generate_ml_kem_768, generate_ed25519, generate_ml_dsa_65 from rng")
+}
+```
+
+Add a test:
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rand_chacha::{rand_core::SeedableRng, ChaCha20Rng};
+
+    #[test]
+    fn generate_produces_consistent_keypairs() {
+        let mut rng = ChaCha20Rng::from_seed([5u8; 32]);
+        let b = generate("Alice", 1_714_060_800_000, &mut rng);
+
+        assert_eq!(b.display_name, "Alice");
+        assert_eq!(b.created_at_ms, 1_714_060_800_000);
+        assert_eq!(b.x25519_sk.expose().len(), X25519_SK_LEN);
+        assert_eq!(b.x25519_pk.len(), X25519_PK_LEN);
+        assert_eq!(b.ml_kem_768_sk.expose().len(), ML_KEM_768_SK_LEN);
+        assert_eq!(b.ml_kem_768_pk.len(), ML_KEM_768_PK_LEN);
+        assert_eq!(b.ed25519_sk.expose().len(), ED25519_SK_LEN);
+        assert_eq!(b.ed25519_pk.len(), ED25519_PK_LEN);
+        assert_eq!(b.ml_dsa_65_sk.expose().len(), ML_DSA_65_SK_LEN);
+        assert_eq!(b.ml_dsa_65_pk.len(), ML_DSA_65_PK_LEN);
+    }
+}
+```
+
+In `core/src/unlock/mod.rs`:
+
+```rust
+pub mod mnemonic;
+pub mod bundle;
+```
+
+Run: `cargo test -p secretary-core --release unlock::bundle::tests`
+Expected: FAIL (compile error, `todo!()` in `generate`).
+
+- [ ] **Step 6.3: Replace `todo!()` with real keypair generation**
+
+Using the names identified in Step 6.1, fill in the four keypair calls. For each, the pattern is:
+```rust
+let (sk, pk) = generate_xxx(rng);
+let xxx_sk = Sensitive::new(sk_bytes_array_or_vec);
+let xxx_pk = pk_bytes_array_or_vec;
+```
+
+If a generator already returns `Sensitive<...>` for the secret key, use it directly without re-wrapping.
+
+Run: `cargo test -p secretary-core --release unlock::bundle::tests`
+Expected: PASS.
+
+- [ ] **Step 6.4: Commit**
+
+```bash
+git add core/src/unlock/bundle.rs core/src/unlock/mod.rs
+git commit -m "feat(unlock): IdentityBundle struct + generate"
+```
+
+---
+
+## Task 7: `bundle.rs` — `to_canonical_cbor`
+
+**Files:**
+- Modify: `core/src/unlock/bundle.rs`
+
+- [ ] **Step 7.1: Write the failing test**
+
+Append to `mod tests`:
+
+```rust
+#[test]
+fn canonical_cbor_roundtrip() {
+    let mut rng = ChaCha20Rng::from_seed([6u8; 32]);
+    let b = generate("Bob", 1_714_060_800_001, &mut rng);
+    let bytes = b.to_canonical_cbor().expect("encode");
+    let parsed = IdentityBundle::from_canonical_cbor(&bytes).expect("decode");
+    // Equality comparison: secret-key sensitive fields don't impl PartialEq,
+    // so compare exposed contents explicitly.
+    assert_eq!(parsed.user_uuid, b.user_uuid);
+    assert_eq!(parsed.display_name, b.display_name);
+    assert_eq!(parsed.x25519_sk.expose(), b.x25519_sk.expose());
+    assert_eq!(parsed.x25519_pk, b.x25519_pk);
+    assert_eq!(parsed.ml_kem_768_sk.expose(), b.ml_kem_768_sk.expose());
+    assert_eq!(parsed.ml_kem_768_pk, b.ml_kem_768_pk);
+    assert_eq!(parsed.ed25519_sk.expose(), b.ed25519_sk.expose());
+    assert_eq!(parsed.ed25519_pk, b.ed25519_pk);
+    assert_eq!(parsed.ml_dsa_65_sk.expose(), b.ml_dsa_65_sk.expose());
+    assert_eq!(parsed.ml_dsa_65_pk, b.ml_dsa_65_pk);
+    assert_eq!(parsed.created_at_ms, b.created_at_ms);
+}
+
+#[test]
+fn canonical_cbor_is_byte_stable() {
+    let mut rng = ChaCha20Rng::from_seed([6u8; 32]);
+    let b = generate("Bob", 1_714_060_800_001, &mut rng);
+    let bytes_1 = b.to_canonical_cbor().expect("encode");
+    let bytes_2 = b.to_canonical_cbor().expect("encode");
+    assert_eq!(bytes_1, bytes_2, "canonical encoding must be deterministic");
+}
+```
+
+Run: expected FAIL (`to_canonical_cbor` and `from_canonical_cbor` do not exist).
+
+- [ ] **Step 7.2: Implement encoder + decoder**
+
+Use the same pattern as `core/src/identity/card.rs`: build a `ciborium::Value::Map` with bytewise-lex-sorted keys, write with `ciborium::ser::into_writer`, and on decode walk the map enforcing strict canonical form.
+
+Add to `bundle.rs` (above `#[cfg(test)]`):
+
+```rust
+use ciborium::Value;
+
+#[derive(Debug, thiserror::Error)]
+pub enum BundleError {
+    #[error("CBOR encode/decode error: {0}")]
+    CborDecode(String),
+    #[error("input was not in canonical CBOR form")]
+    NonCanonicalCbor,
+    #[error("unknown bundle field: {0}")]
+    UnknownField(String),
+    #[error("duplicate field: {0}")]
+    DuplicateField(String),
+    #[error("wrong key size for {field}: expected {expected}, got {got}")]
+    WrongKeySize { field: &'static str, expected: usize, got: usize },
+    #[error("invalid UUID")]
+    InvalidUuid,
+    #[error("invalid timestamp")]
+    InvalidTimestamp,
+}
+
+const KEY_USER_UUID: &str = "user_uuid";
+const KEY_DISPLAY_NAME: &str = "display_name";
+const KEY_X25519_SK: &str = "x25519_sk";
+const KEY_X25519_PK: &str = "x25519_pk";
+const KEY_ML_KEM_768_SK: &str = "ml_kem_768_sk";
+const KEY_ML_KEM_768_PK: &str = "ml_kem_768_pk";
+const KEY_ED25519_SK: &str = "ed25519_sk";
+const KEY_ED25519_PK: &str = "ed25519_pk";
+const KEY_ML_DSA_65_SK: &str = "ml_dsa_65_sk";
+const KEY_ML_DSA_65_PK: &str = "ml_dsa_65_pk";
+const KEY_CREATED_AT: &str = "created_at";
+
+impl IdentityBundle {
+    pub fn to_canonical_cbor(&self) -> Result<Vec<u8>, BundleError> {
+        // Sort key/value pairs bytewise lexicographically by key (RFC 8949
+        // §4.2.1). For all-tstr keys: shorter first, then lex compare.
+        let mut entries: Vec<(Value, Value)> = vec![
+            (Value::Text(KEY_USER_UUID.into()), Value::Bytes(self.user_uuid.to_vec())),
+            (Value::Text(KEY_DISPLAY_NAME.into()), Value::Text(self.display_name.clone())),
+            (Value::Text(KEY_X25519_SK.into()), Value::Bytes(self.x25519_sk.expose().to_vec())),
+            (Value::Text(KEY_X25519_PK.into()), Value::Bytes(self.x25519_pk.to_vec())),
+            (Value::Text(KEY_ML_KEM_768_SK.into()), Value::Bytes(self.ml_kem_768_sk.expose().clone())),
+            (Value::Text(KEY_ML_KEM_768_PK.into()), Value::Bytes(self.ml_kem_768_pk.clone())),
+            (Value::Text(KEY_ED25519_SK.into()), Value::Bytes(self.ed25519_sk.expose().to_vec())),
+            (Value::Text(KEY_ED25519_PK.into()), Value::Bytes(self.ed25519_pk.to_vec())),
+            (Value::Text(KEY_ML_DSA_65_SK.into()), Value::Bytes(self.ml_dsa_65_sk.expose().clone())),
+            (Value::Text(KEY_ML_DSA_65_PK.into()), Value::Bytes(self.ml_dsa_65_pk.clone())),
+            (Value::Text(KEY_CREATED_AT.into()), Value::Integer(self.created_at_ms.into())),
+        ];
+        entries.sort_by(|a, b| canonical_key_cmp(&a.0, &b.0));
+
+        let mut buf = Vec::new();
+        ciborium::ser::into_writer(&Value::Map(entries), &mut buf)
+            .map_err(|e| BundleError::CborDecode(e.to_string()))?;
+        Ok(buf)
+    }
+
+    pub fn from_canonical_cbor(bytes: &[u8]) -> Result<Self, BundleError> {
+        // Strict canonical-input rule, mirroring `card.rs`.
+        let value: Value = ciborium::de::from_reader(bytes)
+            .map_err(|e| BundleError::CborDecode(e.to_string()))?;
+        let Value::Map(entries) = value else {
+            return Err(BundleError::CborDecode("expected map".into()));
+        };
+
+        // Reject non-canonical key order
+        let mut sorted = entries.clone();
+        sorted.sort_by(|a, b| canonical_key_cmp(&a.0, &b.0));
+        if sorted != entries {
+            return Err(BundleError::NonCanonicalCbor);
+        }
+
+        // Walk entries; reject duplicates and unknown fields.
+        let mut user_uuid: Option<[u8; USER_UUID_LEN]> = None;
+        let mut display_name: Option<String> = None;
+        let mut x25519_sk: Option<[u8; X25519_SK_LEN]> = None;
+        let mut x25519_pk: Option<[u8; X25519_PK_LEN]> = None;
+        let mut ml_kem_768_sk: Option<Vec<u8>> = None;
+        let mut ml_kem_768_pk: Option<Vec<u8>> = None;
+        let mut ed25519_sk: Option<[u8; ED25519_SK_LEN]> = None;
+        let mut ed25519_pk: Option<[u8; ED25519_PK_LEN]> = None;
+        let mut ml_dsa_65_sk: Option<Vec<u8>> = None;
+        let mut ml_dsa_65_pk: Option<Vec<u8>> = None;
+        let mut created_at_ms: Option<u64> = None;
+
+        for (k, v) in entries {
+            let Value::Text(key) = k else {
+                return Err(BundleError::CborDecode("non-text map key".into()));
+            };
+            // (continue with one match arm per known KEY_* constant; per arm,
+            // call set_once_*() helpers to guard against duplicates and
+            // wrong-type/wrong-size; on default arm return UnknownField.)
+            // For brevity in this plan: implement following the exact pattern
+            // in `core/src/identity/card.rs::from_canonical_cbor`.
+            todo!("walk entries — pattern from card.rs::from_canonical_cbor")
+        }
+        todo!("collect all fields, return constructed IdentityBundle or specific BundleError")
+    }
+}
+
+fn canonical_key_cmp(a: &Value, b: &Value) -> std::cmp::Ordering {
+    let mut a_buf = Vec::new();
+    let mut b_buf = Vec::new();
+    let _ = ciborium::ser::into_writer(a, &mut a_buf);
+    let _ = ciborium::ser::into_writer(b, &mut b_buf);
+    a_buf.cmp(&b_buf)
+}
+```
+
+Replace the `todo!()` calls with the literal pattern from `core/src/identity/card.rs` (lines around the `from_canonical_cbor` impl). Mirror it field-for-field.
+
+Run: `cargo test -p secretary-core --release unlock::bundle::tests`
+Expected: 3 tests PASS (generate_produces, canonical_cbor_roundtrip, canonical_cbor_is_byte_stable).
+
+- [ ] **Step 7.3: Commit**
+
+```bash
+git add core/src/unlock/bundle.rs
+git commit -m "feat(unlock): IdentityBundle canonical CBOR encode/decode"
+```
+
+---
+
+## Task 8: `bundle.rs` — strict-decoder error variants
+
+**Files:**
+- Modify: `core/src/unlock/bundle.rs`
+
+- [ ] **Step 8.1: Write the failing tests**
+
+Append to `mod tests`. Mirror `core/tests/identity.rs::card_parse_rejects_*`:
+
+```rust
+#[test]
+fn parse_rejects_unknown_field() {
+    use ciborium::Value;
+    let mut entries = vec![
+        (Value::Text(KEY_USER_UUID.into()), Value::Bytes(vec![0u8; 16])),
+        (Value::Text("rogue".into()), Value::Text("payload".into())),
+    ];
+    entries.sort_by(|a, b| super::canonical_key_cmp(&a.0, &b.0));
+    let mut buf = Vec::new();
+    ciborium::ser::into_writer(&Value::Map(entries), &mut buf).unwrap();
+    let err = IdentityBundle::from_canonical_cbor(&buf).unwrap_err();
+    assert!(matches!(err, BundleError::UnknownField(s) if s == "rogue"));
+}
+
+#[test]
+fn parse_rejects_duplicate_field() {
+    use ciborium::Value;
+    let entries = vec![
+        (Value::Text(KEY_DISPLAY_NAME.into()), Value::Text("Alice".into())),
+        (Value::Text(KEY_DISPLAY_NAME.into()), Value::Text("Bob".into())),
+    ];
+    let mut buf = Vec::new();
+    ciborium::ser::into_writer(&Value::Map(entries), &mut buf).unwrap();
+    let err = IdentityBundle::from_canonical_cbor(&buf).unwrap_err();
+    assert!(matches!(err, BundleError::DuplicateField(s) if s == "display_name"));
+}
+
+#[test]
+fn parse_rejects_wrong_x25519_pk_size() {
+    use ciborium::Value;
+    // Build a full-shape map but with x25519_pk truncated to 30 bytes.
+    let mut rng = ChaCha20Rng::from_seed([8u8; 32]);
+    let b = generate("X", 0, &mut rng);
+    let bytes = b.to_canonical_cbor().unwrap();
+    let value: Value = ciborium::de::from_reader(&bytes[..]).unwrap();
+    let Value::Map(mut entries) = value else { panic!() };
+    for (k, v) in entries.iter_mut() {
+        if let Value::Text(s) = k {
+            if s == KEY_X25519_PK {
+                *v = Value::Bytes(vec![0u8; 30]);
+            }
+        }
+    }
+    let mut buf = Vec::new();
+    ciborium::ser::into_writer(&Value::Map(entries), &mut buf).unwrap();
+    let err = IdentityBundle::from_canonical_cbor(&buf).unwrap_err();
+    assert!(matches!(
+        err,
+        BundleError::WrongKeySize { field: "x25519_pk", expected: 32, got: 30 }
+    ));
+}
+
+#[test]
+fn parse_rejects_non_canonical_key_order() {
+    use ciborium::Value;
+    // Emit fields in spec listing order — which is NOT canonical.
+    let mut rng = ChaCha20Rng::from_seed([9u8; 32]);
+    let b = generate("X", 0, &mut rng);
+    let entries: Vec<(Value, Value)> = vec![
+        (Value::Text(KEY_USER_UUID.into()), Value::Bytes(b.user_uuid.to_vec())),
+        (Value::Text(KEY_DISPLAY_NAME.into()), Value::Text(b.display_name.clone())),
+        (Value::Text(KEY_X25519_SK.into()), Value::Bytes(b.x25519_sk.expose().to_vec())),
+        (Value::Text(KEY_X25519_PK.into()), Value::Bytes(b.x25519_pk.to_vec())),
+        (Value::Text(KEY_ML_KEM_768_SK.into()), Value::Bytes(b.ml_kem_768_sk.expose().clone())),
+        (Value::Text(KEY_ML_KEM_768_PK.into()), Value::Bytes(b.ml_kem_768_pk.clone())),
+        (Value::Text(KEY_ED25519_SK.into()), Value::Bytes(b.ed25519_sk.expose().to_vec())),
+        (Value::Text(KEY_ED25519_PK.into()), Value::Bytes(b.ed25519_pk.to_vec())),
+        (Value::Text(KEY_ML_DSA_65_SK.into()), Value::Bytes(b.ml_dsa_65_sk.expose().clone())),
+        (Value::Text(KEY_ML_DSA_65_PK.into()), Value::Bytes(b.ml_dsa_65_pk.clone())),
+        (Value::Text(KEY_CREATED_AT.into()), Value::Integer(b.created_at_ms.into())),
+    ];
+    let mut buf = Vec::new();
+    ciborium::ser::into_writer(&Value::Map(entries), &mut buf).unwrap();
+    let err = IdentityBundle::from_canonical_cbor(&buf).unwrap_err();
+    assert!(matches!(err, BundleError::NonCanonicalCbor));
+}
+```
+
+(Need to make `canonical_key_cmp` `pub(super)` for the test, or duplicate it inline.)
+
+- [ ] **Step 8.2: Implement / verify the strict-decode branches**
+
+The implementation in Task 7 should already hit each of these. If a test fails, implement the missing guard.
+
+Run: `cargo test -p secretary-core --release unlock::bundle::tests`
+Expected: 7 tests PASS.
+
+- [ ] **Step 8.3: Commit**
+
+```bash
+git add core/src/unlock/bundle.rs
+git commit -m "test(unlock): IdentityBundle strict decoder error coverage"
+```
+
+---
+
+## Task 9: `bundle_file.rs` — `BundleFile` struct + encode
+
+**Files:**
+- Create: `core/src/unlock/bundle_file.rs`
+- Modify: `core/src/unlock/mod.rs` (add `pub mod bundle_file;`)
+
+- [ ] **Step 9.1: Write the failing test**
+
+Create `core/src/unlock/bundle_file.rs`:
+
+```rust
+//! `identity.bundle.enc` binary envelope (`docs/vault-format.md` §3).
+//!
+//! Big-endian integers throughout. Three AEAD payloads (wrap_pw, wrap_rec,
+//! bundle), each stored as `nonce || ct_len || ct_with_tag`, where
+//! ct_with_tag is the AEAD ciphertext concatenated with its 16-byte
+//! Poly1305 tag (matching `crypto::aead::encrypt`'s output format).
+
+pub const MAGIC: u32 = 0x53454352;             // "SECR"
+pub const FORMAT_VERSION_V1: u16 = 0x0001;
+pub const FILE_KIND_IDENTITY_BUNDLE: u16 = 0x0001;
+pub const NONCE_LEN: usize = 24;
+pub const WRAP_CT_PLUS_TAG_LEN: usize = 32 + 16;  // identity_block_key + tag
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BundleFile {
+    pub vault_uuid: [u8; 16],
+    pub created_at_ms: u64,
+    pub wrap_pw_nonce: [u8; NONCE_LEN],
+    pub wrap_pw_ct_with_tag: [u8; WRAP_CT_PLUS_TAG_LEN],
+    pub wrap_rec_nonce: [u8; NONCE_LEN],
+    pub wrap_rec_ct_with_tag: [u8; WRAP_CT_PLUS_TAG_LEN],
+    pub bundle_nonce: [u8; NONCE_LEN],
+    pub bundle_ct_with_tag: Vec<u8>,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum BundleFileError {
+    #[error("file truncated at offset {offset}")]
+    Truncated { offset: usize },
+    #[error("bad magic: expected SECR, got {got:#010x}")]
+    BadMagic { got: u32 },
+    #[error("unsupported format version: {0}")]
+    UnsupportedFormatVersion(u16),
+    #[error("unsupported file kind: {0}")]
+    UnsupportedFileKind(u16),
+    #[error("declared length for {field} ({declared}) does not match expected (32)")]
+    WrapLengthMismatch { field: &'static str, declared: u32 },
+}
+
+pub fn encode(file: &BundleFile) -> Vec<u8> {
+    todo!("emit bytes per vault-format §3")
+}
+
+pub fn decode(bytes: &[u8]) -> Result<BundleFile, BundleFileError> {
+    todo!("parse bytes per vault-format §3")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample() -> BundleFile {
+        BundleFile {
+            vault_uuid: [0x11; 16],
+            created_at_ms: 1_714_060_800_000,
+            wrap_pw_nonce: [0x22; NONCE_LEN],
+            wrap_pw_ct_with_tag: [0x33; WRAP_CT_PLUS_TAG_LEN],
+            wrap_rec_nonce: [0x44; NONCE_LEN],
+            wrap_rec_ct_with_tag: [0x55; WRAP_CT_PLUS_TAG_LEN],
+            bundle_nonce: [0x66; NONCE_LEN],
+            bundle_ct_with_tag: vec![0x77; 200],
+        }
+    }
+
+    #[test]
+    fn encode_decode_roundtrip() {
+        let f = sample();
+        let bytes = encode(&f);
+        let parsed = decode(&bytes).expect("decode");
+        assert_eq!(parsed, f);
+    }
+}
+```
+
+In `core/src/unlock/mod.rs`:
+
+```rust
+pub mod mnemonic;
+pub mod bundle;
+pub mod bundle_file;
+```
+
+Run: expected FAIL.
+
+- [ ] **Step 9.2: Implement encode**
+
+Replace `encode` with:
+
+```rust
+pub fn encode(file: &BundleFile) -> Vec<u8> {
+    let mut out = Vec::with_capacity(
+        4 + 2 + 2 + 16 + 8
+            + NONCE_LEN + 4 + WRAP_CT_PLUS_TAG_LEN
+            + NONCE_LEN + 4 + WRAP_CT_PLUS_TAG_LEN
+            + NONCE_LEN + 4 + file.bundle_ct_with_tag.len()
+    );
+    out.extend_from_slice(&MAGIC.to_be_bytes());
+    out.extend_from_slice(&FORMAT_VERSION_V1.to_be_bytes());
+    out.extend_from_slice(&FILE_KIND_IDENTITY_BUNDLE.to_be_bytes());
+    out.extend_from_slice(&file.vault_uuid);
+    out.extend_from_slice(&file.created_at_ms.to_be_bytes());
+
+    out.extend_from_slice(&file.wrap_pw_nonce);
+    // wrap_pw_ct_len: u32 = 32 (the IdentityBlockKey size). Writing the
+    // unwrapped key length, NOT the ciphertext-with-tag length, per §3.
+    out.extend_from_slice(&32u32.to_be_bytes());
+    out.extend_from_slice(&file.wrap_pw_ct_with_tag);
+
+    out.extend_from_slice(&file.wrap_rec_nonce);
+    out.extend_from_slice(&32u32.to_be_bytes());
+    out.extend_from_slice(&file.wrap_rec_ct_with_tag);
+
+    out.extend_from_slice(&file.bundle_nonce);
+    // bundle_ct_len = length of the AEAD ciphertext including the 16-byte
+    // tag (the §3 "bundle_ct" field is the AEAD output as a single blob).
+    out.extend_from_slice(&u32::try_from(file.bundle_ct_with_tag.len())
+        .expect("bundle ct < 4 GiB").to_be_bytes());
+    out.extend_from_slice(&file.bundle_ct_with_tag);
+
+    out
+}
+```
+
+- [ ] **Step 9.3: Implement decode**
+
+Replace `decode` with a careful big-endian parser. Reads each field sequentially, returning `Truncated { offset }` on every short-read:
+
+```rust
+pub fn decode(bytes: &[u8]) -> Result<BundleFile, BundleFileError> {
+    let mut pos = 0;
+    let magic = read_u32_be(bytes, &mut pos)?;
+    if magic != MAGIC {
+        return Err(BundleFileError::BadMagic { got: magic });
+    }
+    let format_version = read_u16_be(bytes, &mut pos)?;
+    if format_version != FORMAT_VERSION_V1 {
+        return Err(BundleFileError::UnsupportedFormatVersion(format_version));
+    }
+    let file_kind = read_u16_be(bytes, &mut pos)?;
+    if file_kind != FILE_KIND_IDENTITY_BUNDLE {
+        return Err(BundleFileError::UnsupportedFileKind(file_kind));
+    }
+    let vault_uuid = read_array::<16>(bytes, &mut pos)?;
+    let created_at_ms = read_u64_be(bytes, &mut pos)?;
+
+    // wrap_pw
+    let wrap_pw_nonce = read_array::<NONCE_LEN>(bytes, &mut pos)?;
+    let wrap_pw_ct_len = read_u32_be(bytes, &mut pos)?;
+    if wrap_pw_ct_len != 32 {
+        return Err(BundleFileError::WrapLengthMismatch { field: "wrap_pw", declared: wrap_pw_ct_len });
+    }
+    let wrap_pw_ct_with_tag = read_array::<WRAP_CT_PLUS_TAG_LEN>(bytes, &mut pos)?;
+
+    // wrap_rec
+    let wrap_rec_nonce = read_array::<NONCE_LEN>(bytes, &mut pos)?;
+    let wrap_rec_ct_len = read_u32_be(bytes, &mut pos)?;
+    if wrap_rec_ct_len != 32 {
+        return Err(BundleFileError::WrapLengthMismatch { field: "wrap_rec", declared: wrap_rec_ct_len });
+    }
+    let wrap_rec_ct_with_tag = read_array::<WRAP_CT_PLUS_TAG_LEN>(bytes, &mut pos)?;
+
+    // bundle
+    let bundle_nonce = read_array::<NONCE_LEN>(bytes, &mut pos)?;
+    let bundle_ct_len = read_u32_be(bytes, &mut pos)? as usize;
+    if pos + bundle_ct_len > bytes.len() {
+        return Err(BundleFileError::Truncated { offset: pos });
+    }
+    let bundle_ct_with_tag = bytes[pos..pos + bundle_ct_len].to_vec();
+    pos += bundle_ct_len;
+
+    if pos != bytes.len() {
+        return Err(BundleFileError::Truncated { offset: pos });
+        // Trailing bytes treated as truncation indicator — file is wrong shape.
+    }
+
+    Ok(BundleFile {
+        vault_uuid,
+        created_at_ms,
+        wrap_pw_nonce,
+        wrap_pw_ct_with_tag,
+        wrap_rec_nonce,
+        wrap_rec_ct_with_tag,
+        bundle_nonce,
+        bundle_ct_with_tag,
+    })
+}
+
+fn read_u16_be(bytes: &[u8], pos: &mut usize) -> Result<u16, BundleFileError> {
+    let arr = read_array::<2>(bytes, pos)?;
+    Ok(u16::from_be_bytes(arr))
+}
+fn read_u32_be(bytes: &[u8], pos: &mut usize) -> Result<u32, BundleFileError> {
+    let arr = read_array::<4>(bytes, pos)?;
+    Ok(u32::from_be_bytes(arr))
+}
+fn read_u64_be(bytes: &[u8], pos: &mut usize) -> Result<u64, BundleFileError> {
+    let arr = read_array::<8>(bytes, pos)?;
+    Ok(u64::from_be_bytes(arr))
+}
+fn read_array<const N: usize>(bytes: &[u8], pos: &mut usize) -> Result<[u8; N], BundleFileError> {
+    if *pos + N > bytes.len() {
+        return Err(BundleFileError::Truncated { offset: *pos });
+    }
+    let mut out = [0u8; N];
+    out.copy_from_slice(&bytes[*pos..*pos + N]);
+    *pos += N;
+    Ok(out)
+}
+```
+
+- [ ] **Step 9.4: Run roundtrip test**
+
+Run: `cargo test -p secretary-core --release unlock::bundle_file::tests::encode_decode_roundtrip`
+Expected: PASS.
+
+- [ ] **Step 9.5: Commit**
+
+```bash
+git add core/src/unlock/bundle_file.rs core/src/unlock/mod.rs
+git commit -m "feat(unlock): bundle_file::encode + decode (vault-format §3)"
+```
+
+---
+
+## Task 10: `bundle_file.rs` — error variants
+
+**Files:**
+- Modify: `core/src/unlock/bundle_file.rs`
+
+- [ ] **Step 10.1: Write the failing tests**
+
+Append to `mod tests`:
+
+```rust
+#[test]
+fn decode_rejects_bad_magic() {
+    let mut bytes = encode(&sample());
+    bytes[0] ^= 0xFF;
+    let err = decode(&bytes).unwrap_err();
+    assert!(matches!(err, BundleFileError::BadMagic { .. }));
+}
+
+#[test]
+fn decode_rejects_bad_format_version() {
+    let mut bytes = encode(&sample());
+    bytes[5] = 0x02;  // bump format_version low byte from 0x01 to 0x02
+    let err = decode(&bytes).unwrap_err();
+    assert!(matches!(err, BundleFileError::UnsupportedFormatVersion(2)));
+}
+
+#[test]
+fn decode_rejects_bad_file_kind() {
+    let mut bytes = encode(&sample());
+    bytes[7] = 0x02;
+    let err = decode(&bytes).unwrap_err();
+    assert!(matches!(err, BundleFileError::UnsupportedFileKind(2)));
+}
+
+#[test]
+fn decode_rejects_truncated_at_every_boundary() {
+    let bytes = encode(&sample());
+    for n in 0..bytes.len() {
+        let truncated = &bytes[..n];
+        let result = decode(truncated);
+        assert!(
+            result.is_err(),
+            "decode must fail on slice [..{n}] of {} bytes",
+            bytes.len()
+        );
+    }
+    // Full bytes — should succeed
+    decode(&bytes).expect("full bytes decode");
+}
+
+#[test]
+fn decode_rejects_wrap_pw_length_mismatch() {
+    let bytes = encode(&sample());
+    // wrap_pw_ct_len starts at offset 4+2+2+16+8 + NONCE_LEN = 32 + 24 = 56
+    let mut tampered = bytes.clone();
+    tampered[56..60].copy_from_slice(&64u32.to_be_bytes());
+    let err = decode(&tampered).unwrap_err();
+    assert!(matches!(
+        err,
+        BundleFileError::WrapLengthMismatch { field: "wrap_pw", declared: 64 }
+    ));
+}
+```
+
+- [ ] **Step 10.2: Run the tests**
+
+Run: `cargo test -p secretary-core --release unlock::bundle_file::tests`
+Expected: 6 PASS.
+
+- [ ] **Step 10.3: Commit**
+
+```bash
+git add core/src/unlock/bundle_file.rs
+git commit -m "test(unlock): bundle_file decode rejects malformed input"
+```
+
+---
+
+## Task 11: `vault_toml.rs` — VaultToml + encode
+
+**Files:**
+- Create: `core/src/unlock/vault_toml.rs`
+- Modify: `core/src/unlock/mod.rs` (add `pub mod vault_toml;`)
+
+- [ ] **Step 11.1: Write the failing test**
+
+Create `core/src/unlock/vault_toml.rs`:
+
+```rust
+//! `vault.toml` cleartext metadata (`docs/vault-format.md` §2).
+
+use base64::{engine::general_purpose::STANDARD, Engine as _};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct VaultToml {
+    pub format_version: u16,
+    pub suite_id: u16,
+    pub vault_uuid: [u8; 16],
+    pub created_at_ms: u64,
+    pub kdf: KdfSection,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct KdfSection {
+    pub algorithm: String,        // must be "argon2id"
+    pub version: String,          // must be "1.3"
+    pub memory_kib: u32,
+    pub iterations: u32,
+    pub parallelism: u32,
+    pub salt: [u8; 32],
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum VaultTomlError {
+    #[error("malformed TOML: {0}")]
+    MalformedToml(String),
+    #[error("unknown key in [kdf] section: {0}")]
+    UnknownKdfKey(String),
+    #[error("unsupported format version: {0}")]
+    UnsupportedFormatVersion(u16),
+    #[error("unsupported suite id: {0}")]
+    UnsupportedSuiteId(u16),
+    #[error("unsupported KDF algorithm: {0}")]
+    UnsupportedKdfAlgorithm(String),
+    #[error("unsupported KDF version: {0}")]
+    UnsupportedKdfVersion(String),
+    #[error("invalid salt length: expected 32 bytes, got {got}")]
+    InvalidSaltLength { got: usize },
+    #[error("invalid UUID")]
+    InvalidUuid,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample() -> VaultToml {
+        VaultToml {
+            format_version: 1,
+            suite_id: 1,
+            vault_uuid: [0xAB; 16],
+            created_at_ms: 1_714_060_800_000,
+            kdf: KdfSection {
+                algorithm: "argon2id".to_string(),
+                version: "1.3".to_string(),
+                memory_kib: 262144,
+                iterations: 3,
+                parallelism: 1,
+                salt: [0xCD; 32],
+            },
+        }
+    }
+
+    #[test]
+    fn encode_decode_roundtrip() {
+        let v = sample();
+        let s = encode(&v);
+        let parsed = decode(&s).expect("decode");
+        assert_eq!(parsed, v);
+    }
+}
+```
+
+In `core/src/unlock/mod.rs`:
+
+```rust
+pub mod mnemonic;
+pub mod bundle;
+pub mod bundle_file;
+pub mod vault_toml;
+```
+
+Run: expected FAIL.
+
+- [ ] **Step 11.2: Implement encode**
+
+Use `toml::to_string` with a serializable wire-format struct:
+
+```rust
+#[derive(Serialize)]
+struct VaultTomlWire {
+    format_version: u16,
+    suite_id: u16,
+    vault_uuid: String,
+    created_at_ms: u64,
+    kdf: KdfSectionWire,
+}
+
+#[derive(Serialize)]
+struct KdfSectionWire {
+    algorithm: String,
+    version: String,
+    memory_kib: u32,
+    iterations: u32,
+    parallelism: u32,
+    salt_b64: String,
+}
+
+pub fn encode(v: &VaultToml) -> String {
+    let wire = VaultTomlWire {
+        format_version: v.format_version,
+        suite_id: v.suite_id,
+        vault_uuid: format_uuid_canonical(&v.vault_uuid),
+        created_at_ms: v.created_at_ms,
+        kdf: KdfSectionWire {
+            algorithm: v.kdf.algorithm.clone(),
+            version: v.kdf.version.clone(),
+            memory_kib: v.kdf.memory_kib,
+            iterations: v.kdf.iterations,
+            parallelism: v.kdf.parallelism,
+            salt_b64: STANDARD.encode(v.kdf.salt),
+        },
+    };
+    toml::to_string(&wire).expect("serializing primitive types cannot fail")
+}
+
+fn format_uuid_canonical(bytes: &[u8; 16]) -> String {
+    // 8-4-4-4-12 hex grouping with hyphens — RFC 4122 textual form.
+    let h = bytes.iter().map(|b| format!("{:02x}", b)).collect::<String>();
+    format!("{}-{}-{}-{}-{}", &h[0..8], &h[8..12], &h[12..16], &h[16..20], &h[20..32])
+}
+```
+
+- [ ] **Step 11.3: Implement decode (happy path only for now)**
+
+```rust
+pub fn decode(s: &str) -> Result<VaultToml, VaultTomlError> {
+    use toml::Value;
+
+    let value: Value = toml::from_str(s).map_err(|e| VaultTomlError::MalformedToml(e.to_string()))?;
+    let table = value.as_table().ok_or_else(|| VaultTomlError::MalformedToml("expected table".into()))?;
+
+    let format_version = table.get("format_version").and_then(Value::as_integer)
+        .ok_or_else(|| VaultTomlError::MalformedToml("format_version missing".into()))?;
+    let format_version = u16::try_from(format_version)
+        .map_err(|_| VaultTomlError::UnsupportedFormatVersion(0))?;
+    if format_version != 1 {
+        return Err(VaultTomlError::UnsupportedFormatVersion(format_version));
+    }
+
+    let suite_id = table.get("suite_id").and_then(Value::as_integer)
+        .ok_or_else(|| VaultTomlError::MalformedToml("suite_id missing".into()))?;
+    let suite_id = u16::try_from(suite_id)
+        .map_err(|_| VaultTomlError::UnsupportedSuiteId(0))?;
+    if suite_id != 1 {
+        return Err(VaultTomlError::UnsupportedSuiteId(suite_id));
+    }
+
+    let vault_uuid_str = table.get("vault_uuid").and_then(Value::as_str)
+        .ok_or_else(|| VaultTomlError::MalformedToml("vault_uuid missing".into()))?;
+    let vault_uuid = parse_uuid_canonical(vault_uuid_str)
+        .ok_or(VaultTomlError::InvalidUuid)?;
+
+    let created_at_ms = table.get("created_at_ms").and_then(Value::as_integer)
+        .ok_or_else(|| VaultTomlError::MalformedToml("created_at_ms missing".into()))?
+        as u64;
+
+    // Strict [kdf] decode: every key must be known.
+    let kdf_table = table.get("kdf").and_then(Value::as_table)
+        .ok_or_else(|| VaultTomlError::MalformedToml("[kdf] missing".into()))?;
+
+    const KNOWN_KDF_KEYS: &[&str] = &[
+        "algorithm", "version", "memory_kib", "iterations", "parallelism", "salt_b64",
+    ];
+    for k in kdf_table.keys() {
+        if !KNOWN_KDF_KEYS.contains(&k.as_str()) {
+            return Err(VaultTomlError::UnknownKdfKey(k.clone()));
+        }
+    }
+
+    let algorithm = kdf_table.get("algorithm").and_then(Value::as_str)
+        .ok_or_else(|| VaultTomlError::MalformedToml("kdf.algorithm missing".into()))?
+        .to_string();
+    if algorithm != "argon2id" {
+        return Err(VaultTomlError::UnsupportedKdfAlgorithm(algorithm));
+    }
+
+    let version = kdf_table.get("version").and_then(Value::as_str)
+        .ok_or_else(|| VaultTomlError::MalformedToml("kdf.version missing".into()))?
+        .to_string();
+    if version != "1.3" {
+        return Err(VaultTomlError::UnsupportedKdfVersion(version));
+    }
+
+    let memory_kib = kdf_table.get("memory_kib").and_then(Value::as_integer)
+        .ok_or_else(|| VaultTomlError::MalformedToml("kdf.memory_kib missing".into()))? as u32;
+    let iterations = kdf_table.get("iterations").and_then(Value::as_integer)
+        .ok_or_else(|| VaultTomlError::MalformedToml("kdf.iterations missing".into()))? as u32;
+    let parallelism = kdf_table.get("parallelism").and_then(Value::as_integer)
+        .ok_or_else(|| VaultTomlError::MalformedToml("kdf.parallelism missing".into()))? as u32;
+
+    let salt_b64 = kdf_table.get("salt_b64").and_then(Value::as_str)
+        .ok_or_else(|| VaultTomlError::MalformedToml("kdf.salt_b64 missing".into()))?;
+    let salt_vec = STANDARD.decode(salt_b64)
+        .map_err(|e| VaultTomlError::MalformedToml(format!("salt_b64: {e}")))?;
+    let salt: [u8; 32] = salt_vec.as_slice().try_into()
+        .map_err(|_| VaultTomlError::InvalidSaltLength { got: salt_vec.len() })?;
+
+    Ok(VaultToml {
+        format_version,
+        suite_id,
+        vault_uuid,
+        created_at_ms,
+        kdf: KdfSection {
+            algorithm,
+            version,
+            memory_kib,
+            iterations,
+            parallelism,
+            salt,
+        },
+    })
+}
+
+fn parse_uuid_canonical(s: &str) -> Option<[u8; 16]> {
+    // Accept "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" form only.
+    let stripped: String = s.chars().filter(|c| *c != '-').collect();
+    if stripped.len() != 32 {
+        return None;
+    }
+    let mut out = [0u8; 16];
+    for i in 0..16 {
+        let byte = u8::from_str_radix(&stripped[i*2..i*2+2], 16).ok()?;
+        out[i] = byte;
+    }
+    Some(out)
+}
+```
+
+- [ ] **Step 11.4: Run the roundtrip test**
+
+Run: `cargo test -p secretary-core --release unlock::vault_toml::tests::encode_decode_roundtrip`
+Expected: PASS.
+
+- [ ] **Step 11.5: Commit**
+
+```bash
+git add core/src/unlock/vault_toml.rs core/src/unlock/mod.rs
+git commit -m "feat(unlock): vault_toml::encode + decode (vault-format §2)"
+```
+
+---
+
+## Task 12: `vault_toml.rs` — error variants
+
+**Files:**
+- Modify: `core/src/unlock/vault_toml.rs`
+
+- [ ] **Step 12.1: Write the failing tests**
+
+Append to `mod tests`:
+
+```rust
+#[test]
+fn decode_ignores_unknown_top_level_key() {
+    let mut s = encode(&sample());
+    s.push_str("\nfuture_key = \"some value\"\n");
+    let parsed = decode(&s).expect("unknown top-level key must be ignored");
+    assert_eq!(parsed, sample());
+}
+
+#[test]
+fn decode_rejects_unknown_kdf_key() {
+    let mut s = encode(&sample());
+    // Inject a rogue key inside [kdf]
+    s.push_str("\nrogue_param = 42\n");
+    let err = decode(&s).unwrap_err();
+    assert!(matches!(err, VaultTomlError::UnknownKdfKey(s) if s == "rogue_param"));
+}
+
+#[test]
+fn decode_rejects_unsupported_format_version() {
+    let s = encode(&sample()).replace("format_version = 1", "format_version = 2");
+    let err = decode(&s).unwrap_err();
+    assert!(matches!(err, VaultTomlError::UnsupportedFormatVersion(2)));
+}
+
+#[test]
+fn decode_rejects_unsupported_suite_id() {
+    let s = encode(&sample()).replace("suite_id = 1", "suite_id = 2");
+    let err = decode(&s).unwrap_err();
+    assert!(matches!(err, VaultTomlError::UnsupportedSuiteId(2)));
+}
+
+#[test]
+fn decode_rejects_wrong_kdf_algorithm() {
+    let s = encode(&sample()).replace("algorithm = \"argon2id\"", "algorithm = \"scrypt\"");
+    let err = decode(&s).unwrap_err();
+    assert!(matches!(err, VaultTomlError::UnsupportedKdfAlgorithm(s) if s == "scrypt"));
+}
+
+#[test]
+fn decode_rejects_wrong_kdf_version() {
+    let s = encode(&sample()).replace("version = \"1.3\"", "version = \"1.0\"");
+    let err = decode(&s).unwrap_err();
+    assert!(matches!(err, VaultTomlError::UnsupportedKdfVersion(s) if s == "1.0"));
+}
+
+#[test]
+fn decode_rejects_short_salt() {
+    let mut v = sample();
+    let s = encode(&v);
+    // Replace the salt_b64 with a short value
+    let short_b64 = STANDARD.encode([0u8; 16]);
+    let original_b64 = STANDARD.encode([0xCD; 32]);
+    let s = s.replace(&original_b64, &short_b64);
+    let err = decode(&s).unwrap_err();
+    assert!(matches!(err, VaultTomlError::InvalidSaltLength { got: 16 }));
+    let _ = v;
+}
+```
+
+- [ ] **Step 12.2: Run + commit**
+
+Run: `cargo test -p secretary-core --release unlock::vault_toml::tests`
+Expected: 8 tests PASS.
+
+```bash
+git add core/src/unlock/vault_toml.rs
+git commit -m "test(unlock): vault_toml decode error coverage"
+```
+
+---
+
+## Task 13: `mod.rs` — `UnlockError` + `From` impls
+
+**Files:**
+- Modify: `core/src/unlock/mod.rs`
+
+- [ ] **Step 13.1: Add `UnlockError` enum**
+
+Append to `core/src/unlock/mod.rs`:
+
+```rust
+use crate::crypto::aead::AeadError;
+use crate::crypto::kdf::KdfError;
+
+#[derive(Debug, thiserror::Error)]
+pub enum UnlockError {
+    #[error("wrong password or vault corruption")]
+    WrongPasswordOrCorrupt,
+    #[error("wrong recovery mnemonic or vault corruption")]
+    WrongMnemonicOrCorrupt,
+    #[error("invalid mnemonic: {0}")]
+    InvalidMnemonic(#[from] mnemonic::MnemonicError),
+    #[error("vault data integrity failure")]
+    CorruptVault,
+    #[error("vault.toml and identity.bundle.enc reference different vaults")]
+    VaultMismatch,
+
+    #[error("malformed vault.toml: {0}")]
+    MalformedVaultToml(#[from] vault_toml::VaultTomlError),
+    #[error("malformed identity.bundle.enc: {0}")]
+    MalformedBundleFile(#[from] bundle_file::BundleFileError),
+    #[error("malformed identity bundle plaintext: {0}")]
+    MalformedBundle(#[from] bundle::BundleError),
+
+    #[error("KDF failure: {0}")]
+    KdfFailure(#[from] KdfError),
+    #[error("AEAD primitive failure")]
+    AeadFailure,
+}
+
+impl From<AeadError> for UnlockError {
+    fn from(_: AeadError) -> Self {
+        // AEAD primitive errors collapse to AeadFailure — see spec §Error model.
+        // Position-specific user-facing variants (WrongPasswordOrCorrupt etc.)
+        // are produced explicitly at call sites, not via From.
+        UnlockError::AeadFailure
+    }
+}
+```
+
+- [ ] **Step 13.2: Verify it compiles**
+
+Run: `cargo check -p secretary-core`
+Expected: clean.
+
+- [ ] **Step 13.3: Commit**
+
+```bash
+git add core/src/unlock/mod.rs
+git commit -m "feat(unlock): UnlockError enum with From impls"
+```
+
+---
+
+## Task 14: `mod.rs` — `create_vault`
+
+**Files:**
+- Modify: `core/src/unlock/mod.rs`
+
+- [ ] **Step 14.1: Write the failing test as an integration test stub**
+
+Append to `core/src/unlock/mod.rs`:
+
+```rust
+use rand_core::{CryptoRng, RngCore};
+
+use crate::crypto::aead::{decrypt, encrypt, AeadKey, AeadNonce, AEAD_TAG_LEN};
+use crate::crypto::kdf::{
+    derive_master_kek, derive_recovery_kek, Argon2idParams,
+    TAG_ID_BUNDLE, TAG_ID_WRAP_PW, TAG_ID_WRAP_REC,
+};
+use crate::crypto::secret::{SecretBytes, Sensitive};
+
+pub struct CreatedVault {
+    pub vault_toml_bytes: Vec<u8>,
+    pub identity_bundle_bytes: Vec<u8>,
+    pub recovery_mnemonic: mnemonic::Mnemonic,
+    pub identity_block_key: Sensitive<[u8; 32]>,
+    pub identity: bundle::IdentityBundle,
+}
+
+pub struct UnlockedIdentity {
+    pub identity_block_key: Sensitive<[u8; 32]>,
+    pub identity: bundle::IdentityBundle,
+}
+
+pub fn create_vault(
+    password: &SecretBytes,
+    display_name: &str,
+    created_at_ms: u64,
+    kdf_params: Argon2idParams,
+    rng: &mut (impl RngCore + CryptoRng),
+) -> Result<CreatedVault, UnlockError> {
+    todo!()
+}
+```
+
+In a new inline test module at the bottom of `mod.rs`:
+
+```rust
+#[cfg(test)]
+mod create_tests {
+    use super::*;
+    use crate::crypto::kdf::Argon2idParams;
+    use rand_chacha::{rand_core::SeedableRng, ChaCha20Rng};
+
+    #[test]
+    fn create_vault_produces_well_formed_artifacts() {
+        let mut rng = ChaCha20Rng::from_seed([42u8; 32]);
+        let password = SecretBytes::new(b"correct horse battery staple".to_vec());
+        // Use minimal Argon2id params for test speed (memory floor relaxed).
+        let params = Argon2idParams::new(8, 1, 1);
+        let v = create_vault(&password, "Alice", 1_714_060_800_000, params, &mut rng)
+            .expect("create_vault");
+        assert!(!v.vault_toml_bytes.is_empty());
+        assert!(!v.identity_bundle_bytes.is_empty());
+        assert_eq!(v.recovery_mnemonic.phrase().split_whitespace().count(), 24);
+        assert_eq!(v.identity.display_name, "Alice");
+    }
+}
+```
+
+Run: expected FAIL (`todo!()`).
+
+- [ ] **Step 14.2: Implement `create_vault`**
+
+Replace `todo!()`:
+
+```rust
+pub fn create_vault(
+    password: &SecretBytes,
+    display_name: &str,
+    created_at_ms: u64,
+    kdf_params: Argon2idParams,
+    rng: &mut (impl RngCore + CryptoRng),
+) -> Result<CreatedVault, UnlockError> {
+    // Step 1-2: identifiers and salt
+    let mut vault_uuid = [0u8; 16];
+    rng.fill_bytes(&mut vault_uuid);
+    let mut argon2_salt = [0u8; 32];
+    rng.fill_bytes(&mut argon2_salt);
+
+    // Step 3: Master KEK
+    let master_kek = derive_master_kek(password, &argon2_salt, &kdf_params)?;
+
+    // Step 4-5: mnemonic + Recovery KEK
+    let recovery_mnemonic = mnemonic::generate(rng);
+    let recovery_kek = derive_recovery_kek(recovery_mnemonic.entropy());
+
+    // Step 6: Identity Block Key
+    let mut ibk = [0u8; 32];
+    rng.fill_bytes(&mut ibk);
+    let identity_block_key = Sensitive::new(ibk);
+
+    // Step 7-8: identity + canonical CBOR
+    let identity = bundle::generate(display_name, created_at_ms, rng);
+    let bundle_plaintext = identity.to_canonical_cbor()?;
+
+    // Step 9: nonces
+    let mut nonce_id = [0u8; 24];
+    rng.fill_bytes(&mut nonce_id);
+    let mut nonce_pw = [0u8; 24];
+    rng.fill_bytes(&mut nonce_pw);
+    let mut nonce_rec = [0u8; 24];
+    rng.fill_bytes(&mut nonce_rec);
+
+    // Step 10: AEAD-encrypt bundle. `AeadKey` = `Sensitive<[u8;32]>`, and
+    // `identity_block_key` already has that type — pass by reference, no
+    // re-wrap needed. Same for master_kek and recovery_kek below.
+    let bundle_aad = compose_aad(TAG_ID_BUNDLE, &vault_uuid);
+    let bundle_ct_with_tag = encrypt(
+        &identity_block_key,
+        &nonce_id,
+        &bundle_aad,
+        &bundle_plaintext,
+    )?;
+
+    // Step 11: wrap_pw
+    let wrap_pw_aad = compose_aad(TAG_ID_WRAP_PW, &vault_uuid);
+    let wrap_pw_with_tag = encrypt(
+        &master_kek,
+        &nonce_pw,
+        &wrap_pw_aad,
+        identity_block_key.expose(),
+    )?;
+    let wrap_pw_arr: [u8; 48] = wrap_pw_with_tag.as_slice().try_into()
+        .expect("32-byte plaintext + 16-byte tag = 48 bytes");
+
+    // Step 12: wrap_rec
+    let wrap_rec_aad = compose_aad(TAG_ID_WRAP_REC, &vault_uuid);
+    let wrap_rec_with_tag = encrypt(
+        &recovery_kek,
+        &nonce_rec,
+        &wrap_rec_aad,
+        identity_block_key.expose(),
+    )?;
+    let wrap_rec_arr: [u8; 48] = wrap_rec_with_tag.as_slice().try_into()
+        .expect("32-byte plaintext + 16-byte tag = 48 bytes");
+
+    // Step 13: bundle_file
+    let bf = bundle_file::BundleFile {
+        vault_uuid,
+        created_at_ms,
+        wrap_pw_nonce: nonce_pw,
+        wrap_pw_ct_with_tag: wrap_pw_arr,
+        wrap_rec_nonce: nonce_rec,
+        wrap_rec_ct_with_tag: wrap_rec_arr,
+        bundle_nonce: nonce_id,
+        bundle_ct_with_tag,
+    };
+    let identity_bundle_bytes = bundle_file::encode(&bf);
+
+    // Step 14: vault_toml
+    let vt = vault_toml::VaultToml {
+        format_version: 1,
+        suite_id: 1,
+        vault_uuid,
+        created_at_ms,
+        kdf: vault_toml::KdfSection {
+            algorithm: "argon2id".to_string(),
+            version: "1.3".to_string(),
+            memory_kib: kdf_params.memory_kib,
+            iterations: kdf_params.iterations,
+            parallelism: kdf_params.parallelism,
+            salt: argon2_salt,
+        },
+    };
+    let vault_toml_bytes = vault_toml::encode(&vt).into_bytes();
+
+    // master_kek and recovery_kek go out of scope here → Sensitive Drop
+    // zeroizes them automatically. No explicit zeroize call required.
+
+    Ok(CreatedVault {
+        vault_toml_bytes,
+        identity_bundle_bytes,
+        recovery_mnemonic,
+        identity_block_key,
+        identity,
+    })
+}
+
+fn compose_aad(tag: &[u8], vault_uuid: &[u8; 16]) -> Vec<u8> {
+    let mut out = Vec::with_capacity(tag.len() + vault_uuid.len());
+    out.extend_from_slice(tag);
+    out.extend_from_slice(vault_uuid);
+    out
+}
+```
+
+- [ ] **Step 14.3: Run the test**
+
+Run: `cargo test -p secretary-core --release unlock::create_tests`
+Expected: PASS.
+
+- [ ] **Step 14.4: Commit**
+
+```bash
+git add core/src/unlock/mod.rs
+git commit -m "feat(unlock): create_vault — generate identity + dual-wrap"
+```
+
+---
+
+## Task 15: `mod.rs` — `open_with_password`
+
+**Files:**
+- Modify: `core/src/unlock/mod.rs`
+
+- [ ] **Step 15.1: Write the failing test**
+
+Append to `mod create_tests` (or a sibling `mod password_tests`):
+
+```rust
+#[test]
+fn create_then_open_with_password_roundtrips() {
+    let mut rng = ChaCha20Rng::from_seed([7u8; 32]);
+    let password = SecretBytes::new(b"hunter2".to_vec());
+    let params = Argon2idParams::new(8, 1, 1);
+    let v = create_vault(&password, "Alice", 0, params, &mut rng).unwrap();
+
+    let opened = open_with_password(&v.vault_toml_bytes, &v.identity_bundle_bytes, &password)
+        .expect("open");
+    assert_eq!(opened.identity_block_key.expose(), v.identity_block_key.expose());
+    assert_eq!(opened.identity.user_uuid, v.identity.user_uuid);
+    assert_eq!(opened.identity.display_name, v.identity.display_name);
+    assert_eq!(opened.identity.x25519_sk.expose(), v.identity.x25519_sk.expose());
+}
+
+#[test]
+fn open_with_wrong_password_returns_wrong_password_or_corrupt() {
+    let mut rng = ChaCha20Rng::from_seed([8u8; 32]);
+    let password = SecretBytes::new(b"hunter2".to_vec());
+    let params = Argon2idParams::new(8, 1, 1);
+    let v = create_vault(&password, "Alice", 0, params, &mut rng).unwrap();
+
+    let bad = SecretBytes::new(b"hunter3".to_vec());
+    let err = open_with_password(&v.vault_toml_bytes, &v.identity_bundle_bytes, &bad)
+        .unwrap_err();
+    assert!(matches!(err, UnlockError::WrongPasswordOrCorrupt));
+}
+```
+
+Run: expected FAIL (`open_with_password` not defined).
+
+- [ ] **Step 15.2: Implement `open_with_password`**
+
+```rust
+pub fn open_with_password(
+    vault_toml_bytes: &[u8],
+    identity_bundle_bytes: &[u8],
+    password: &SecretBytes,
+) -> Result<UnlockedIdentity, UnlockError> {
+    // Step 1: parse vault.toml (the From impl maps VaultTomlError into UnlockError)
+    let vt_str = std::str::from_utf8(vault_toml_bytes)
+        .map_err(|_| UnlockError::MalformedVaultToml(vault_toml::VaultTomlError::MalformedToml(
+            "non-UTF-8 input".to_string(),
+        )))?;
+    let vt = vault_toml::decode(vt_str)?;
+
+    // Step 2: parse identity.bundle.enc; check vault_uuid match
+    let bf = bundle_file::decode(identity_bundle_bytes)?;
+    if bf.vault_uuid != vt.vault_uuid {
+        return Err(UnlockError::VaultMismatch);
+    }
+
+    // Step 3: derive Master KEK
+    let kdf_params = Argon2idParams::new(vt.kdf.memory_kib, vt.kdf.iterations, vt.kdf.parallelism);
+    let master_kek = derive_master_kek(password, &vt.kdf.salt, &kdf_params)?;
+
+    // Step 4: AEAD-decrypt wrap_pw → identity_block_key
+    let wrap_pw_aad = compose_aad(TAG_ID_WRAP_PW, &vt.vault_uuid);
+    let ibk_bytes = decrypt(
+        &master_kek,
+        &bf.wrap_pw_nonce,
+        &wrap_pw_aad,
+        &bf.wrap_pw_ct_with_tag,
+    )
+    .map_err(|_| UnlockError::WrongPasswordOrCorrupt)?;
+
+    let ibk_arr: [u8; 32] = ibk_bytes.expose().try_into()
+        .map_err(|_| UnlockError::CorruptVault)?;
+    let identity_block_key = Sensitive::new(ibk_arr);
+
+    // Step 5: AEAD-decrypt bundle → plaintext
+    let bundle_aad = compose_aad(TAG_ID_BUNDLE, &vt.vault_uuid);
+    let bundle_plaintext = decrypt(
+        &identity_block_key,
+        &bf.bundle_nonce,
+        &bundle_aad,
+        &bf.bundle_ct_with_tag,
+    )
+    .map_err(|_| UnlockError::CorruptVault)?;
+
+    // Step 6: CBOR decode
+    let identity = bundle::IdentityBundle::from_canonical_cbor(bundle_plaintext.expose())?;
+
+    Ok(UnlockedIdentity { identity_block_key, identity })
+}
+```
+
+- [ ] **Step 15.3: Run the tests**
+
+Run: `cargo test -p secretary-core --release unlock::create_tests`
+Expected: 4 tests PASS (the 2 new + 2 from earlier).
+
+- [ ] **Step 15.4: Commit**
+
+```bash
+git add core/src/unlock/mod.rs
+git commit -m "feat(unlock): open_with_password"
+```
+
+---
+
+## Task 16: `mod.rs` — `open_with_recovery`
+
+**Files:**
+- Modify: `core/src/unlock/mod.rs`
+
+- [ ] **Step 16.1: Write the failing test**
+
+Append:
+
+```rust
+#[test]
+fn create_then_open_with_recovery_roundtrips() {
+    let mut rng = ChaCha20Rng::from_seed([9u8; 32]);
+    let password = SecretBytes::new(b"hunter2".to_vec());
+    let params = Argon2idParams::new(8, 1, 1);
+    let v = create_vault(&password, "Alice", 0, params, &mut rng).unwrap();
+
+    let words = v.recovery_mnemonic.phrase().to_string();
+    let opened = open_with_recovery(&v.vault_toml_bytes, &v.identity_bundle_bytes, &words)
+        .expect("open");
+    assert_eq!(opened.identity_block_key.expose(), v.identity_block_key.expose());
+    assert_eq!(opened.identity.user_uuid, v.identity.user_uuid);
+}
+
+#[test]
+fn open_with_wrong_mnemonic_returns_wrong_mnemonic_or_corrupt() {
+    let mut rng = ChaCha20Rng::from_seed([10u8; 32]);
+    let password = SecretBytes::new(b"hunter2".to_vec());
+    let params = Argon2idParams::new(8, 1, 1);
+    let v = create_vault(&password, "Alice", 0, params, &mut rng).unwrap();
+
+    // A different fresh mnemonic — valid checksum, just not this vault's.
+    let mut other_rng = ChaCha20Rng::from_seed([99u8; 32]);
+    let other = mnemonic::generate(&mut other_rng);
+    let err = open_with_recovery(&v.vault_toml_bytes, &v.identity_bundle_bytes, other.phrase())
+        .unwrap_err();
+    assert!(matches!(err, UnlockError::WrongMnemonicOrCorrupt));
+}
+
+#[test]
+fn open_with_invalid_mnemonic_returns_invalid_mnemonic() {
+    let mut rng = ChaCha20Rng::from_seed([11u8; 32]);
+    let v = create_vault(
+        &SecretBytes::new(b"x".to_vec()), "Alice", 0,
+        Argon2idParams::new(8, 1, 1), &mut rng,
+    ).unwrap();
+    let err = open_with_recovery(&v.vault_toml_bytes, &v.identity_bundle_bytes, "abandon abandon")
+        .unwrap_err();
+    assert!(matches!(err, UnlockError::InvalidMnemonic(mnemonic::MnemonicError::WrongLength { .. })));
+}
+
+#[test]
+fn both_unlock_paths_yield_same_identity_block_key() {
+    let mut rng = ChaCha20Rng::from_seed([12u8; 32]);
+    let password = SecretBytes::new(b"hunter2".to_vec());
+    let v = create_vault(&password, "Alice", 0, Argon2idParams::new(8, 1, 1), &mut rng).unwrap();
+
+    let by_pw = open_with_password(&v.vault_toml_bytes, &v.identity_bundle_bytes, &password).unwrap();
+    let by_rec = open_with_recovery(&v.vault_toml_bytes, &v.identity_bundle_bytes, v.recovery_mnemonic.phrase()).unwrap();
+    assert_eq!(by_pw.identity_block_key.expose(), by_rec.identity_block_key.expose());
+}
+```
+
+Run: expected FAIL.
+
+- [ ] **Step 16.2: Implement `open_with_recovery`**
+
+```rust
+pub fn open_with_recovery(
+    vault_toml_bytes: &[u8],
+    identity_bundle_bytes: &[u8],
+    mnemonic_words: &str,
+) -> Result<UnlockedIdentity, UnlockError> {
+    // Steps 1-2: vault.toml + bundle file (same as open_with_password)
+    let vt_str = std::str::from_utf8(vault_toml_bytes)
+        .map_err(|_| UnlockError::MalformedVaultToml(vault_toml::VaultTomlError::MalformedToml(
+            "non-UTF-8 input".to_string(),
+        )))?;
+    let vt = vault_toml::decode(vt_str)?;
+    let bf = bundle_file::decode(identity_bundle_bytes)?;
+    if bf.vault_uuid != vt.vault_uuid {
+        return Err(UnlockError::VaultMismatch);
+    }
+
+    // Step 3: parse mnemonic
+    let parsed = mnemonic::parse(mnemonic_words)?;
+
+    // Step 4: derive Recovery KEK
+    let recovery_kek = derive_recovery_kek(parsed.entropy());
+
+    // Step 5: AEAD-decrypt wrap_rec
+    let wrap_rec_aad = compose_aad(TAG_ID_WRAP_REC, &vt.vault_uuid);
+    let ibk_bytes = decrypt(
+        &recovery_kek,
+        &bf.wrap_rec_nonce,
+        &wrap_rec_aad,
+        &bf.wrap_rec_ct_with_tag,
+    )
+    .map_err(|_| UnlockError::WrongMnemonicOrCorrupt)?;
+
+    let ibk_arr: [u8; 32] = ibk_bytes.expose().try_into()
+        .map_err(|_| UnlockError::CorruptVault)?;
+    let identity_block_key = Sensitive::new(ibk_arr);
+
+    // Step 6: AEAD-decrypt bundle
+    let bundle_aad = compose_aad(TAG_ID_BUNDLE, &vt.vault_uuid);
+    let bundle_plaintext = decrypt(
+        &identity_block_key,
+        &bf.bundle_nonce,
+        &bundle_aad,
+        &bf.bundle_ct_with_tag,
+    )
+    .map_err(|_| UnlockError::CorruptVault)?;
+
+    let identity = bundle::IdentityBundle::from_canonical_cbor(bundle_plaintext.expose())?;
+    Ok(UnlockedIdentity { identity_block_key, identity })
+}
+```
+
+- [ ] **Step 16.3: Run the tests**
+
+Run: `cargo test -p secretary-core --release unlock::create_tests`
+Expected: 7 tests PASS.
+
+- [ ] **Step 16.4: Commit**
+
+```bash
+git add core/src/unlock/mod.rs
+git commit -m "feat(unlock): open_with_recovery"
+```
+
+---
+
+## Task 17: Integration tests — corruption + vault mismatch
+
+**Files:**
+- Create: `core/tests/unlock.rs`
+
+- [ ] **Step 17.1: Create the file**
+
+Create `core/tests/unlock.rs`:
+
+```rust
+//! Integration tests for the unlock module — exercises the public surface
+//! across realistic scenarios: corruption detection, vault mismatch, and the
+//! full create→open round-trip with both unlock paths.
+
+mod common;
+
+use rand_chacha::{rand_core::SeedableRng, ChaCha20Rng};
+
+use secretary_core::crypto::kdf::Argon2idParams;
+use secretary_core::crypto::secret::SecretBytes;
+use secretary_core::unlock::{
+    self, bundle_file, create_vault, open_with_password, open_with_recovery, UnlockError,
+};
+
+fn fast_params() -> Argon2idParams {
+    // Below v1 floor — only legal via Argon2idParams::new (not try_new_v1).
+    // Used here to keep tests fast (~ms instead of seconds).
+    Argon2idParams::new(8, 1, 1)
+}
+
+fn create(seed: u8, pw: &[u8]) -> unlock::CreatedVault {
+    let mut rng = ChaCha20Rng::from_seed([seed; 32]);
+    create_vault(
+        &SecretBytes::new(pw.to_vec()),
+        "Alice",
+        1_714_060_800_000,
+        fast_params(),
+        &mut rng,
+    )
+    .expect("create_vault")
+}
+
+#[test]
+fn flipped_bundle_ct_byte_returns_corrupt_vault() {
+    let pw = b"hunter2";
+    let v = create(1, pw);
+
+    // Decode the bundle file, flip a byte deep in bundle_ct_with_tag, re-encode.
+    let mut bf = bundle_file::decode(&v.identity_bundle_bytes).unwrap();
+    let mid = bf.bundle_ct_with_tag.len() / 2;
+    bf.bundle_ct_with_tag[mid] ^= 0xFF;
+    let tampered = bundle_file::encode(&bf);
+
+    let err = open_with_password(&v.vault_toml_bytes, &tampered, &SecretBytes::new(pw.to_vec()))
+        .unwrap_err();
+    // wrap_pw decrypts fine (we didn't touch it) → bundle AEAD fails →
+    // CorruptVault.
+    assert!(matches!(err, UnlockError::CorruptVault));
+}
+
+#[test]
+fn swapped_bundle_file_returns_vault_mismatch() {
+    let pw = b"hunter2";
+    let a = create(1, pw);
+    let b = create(2, pw);
+
+    // Open vault A's vault.toml with vault B's identity.bundle.enc.
+    let err = open_with_password(
+        &a.vault_toml_bytes, &b.identity_bundle_bytes,
+        &SecretBytes::new(pw.to_vec()),
+    ).unwrap_err();
+    assert!(matches!(err, UnlockError::VaultMismatch));
+}
+
+#[test]
+fn mnemonic_not_24_words_returns_invalid_mnemonic() {
+    let v = create(3, b"x");
+    let err = open_with_recovery(
+        &v.vault_toml_bytes, &v.identity_bundle_bytes,
+        "abandon abandon abandon",
+    ).unwrap_err();
+    assert!(matches!(err, UnlockError::InvalidMnemonic(_)));
+}
+```
+
+- [ ] **Step 17.2: Run**
+
+Run: `cargo test -p secretary-core --release --test unlock`
+Expected: 3 tests PASS.
+
+- [ ] **Step 17.3: Commit**
+
+```bash
+git add core/tests/unlock.rs
+git commit -m "test(unlock): integration — corruption, swap, mnemonic shape"
+```
+
+---
+
+## Task 18: BIP-39 recovery KAT — JSON file + KAT struct + test
+
+**Files:**
+- Create: `core/tests/data/bip39_recovery_kat.json`
+- Modify: `core/tests/common/mod.rs` (add `Bip39RecoveryKat` struct)
+- Modify: `core/tests/unlock.rs` (add `bip39_recovery_kat_vectors` test)
+
+- [ ] **Step 18.1: Compute the KAT vectors out-of-band**
+
+The KAT pins three relations:
+1. `mnemonic ↔ entropy` per BIP-39 English wordlist + checksum
+2. `entropy + info_tag → expected_recovery_kek` per HKDF-SHA-256 with `salt = [0u8;32]`
+3. `info_tag` is exactly the bytes of `b"secretary-v1-recovery-kek"`
+
+Use `uv` to run a Python script that produces all four vectors:
+
+```bash
+uv run --with bip39 --with cryptography python <<'PY'
+import json
+from bip39 import Mnemonic
+from cryptography.hazmat.primitives import hashes
+from cryptography.hazmat.primitives.kdf.hkdf import HKDF
+
+INFO = b"secretary-v1-recovery-kek"
+mnemo = Mnemonic("english")
+
+def derive_kek(entropy: bytes) -> bytes:
+    return HKDF(
+        algorithm=hashes.SHA256(),
+        length=32,
+        salt=b"\x00" * 32,
+        info=INFO,
+    ).derive(entropy)
+
+vectors = []
+
+# Vector 1: all-zero entropy
+e = b"\x00" * 32
+vectors.append({
+    "name": "all_zero_entropy",
+    "mnemonic": mnemo.to_mnemonic(e),
+    "entropy": e.hex(),
+    "info_tag": INFO.hex(),
+    "expected_recovery_kek": derive_kek(e).hex(),
+})
+
+# Vector 2: all-FF entropy
+e = b"\xFF" * 32
+vectors.append({
+    "name": "all_ff_entropy",
+    "mnemonic": mnemo.to_mnemonic(e),
+    "entropy": e.hex(),
+    "info_tag": INFO.hex(),
+    "expected_recovery_kek": derive_kek(e).hex(),
+})
+
+# Vectors 3 & 4: from the canonical Trezor BIP-39 vectors (24-word entries).
+# https://github.com/trezor/python-mnemonic/blob/master/vectors.json
+trezor_vectors = [
+    ("0000000000000000000000000000000000000000000000000000000000000000",
+     "abandon abandon abandon abandon abandon abandon abandon abandon "
+     "abandon abandon abandon abandon abandon abandon abandon abandon "
+     "abandon abandon abandon abandon abandon abandon abandon art"),
+    ("8080808080808080808080808080808080808080808080808080808080808080",
+     "letter advice cage absurd amount doctor acoustic avoid letter "
+     "advice cage absurd amount doctor acoustic avoid letter advice "
+     "cage absurd amount doctor acoustic bless"),
+]
+for i, (entropy_hex, expected_phrase) in enumerate(trezor_vectors, start=1):
+    e = bytes.fromhex(entropy_hex)
+    # Cross-check our wordlist matches Trezor's
+    derived_phrase = mnemo.to_mnemonic(e)
+    assert derived_phrase == expected_phrase, (
+        f"vector {i}: bip39 phrase divergence — got {derived_phrase!r}, "
+        f"expected {expected_phrase!r}"
+    )
+    vectors.append({
+        "name": f"trezor_vector_24w_{i}",
+        "mnemonic": expected_phrase,
+        "entropy": entropy_hex,
+        "info_tag": INFO.hex(),
+        "expected_recovery_kek": derive_kek(e).hex(),
+    })
+
+print(json.dumps({"vectors": vectors}, indent=2))
+PY
+```
+
+If the `bip39` package on PyPI under that name is not the canonical `mnemonic` package (Trezor's), substitute `--with mnemonic` and `from mnemonic import Mnemonic`. Both produce equivalent BIP-39 English output; the assertion against Trezor's expected phrase will surface a divergence immediately.
+
+Save the script's stdout to `core/tests/data/bip39_recovery_kat.json`.
+
+- [ ] **Step 18.2: Sanity-check the file structure**
+
+Run: `cat core/tests/data/bip39_recovery_kat.json | python -m json.tool > /dev/null` (replace with `uv run python -m json.tool` if needed)
+Expected: no output, no error.
+
+Then run the existing JSON-parse smoke test:
+
+Run: `cargo test -p secretary-core --release --test kat_loader`
+Expected: PASS — the new file is now picked up by the smoke test.
+
+- [ ] **Step 18.3: Add the `Bip39RecoveryKat` struct to `common/mod.rs`**
+
+Append to `core/tests/common/mod.rs`:
+
+```rust
+#[derive(Debug, Deserialize)]
+pub struct Bip39RecoveryKat {
+    pub vectors: Vec<Bip39RecoveryVector>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct Bip39RecoveryVector {
+    pub name: String,
+    pub mnemonic: String,
+    #[serde(deserialize_with = "de_hex_array::<32, _>")]
+    pub entropy: [u8; 32],
+    #[serde(deserialize_with = "de_hex")]
+    pub info_tag: Vec<u8>,
+    #[serde(deserialize_with = "de_hex_array::<32, _>")]
+    pub expected_recovery_kek: [u8; 32],
+}
+```
+
+- [ ] **Step 18.4: Add the KAT test**
+
+Append to `core/tests/unlock.rs`:
+
+```rust
+use common::{load_kat, Bip39RecoveryKat};
+use secretary_core::crypto::kdf::{derive_recovery_kek, TAG_RECOVERY_KEK};
+use secretary_core::crypto::secret::Sensitive;
+use secretary_core::unlock::mnemonic;
+
+#[test]
+fn bip39_recovery_kat_vectors() {
+    let kat: Bip39RecoveryKat = load_kat("bip39_recovery_kat.json");
+    assert!(!kat.vectors.is_empty(), "KAT file has no vectors");
+    for v in &kat.vectors {
+        // Pin half 1: mnemonic → entropy
+        let parsed = mnemonic::parse(&v.mnemonic).unwrap_or_else(|e| {
+            panic!("vector {}: parse failed: {e}", v.name)
+        });
+        assert_eq!(
+            parsed.entropy().expose(), &v.entropy,
+            "vector {}: mnemonic→entropy mismatch", v.name,
+        );
+
+        // Pin half 2: info_tag matches our domain-separation tag
+        assert_eq!(
+            v.info_tag, TAG_RECOVERY_KEK,
+            "vector {}: info_tag does not match TAG_RECOVERY_KEK", v.name,
+        );
+
+        // Pin half 3: entropy → recovery_kek
+        let kek = derive_recovery_kek(&Sensitive::new(v.entropy));
+        assert_eq!(
+            kek.expose(), &v.expected_recovery_kek,
+            "vector {}: HKDF output mismatch", v.name,
+        );
+    }
+}
+```
+
+- [ ] **Step 18.5: Run**
+
+Run: `cargo test -p secretary-core --release --test unlock bip39_recovery_kat_vectors`
+Expected: PASS.
+
+- [ ] **Step 18.6: Commit**
+
+```bash
+git add core/tests/data/bip39_recovery_kat.json core/tests/common/mod.rs core/tests/unlock.rs
+git commit -m "test(unlock): §15 BIP-39 recovery KAT — pins mnemonic→entropy→KEK"
+```
+
+---
+
+## Task 19: Property tests in `core/tests/proptest.rs`
+
+**Files:**
+- Modify: `core/tests/proptest.rs`
+
+- [ ] **Step 19.1: Inspect existing proptest layout**
+
+Read `core/tests/proptest.rs` head to confirm: macro import (`proptest! { ... }`), how strategies are constructed, and which submodules already exist. Match the file's style — do not introduce a new pattern.
+
+- [ ] **Step 19.2: Add `mod unlock` block**
+
+Append to `core/tests/proptest.rs`:
+
+```rust
+mod unlock {
+    use proptest::prelude::*;
+    use rand_chacha::{rand_core::SeedableRng, ChaCha20Rng};
+
+    use secretary_core::crypto::kdf::Argon2idParams;
+    use secretary_core::crypto::secret::SecretBytes;
+    use secretary_core::unlock::{
+        bundle, bundle_file, create_vault, open_with_password, vault_toml,
+    };
+
+    proptest! {
+        #[test]
+        fn identity_bundle_canonical_cbor_roundtrip(seed: [u8; 32]) {
+            let mut rng = ChaCha20Rng::from_seed(seed);
+            let b = bundle::generate("X", 0, &mut rng);
+            let bytes_1 = b.to_canonical_cbor().unwrap();
+            let bytes_2 = b.to_canonical_cbor().unwrap();
+            prop_assert_eq!(&bytes_1, &bytes_2, "encoding non-deterministic");
+            let parsed = bundle::IdentityBundle::from_canonical_cbor(&bytes_1).unwrap();
+            prop_assert_eq!(parsed.user_uuid, b.user_uuid);
+            prop_assert_eq!(parsed.x25519_pk, b.x25519_pk);
+        }
+
+        #[test]
+        fn bundle_file_roundtrip(
+            vault_uuid in any::<[u8; 16]>(),
+            created_at_ms in any::<u64>(),
+            wpw_nonce in any::<[u8; 24]>(),
+            wpw_ct in any::<[u8; 48]>(),
+            wrec_nonce in any::<[u8; 24]>(),
+            wrec_ct in any::<[u8; 48]>(),
+            bundle_nonce in any::<[u8; 24]>(),
+            bundle_ct in proptest::collection::vec(any::<u8>(), 16..1024),
+        ) {
+            let f = bundle_file::BundleFile {
+                vault_uuid,
+                created_at_ms,
+                wrap_pw_nonce: wpw_nonce,
+                wrap_pw_ct_with_tag: wpw_ct,
+                wrap_rec_nonce: wrec_nonce,
+                wrap_rec_ct_with_tag: wrec_ct,
+                bundle_nonce,
+                bundle_ct_with_tag: bundle_ct,
+            };
+            let bytes = bundle_file::encode(&f);
+            let parsed = bundle_file::decode(&bytes).unwrap();
+            prop_assert_eq!(parsed, f);
+        }
+
+        #[test]
+        fn vault_toml_roundtrip(
+            vault_uuid in any::<[u8; 16]>(),
+            created_at_ms in any::<u64>(),
+            memory_kib in 8u32..1024u32,
+            iterations in 1u32..16u32,
+            parallelism in 1u32..8u32,
+            salt in any::<[u8; 32]>(),
+        ) {
+            let v = vault_toml::VaultToml {
+                format_version: 1,
+                suite_id: 1,
+                vault_uuid,
+                created_at_ms,
+                kdf: vault_toml::KdfSection {
+                    algorithm: "argon2id".to_string(),
+                    version: "1.3".to_string(),
+                    memory_kib,
+                    iterations,
+                    parallelism,
+                    salt,
+                },
+            };
+            let s = vault_toml::encode(&v);
+            let parsed = vault_toml::decode(&s).unwrap();
+            prop_assert_eq!(parsed, v);
+        }
+
+        #[test]
+        fn create_then_open_roundtrip_preserves_identity(seed: [u8; 32], pw_seed: [u8; 16]) {
+            let mut rng = ChaCha20Rng::from_seed(seed);
+            let pw = SecretBytes::new(pw_seed.to_vec());
+            let v = create_vault(&pw, "X", 0, Argon2idParams::new(8, 1, 1), &mut rng).unwrap();
+            let opened = open_with_password(
+                &v.vault_toml_bytes, &v.identity_bundle_bytes, &pw,
+            ).unwrap();
+            prop_assert_eq!(opened.identity_block_key.expose(), v.identity_block_key.expose());
+            prop_assert_eq!(opened.identity.user_uuid, v.identity.user_uuid);
+        }
+    }
+}
+```
+
+(For the `bundle_file_roundtrip` strategy: use `proptest::collection::vec(any::<u8>(), 0..1024)` for `bundle_ct_with_tag` rather than synthesizing the array fields manually if it's simpler.)
+
+- [ ] **Step 19.3: Run**
+
+Run: `cargo test -p secretary-core --release --test proptest unlock`
+Expected: each property runs default 256 cases, all PASS. Slow due to Argon2; acceptable.
+
+- [ ] **Step 19.4: Commit**
+
+```bash
+git add core/tests/proptest.rs
+git commit -m "test(unlock): proptest — CBOR/bundle-file roundtrip + create/open"
+```
+
+---
+
+## Task 20: Final verification — full test suite + clippy
+
+**Files:** none modified — verification only.
+
+- [ ] **Step 20.1: Run the full test suite**
+
+Run: `cargo test --release --workspace`
+Expected: every test PASS. Total count = 122 (existing) + ~20 new unit tests + 3 integration tests + 1 KAT test + 3 properties.
+
+- [ ] **Step 20.2: Run clippy**
+
+Run: `cargo clippy --all-targets -- -D warnings`
+Expected: clean.
+
+- [ ] **Step 20.3: If clippy complains, fix issues and re-commit**
+
+```bash
+git add -p
+git commit -m "chore(unlock): clippy fixes"
+```
+
+---
+
+## Task 21: Update `secretary_next_session.md`
+
+**Files:**
+- Modify: `secretary_next_session.md`
+
+- [ ] **Step 21.1: Mark Item 1a and Item 3 as completed**
+
+Edit `secretary_next_session.md`:
+
+- In Item 1a's section, change the heading to `### 1a. ~~bip39_recovery_kat.json~~ — DONE 2026-04-27` and append a one-line note: "Delivered as `core/tests/data/bip39_recovery_kat.json` plus the `bip39_recovery_kat_vectors` test in `core/tests/unlock.rs`."
+- In Item 3's section, change the heading to `## ~~Item 3 — Build-sequence next: \`unlock\` module~~ — DONE 2026-04-27` and append a one-line note pointing at the spec doc and the implementation files.
+- In the "What this session delivered" block at the bottom, append a new dated entry summarizing the unlock module work.
+
+- [ ] **Step 21.2: Verify the file still parses cleanly as Markdown**
+
+Run: visually scan in editor, or `cat secretary_next_session.md | head -50` to confirm structure. No tooling required.
+
+- [ ] **Step 21.3: Commit**
+
+```bash
+git add secretary_next_session.md
+git commit -m "docs: close out FIXME items 1a + 3 (unlock module + BIP-39 KAT)"
+```
+
+---
+
+## Self-review notes
+
+After completing all tasks, the following spec coverage should hold:
+
+| Spec section | Implementing task |
+|---|---|
+| Public API surface | Tasks 14-16 |
+| `mnemonic.rs` | Tasks 2-5 |
+| `bundle.rs` | Tasks 6-8 |
+| `bundle_file.rs` | Tasks 9-10 |
+| `vault_toml.rs` | Tasks 11-12 |
+| `mod.rs` (UnlockError + composers) | Tasks 13-16 |
+| Layer 1 unit tests | Tasks 2-12 inline |
+| Layer 2 integration tests | Task 17 + Tasks 14-16 (4 of 8 scenarios live in `mod.rs` `#[cfg(test)]`; Task 17 adds the rest) |
+| Layer 3 property tests | Task 19 |
+| Layer 4 BIP-39 recovery KAT | Task 18 |
+| Layer 5 clippy clean | Task 20 |
+
+Open items intentionally deferred (per spec "Out of scope"):
+- Filesystem I/O — vault module
+- Manifest decryption — vault module
+- Block decryption — vault module
+- Cross-language `conformance.py` — written after vault module exists

--- a/docs/superpowers/specs/2026-04-27-unlock-module-design.md
+++ b/docs/superpowers/specs/2026-04-27-unlock-module-design.md
@@ -1,0 +1,396 @@
+# `core/src/unlock/` module — design
+
+**Date:** 2026-04-27
+**Scope:** Sub-project A, build-sequence step 5 (`unlock` module). Also delivers Item 1a from `secretary_next_session.md` (the BIP-39 recovery KAT — `bip39_recovery_kat.json`).
+**Status:** approved design, awaiting implementation plan.
+
+## Context
+
+The unlock module is the next module in the build sequence per `docs/crypto-design.md` §3 + §4 and per the Sub-project A design anchor at `/Users/hherb/.claude/plans/we-are-starting-with-logical-newt.md`. The crypto primitives (`crypto/{kdf, aead, secret, hash, kem, sig}`) and identity-side modules (`identity/{card, fingerprint}`) are in place. The vault module is still a stub and is the next session's target after this one.
+
+The byte-level format the unlock module reads and writes is fully specified:
+
+- `vault.toml` — `docs/vault-format.md` §2 (cleartext TOML metadata)
+- `identity.bundle.enc` — `docs/vault-format.md` §3 (binary envelope)
+- `IdentityBundle` plaintext — `docs/crypto-design.md` §5 (canonical CBOR §6.2)
+- Master KEK derivation — `docs/crypto-design.md` §3 (Argon2id)
+- Recovery KEK derivation — `docs/crypto-design.md` §4 (HKDF-SHA-256)
+- Domain-separation tags — `docs/crypto-design.md` §1.3 (already imported as `pub const` in `core/src/crypto/kdf.rs`)
+
+This document contains no new spec material. It is purely an implementation design for code that realises the existing spec.
+
+## Architecture
+
+### Position in the dependency graph
+
+```
+crypto/{kdf, aead, secret, hash}   identity/{card, fingerprint}
+                  │                              │
+                  └──────────────┬───────────────┘
+                                 ▼
+                          unlock  ← this module
+                                 │
+                                 ▼
+                              vault   (next session)
+```
+
+Unlock depends down on the crypto primitives and is depended on by the future `vault` module — `vault::manifest` will need the unwrapped `identity_block_key` to AEAD-decrypt the manifest, and the `IdentityBundle`'s Ed25519 + ML-DSA-65 public keys to verify the manifest's hybrid signature.
+
+### Trust boundary and side-effect discipline
+
+The module is a stateless byte-in / byte-out transformer. No filesystem I/O — atomic writes belong to the `vault` module per the design anchor. No clock reads — `created_at_ms` is an explicit parameter. All randomness comes through an injected `RngCore + CryptoRng`, so tests use a seeded RNG (`ChaCha20Rng`) for deterministic vault bytes and production callers pass `&mut OsRng`.
+
+This shape matches the user's general design preference (pure functions in reusable modules) and makes the module straightforward to consume from the eventual FFI layers (PyO3, uniffi).
+
+### Public API surface
+
+```rust
+// core/src/unlock/mod.rs
+
+pub mod mnemonic;
+pub mod bundle;
+pub mod bundle_file;
+pub mod vault_toml;
+
+pub struct CreatedVault {
+    pub vault_toml_bytes: Vec<u8>,
+    pub identity_bundle_bytes: Vec<u8>,
+    pub recovery_mnemonic: mnemonic::Mnemonic,        // show once, then drop
+    pub identity_block_key: Sensitive<[u8; 32]>,
+    pub identity: bundle::IdentityBundle,
+}
+
+pub struct UnlockedIdentity {
+    pub identity_block_key: Sensitive<[u8; 32]>,
+    pub identity: bundle::IdentityBundle,
+}
+
+pub fn create_vault(
+    password: &SecretBytes,
+    display_name: &str,
+    created_at_ms: u64,
+    kdf_params: Argon2idParams,
+    rng: &mut (impl RngCore + CryptoRng),
+) -> Result<CreatedVault, UnlockError>;
+
+pub fn open_with_password(
+    vault_toml_bytes: &[u8],
+    identity_bundle_bytes: &[u8],
+    password: &SecretBytes,
+) -> Result<UnlockedIdentity, UnlockError>;
+
+pub fn open_with_recovery(
+    vault_toml_bytes: &[u8],
+    identity_bundle_bytes: &[u8],
+    mnemonic_words: &str,
+) -> Result<UnlockedIdentity, UnlockError>;
+```
+
+`open_with_password` and `open_with_recovery` are deliberately separate functions, not a single function with auto-detection. The UX flow ("I forgot my password, I'll use the recovery mnemonic") is an explicit user choice. We never silently fall back from one to the other.
+
+## File-level components
+
+Five files, each independently testable. Approximate line counts are estimates; the actual constraint is "each file owns one purpose."
+
+### `mod.rs` — public surface and composition (~150 lines)
+
+- Re-exports the four submodules.
+- `pub struct CreatedVault`, `pub struct UnlockedIdentity`.
+- `pub enum UnlockError` (see Error model below).
+- The three public free functions. Each is a short composer that calls into the submodules; no novel logic in `mod.rs` itself.
+- One small private helper `wrap_identity_block_key(kek, key, aad_tag, vault_uuid, rng)` that performs the §5 wrap step shared between `wrap_pw` and `wrap_rec` — they differ only in their AAD tag and KEK.
+
+### `mnemonic.rs` — BIP-39 wrapper (~100 lines)
+
+- `pub struct Mnemonic` — opaque wrapper around `bip39::Mnemonic`. Holds the 24-word phrase and the 256-bit entropy. `Drop` zeroizes both the phrase string and the entropy (the latter via `Sensitive`'s `ZeroizeOnDrop`). No `Display`, no `Clone`, no derived `Debug`: every read of the phrase goes through an explicit `pub fn phrase(&self) -> &str` accessor (mirrors the `SecretBytes::expose()` convention in `crypto/secret.rs` — secret reads must be grep-able at use sites). A manual `Debug` impl is provided that prints `Mnemonic { phrase: "<redacted>", entropy: "<redacted>" }` so the type can appear in `Result::unwrap_err()` test assertions without leaking.
+- `pub fn generate(rng: &mut (impl RngCore + CryptoRng)) -> Mnemonic` — 256 bits → bip39 24-word phrase, English wordlist.
+- `pub fn parse(words: &str) -> Result<Mnemonic, MnemonicError>` — apply Unicode NFKD normalization (BIP-39 standard), then collapse whitespace runs, trim, lowercase, then validate word-list membership and validate BIP-39 checksum. Returns parsed mnemonic with extracted entropy.
+- `pub fn entropy(&self) -> &Sensitive<[u8; 32]>` — accessor for `derive_recovery_kek`.
+- `pub enum MnemonicError { WrongLength { got: usize }, UnknownWord(String), BadChecksum }`.
+
+This is the only file that depends on the external `bip39` crate. If we ever swap libraries, only this file changes.
+
+### `bundle.rs` — IdentityBundle plaintext (~150 lines)
+
+- `pub struct IdentityBundle` — the §5 plaintext fields: `user_uuid: [u8; 16]`, `display_name: String`, `(x25519_sk, x25519_pk)`, `(ml_kem_768_sk, ml_kem_768_pk)`, `(ed25519_sk, ed25519_pk)`, `(ml_dsa_65_sk, ml_dsa_65_pk)`, `created_at_ms: u64`. Secret-key fields wrapped in `Sensitive<...>`.
+- `pub fn generate(display_name: &str, created_at_ms: u64, rng: &mut ...) -> IdentityBundle` — generate fresh `user_uuid` + four keypairs.
+- `pub fn to_canonical_cbor(&self) -> Vec<u8>` — RFC 8949 §4.2.1 deterministic encoding (sorted keys, definite-length, shortest-form). Output is byte-stable and what the §15 KAT pins.
+- `pub fn from_canonical_cbor(bytes: &[u8]) -> Result<IdentityBundle, BundleError>` — strict decoder. Rejects unknown fields (the bundle is fully-specified; an unknown field signals suite drift). Rejects duplicate map keys (RFC 8949 §5.4).
+
+No crypto, no I/O. Pure translation between Rust struct ↔ CBOR bytes.
+
+### `bundle_file.rs` — `identity.bundle.enc` framing (~200 lines)
+
+- `pub struct BundleFile` — parsed envelope: `vault_uuid`, `created_at_ms`, three `(nonce, ct, tag)` triples (`wrap_pw`, `wrap_rec`, `bundle`).
+- `pub fn encode(file: &BundleFile) -> Vec<u8>` — emit byte layout from `vault-format.md` §3.
+- `pub fn decode(bytes: &[u8]) -> Result<BundleFile, BundleFileError>` — parse and validate magic (`0x53454352`), `format_version` (1), `file_kind` (0x0001), internal length fields. Rejects truncation, version mismatch, length-field disagreement.
+
+No crypto here either — just framing. `mod.rs` does the AEAD calls using fields pulled out of `BundleFile`. Separating framing from crypto means we can fuzz the parser independently and a clean-room implementation can verify the parser without keys.
+
+### `vault_toml.rs` — `vault.toml` ser/de (~80 lines)
+
+- `pub struct VaultToml` — typed view: `format_version: u16`, `suite_id: u16`, `vault_uuid: [u8; 16]`, `created_at_ms: u64`, plus a `kdf: KdfSection` substruct holding `algorithm: String`, `version: String`, `memory_kib: u32`, `iterations: u32`, `parallelism: u32`, `salt: [u8; 32]` (decoded from `salt_b64`).
+- `pub fn encode(v: &VaultToml) -> String` — produces a stable TOML string so the §15 KAT can pin bytes.
+- `pub fn decode(s: &str) -> Result<VaultToml, VaultTomlError>` — strict parsing per `vault-format.md` §2:
+  - Unknown top-level keys silently ignored (forward compat).
+  - Unknown keys inside `[kdf]` are errors (misinterpreting KDF parameters would derive a wrong key — defense in depth against malformed or downgrade-tampered files).
+  - `kdf.algorithm` must be exactly `"argon2id"` (else `UnsupportedKdfAlgorithm`); `kdf.version` must be exactly `"1.3"` (else `UnsupportedKdfVersion`). vault.toml is cleartext and attacker-writable per `threat-model.md` §2.1; we reject on any deviation rather than silently coercing.
+
+## Data flows
+
+### `create_vault`
+
+```
+1.  vault_uuid          ← 16 random bytes from rng
+2.  argon2_salt         ← 32 random bytes from rng
+3.  master_kek          ← derive_master_kek(password, argon2_salt, kdf_params)   [Argon2id]
+4.  mnemonic            ← mnemonic::generate(rng)                                [256 bits → 24 words]
+5.  recovery_kek        ← derive_recovery_kek(mnemonic.entropy())                [HKDF-SHA-256]
+6.  identity_block_key  ← 32 random bytes from rng
+7.  identity            ← bundle::generate(display_name, created_at_ms, rng)
+8.  bundle_plaintext    ← identity.to_canonical_cbor()
+9.  nonce_id, nonce_pw, nonce_rec ← three independent 24-byte nonces from rng
+10. bundle_ct, bundle_tag ← AEAD-encrypt(identity_block_key, nonce_id,
+                              aad = TAG_ID_BUNDLE   || vault_uuid, bundle_plaintext)
+11. wrap_pw_ct, wrap_pw_tag ← AEAD-encrypt(master_kek, nonce_pw,
+                              aad = TAG_ID_WRAP_PW  || vault_uuid, identity_block_key)
+12. wrap_rec_ct, wrap_rec_tag ← AEAD-encrypt(recovery_kek, nonce_rec,
+                              aad = TAG_ID_WRAP_REC || vault_uuid, identity_block_key)
+13. bundle_file_bytes   ← bundle_file::encode(BundleFile { vault_uuid, created_at_ms,
+                              all three (nonce, ct, tag) triples })
+14. vault_toml_bytes    ← vault_toml::encode(VaultToml { ..., kdf.salt = argon2_salt })
+15. zeroize: master_kek, recovery_kek
+16. return CreatedVault { vault_toml_bytes, identity_bundle_bytes, mnemonic,
+                          identity_block_key, identity }
+```
+
+### `open_with_password`
+
+```
+1. vault_toml          ← vault_toml::decode(vault_toml_bytes)
+                          ↳ check format_version == 1, suite_id == 1, else UnsupportedFormatVersion / UnsupportedSuiteId
+2. bundle_file         ← bundle_file::decode(identity_bundle_bytes)
+                          ↳ check magic, file_kind, format_version
+                          ↳ check bundle_file.vault_uuid == vault_toml.vault_uuid, else VaultMismatch
+3. master_kek          ← derive_master_kek(password, vault_toml.kdf.salt, vault_toml.kdf params)
+4. identity_block_key  ← AEAD-decrypt(master_kek, bundle_file.wrap_pw_nonce,
+                          aad = TAG_ID_WRAP_PW || vault_uuid,
+                          ct  = bundle_file.wrap_pw_ct, tag = bundle_file.wrap_pw_tag)
+                          ↳ on AEAD failure: WrongPasswordOrCorrupt
+5. bundle_plaintext    ← AEAD-decrypt(identity_block_key, bundle_file.bundle_nonce,
+                          aad = TAG_ID_BUNDLE || vault_uuid,
+                          ct  = bundle_file.bundle_ct, tag = bundle_file.bundle_tag)
+                          ↳ on AEAD failure: CorruptVault (step 4 succeeded → wraps disagree → tampering)
+6. identity            ← bundle::from_canonical_cbor(bundle_plaintext)
+7. zeroize: master_kek, bundle_plaintext
+8. return UnlockedIdentity { identity_block_key, identity }
+```
+
+### `open_with_recovery`
+
+```
+1. vault_toml          ← vault_toml::decode(...)                                [as above]
+2. bundle_file         ← bundle_file::decode(...)                               [as above]
+3. mnemonic            ← mnemonic::parse(mnemonic_words)
+                          ↳ on MnemonicError: InvalidMnemonic(reason)
+4. recovery_kek        ← derive_recovery_kek(mnemonic.entropy())
+5. identity_block_key  ← AEAD-decrypt(recovery_kek, bundle_file.wrap_rec_nonce,
+                          aad = TAG_ID_WRAP_REC || vault_uuid,
+                          ct  = bundle_file.wrap_rec_ct, tag = bundle_file.wrap_rec_tag)
+                          ↳ on AEAD failure: WrongMnemonicOrCorrupt
+6. bundle_plaintext, identity ← (as steps 5-6 above)
+7. zeroize: recovery_kek, mnemonic, bundle_plaintext
+8. return UnlockedIdentity { identity_block_key, identity }
+```
+
+### Three runtime invariants worth naming
+
+1. **`vault_uuid` is bound into every AAD.** An attacker who swaps `identity.bundle.enc` between two vaults causes AAD mismatch → AEAD tag failure → bundle rejected. Without this binding, a swap could silently succeed if both vaults shared a (password, salt) coincidence.
+2. **The same `identity_block_key` is recovered via either unlock path.** That's the dual-wrap invariant — there is exactly one key encrypted twice, not two equivalent keys.
+3. **`master_kek` and `recovery_kek` are zeroized at the end of every flow.** They are never stored, returned, or kept past the function boundary. Only `identity_block_key` and the `IdentityBundle` survive — the `vault` module needs them to decrypt the manifest and per-block keys.
+
+## Error model
+
+Following the existing `crypto/kdf.rs` pattern: `thiserror`-derived enums, one per submodule, composed into `UnlockError` via `From` impls. No `anyhow`, no `Box<dyn Error>`. Concrete enums everywhere — keeps the FFI layer's job straightforward (each variant maps to a Python exception class, a Swift enum case, etc.).
+
+### Submodule errors
+
+```rust
+// mnemonic.rs
+pub enum MnemonicError {
+    WrongLength { got: usize },        // not 24 words
+    UnknownWord(String),               // word not in BIP-39 English list
+    BadChecksum,                       // 8-bit checksum doesn't match
+}
+
+// bundle.rs
+pub enum BundleError {
+    MalformedCbor(ciborium::de::Error),
+    UnknownField(String),              // strict; bundle is fully-specified
+    DuplicateField(String),            // RFC 8949 §5.4 violation
+    WrongKeySize { field: &'static str, expected: usize, got: usize },
+    InvalidUuid,
+    InvalidTimestamp,
+}
+
+// bundle_file.rs
+pub enum BundleFileError {
+    Truncated { offset: usize },
+    BadMagic { got: u32 },
+    UnsupportedFormatVersion(u16),     // != 1
+    UnsupportedFileKind(u16),          // != 0x0001 (identity-bundle)
+    WrapLengthMismatch { field: &'static str, declared: u32 },  // ct_len != 32
+}
+
+// vault_toml.rs
+pub enum VaultTomlError {
+    MalformedToml(toml::de::Error),
+    UnknownKdfKey(String),                 // strict inside [kdf] (vault-format §2)
+    UnsupportedFormatVersion(u16),
+    UnsupportedSuiteId(u16),
+    UnsupportedKdfAlgorithm(String),       // != "argon2id"
+    UnsupportedKdfVersion(String),         // != "1.3"
+    InvalidSaltLength { got: usize },      // not 32 bytes after b64 decode
+    InvalidUuid,
+}
+```
+
+### Top-level `UnlockError`
+
+```rust
+pub enum UnlockError {
+    // user-facing categories
+    WrongPasswordOrCorrupt,
+    WrongMnemonicOrCorrupt,
+    InvalidMnemonic(MnemonicError),
+    CorruptVault,
+    VaultMismatch,
+
+    // structural / format failures
+    MalformedVaultToml(VaultTomlError),
+    MalformedBundleFile(BundleFileError),
+    MalformedBundle(BundleError),
+    UnsupportedFormatVersion(u16),
+    UnsupportedSuiteId(u16),
+
+    // composition with existing crypto errors
+    KdfFailure(crate::crypto::kdf::KdfError),
+    AeadFailure,
+}
+```
+
+### Three deliberate choices
+
+1. **`WrongPasswordOrCorrupt` vs. `CorruptVault` are distinct variants** even though cryptographically a wrong-key AEAD failure is indistinguishable from corruption. The distinction is *positional*: if `wrap_pw` AEAD fails, the user almost certainly mistyped the password — UI prompts re-entry. If `wrap_pw` *succeeds* and the inner bundle AEAD then fails, the unwrapped key worked but the bundle plaintext is unverifiable — that's tampering or genuine corruption, and "try your password again" is the wrong UX.
+2. **`InvalidMnemonic` carries the inner `MnemonicError`** so the UI can distinguish "you typed 22 words" from "the third word isn't in the list" from "checksum off — likely a transcription typo."
+3. **AEAD primitive errors collapse to `AeadFailure`** without inner detail. The `chacha20poly1305` crate's error type carries no information beyond "failed," and AAD/key/nonce shapes are caller-controlled here, so an unexpected `AeadFailure` indicates a programming bug rather than a user-facing condition.
+
+## Testing strategy
+
+Five layers, mapping to the existing repo conventions.
+
+### Layer 1 — unit tests inside each submodule
+
+In-file `#[cfg(test)] mod tests`:
+
+- `mnemonic.rs`: generate produces 24 words; `parse(generate)` round-trips entropy; parse normalizes whitespace and case; rejects each `MnemonicError` variant on the appropriate bad input.
+- `bundle.rs`: canonical CBOR is byte-stable across runs and across `HashMap` iteration order; decode→encode round-trip is byte-identical; rejects unknown / duplicate fields and wrong-size keys.
+- `bundle_file.rs`: encode/decode round-trip; rejects bad magic, wrong file_kind; sliced-truncation test (slice encoded bytes from `[..n]` for each `n` and assert all fail with `Truncated { offset }` matching `n` or `BadMagic` for very short slices); wrap length mismatches.
+- `vault_toml.rs`: round-trip; unknown top-level key silently ignored (spec); unknown `[kdf]` key is a hard error (spec); bad salt b64 length rejected.
+
+### Layer 2 — integration tests in `core/tests/unlock.rs`
+
+New file modeled after `core/tests/identity.rs`. Eight scenarios:
+
+1. `create → open_with_password` returns identical `IdentityBundle` and `identity_block_key`.
+2. `create → open_with_recovery` returns identical `IdentityBundle` and `identity_block_key`.
+3. Both unlock paths return the same `identity_block_key` (the dual-wrap invariant).
+4. `open_with_password(wrong_password)` → `WrongPasswordOrCorrupt`.
+5. `open_with_recovery(wrong_mnemonic)` → `WrongMnemonicOrCorrupt`.
+6. `open_with_recovery(malformed_words)` → `InvalidMnemonic(_)` with the right inner variant.
+7. Swap `identity.bundle.enc` from vault A into vault B's `vault.toml` → `VaultMismatch`.
+8. Flip one byte in `bundle_ct` → `CorruptVault` (wrap unwrapped fine; body didn't).
+
+All use a seeded `ChaCha20Rng` for deterministic vault bytes — a flake here means a real bug.
+
+### Layer 3 — property tests in `core/tests/proptest.rs`
+
+Extend the existing file with a new `mod unlock` block. Three round-trip properties using `proptest`:
+
+- For any valid `IdentityBundle`: `from_canonical_cbor(to_canonical_cbor(b)) == b` and the canonical encoding is unique (encoding twice produces identical bytes).
+- For any valid `BundleFile`: `decode(encode(f)) == f`.
+- For any valid `VaultToml`: `decode(encode(t)) == t`.
+
+Plus one composed property: for any `(password, display_name, seed)`, `open_with_password(create_vault(...))` returns the original `IdentityBundle` and the original `identity_block_key`. This is the central correctness claim of the whole module reduced to one assertion.
+
+### Layer 4 — §15 KAT: `bip39_recovery_kat.json` (Item 1a)
+
+New file `core/tests/data/bip39_recovery_kat.json`. Schema as proposed in `secretary_next_session.md`:
+
+```json
+{
+  "vectors": [
+    { "name": "all_zero_entropy",         "mnemonic": "...", "entropy": "<hex>",
+      "info_tag": "<hex of TAG_RECOVERY_KEK>", "expected_recovery_kek": "<hex>" },
+    { "name": "all_ones_entropy",         "..." },
+    { "name": "trezor_vector_24w_random_1", "..." },
+    { "name": "trezor_vector_24w_random_2", "..." }
+  ]
+}
+```
+
+Cross-verification, recorded in a comment in the test file:
+
+- `mnemonic ↔ entropy` cross-checked against the `bip39` Python package.
+- For at least two vectors, `(mnemonic, entropy)` lifted directly from the canonical Trezor BIP-39 test vectors, anchoring against an external reference rather than internal consistency only.
+- `entropy + info_tag → expected_recovery_kek` cross-checked against Python `cryptography.hazmat.primitives.kdf.hkdf.HKDF`.
+
+Loaded via existing `core/tests/kat_loader.rs` infrastructure. Test in `core/tests/unlock.rs`:
+
+```rust
+#[test]
+fn bip39_recovery_kat_vectors() {
+    let kat = load_kat::<Bip39RecoveryKat>("bip39_recovery_kat.json");
+    for v in kat.vectors {
+        let mnemonic = mnemonic::parse(&v.mnemonic).unwrap();
+        assert_eq!(mnemonic.entropy().expose(), &v.entropy);
+        let kek = derive_recovery_kek(mnemonic.entropy());
+        assert_eq!(kek.expose(), &v.expected_recovery_kek, "vector {}", v.name);
+    }
+}
+```
+
+This pins both halves — `mnemonic → entropy` and `entropy → KEK` — and their composition. The existing `recovery_kek_test_vector_zero_entropy` in `core/tests/kdf.rs` only covered the second half.
+
+### Layer 5 — `cargo clippy --all-targets -- -D warnings` clean
+
+Same bar as the rest of the crate. No exceptions.
+
+## Out of scope for this session
+
+- **Filesystem I/O** — atomic writes, file locking, vault-folder layout. Belongs to the `vault` module per the design anchor.
+- **Manifest decryption** — `manifest.cbor.enc` parsing/verification belongs to `vault::manifest` (which will use the `identity_block_key` and the `IdentityBundle`'s public keys returned by this module).
+- **Block decryption** — per-block AEAD and per-recipient hybrid-KEM unwraps belong to `vault::block`.
+- **Biometric / OS-keystore caching of `identity_block_key`** — per-platform clients (sub-projects C/D/E).
+- **Password change / recovery-key rotation** — future enhancement; not in v1.
+- **Cross-language conformance script** (`core/tests/python/conformance.py`). Sub-project A's "done" checklist requires it, but it's better written *after* the `vault` module exists. Verifying just unlock from Python alone covers half the spec, and the second half would be stale by next session.
+
+## Spec compliance and references
+
+| Spec section | Realised by |
+|---|---|
+| `crypto-design.md` §3 (Master KEK) | `mod.rs` calls existing `derive_master_kek` |
+| `crypto-design.md` §4 (Recovery KEK) | `mod.rs` calls existing `derive_recovery_kek`; `mnemonic.rs` produces the entropy |
+| `crypto-design.md` §5 (Identity Bundle wrap) | `mod.rs` orchestrates; `bundle.rs` produces canonical CBOR; `bundle_file.rs` produces the binary envelope |
+| `crypto-design.md` §6.2 (canonical CBOR) | `bundle.rs::to_canonical_cbor` |
+| `vault-format.md` §2 (`vault.toml`) | `vault_toml.rs` |
+| `vault-format.md` §3 (`identity.bundle.enc`) | `bundle_file.rs` |
+| §15 entry: BIP-39 recovery KAT | `core/tests/data/bip39_recovery_kat.json` + test in `core/tests/unlock.rs` |
+
+## Verification of "done"
+
+1. `cargo test --workspace` green.
+2. `cargo test --release` green (existing convention; the integration tests are practical only at release with real Argon2id parameters in some scenarios).
+3. `cargo clippy --all-targets -- -D warnings` clean.
+4. New KAT file validated externally against `bip39` Python package and `cryptography` HKDF before commit.
+5. `secretary_next_session.md` updated: Item 1a struck through, Item 3 marked done; Items 1b, 2, 4 carry forward.

--- a/secretary_next_session.md
+++ b/secretary_next_session.md
@@ -18,38 +18,15 @@ Per `docs/crypto-design.md` §15, the §15 list has twelve entries. Ten are
 in `core/tests/data/*.json` already. Two remain, both blocked on modules
 that are still stubs as of this session:
 
-### 1a. `bip39_recovery_kat.json` — blocked on the `unlock` module
+### 1a. ~~`bip39_recovery_kat.json`~~ — DONE 2026-04-27
 
-§15 promises a KAT covering "Mnemonic encoding / decoding round-trip and
-HKDF derivation." The BIP-39 wordlist itself lives at
-[core/src/identity/bip39_wordlist.rs](core/src/identity/bip39_wordlist.rs)
-and the inverse (entropy → words) is exercised by `mnemonic_form` in
-[core/src/identity/fingerprint.rs](core/src/identity/fingerprint.rs) (used for
-fingerprint *presentation*, not recovery — see §6.1 vs §3).
-
-The recovery flow itself — 24-word mnemonic → 256-bit entropy →
-HKDF-SHA-256 → Recovery KEK — needs the [core/src/unlock/](core/src/unlock/)
-module, currently a stub. Once that module exists, the KAT shape is:
-
-```json
-{
-  "vectors": [
-    {
-      "name": "rfc_test_vector_or_reference_impl",
-      "mnemonic": "<24 words separated by single spaces>",
-      "entropy": "<32-byte hex>",
-      "info_tag": "<TAG_RECOVERY_KEK bytes from kdf.rs>",
-      "expected_recovery_kek": "<32-byte hex>"
-    }
-  ]
-}
-```
-
-Cross-verify against the `bip39` Python package + the existing HKDF
-implementation. The `recovery_kek_test_vector_zero_entropy` and
-`recovery_kek_uses_recovery_kek_tag` tests in
-[core/tests/kdf.rs](core/tests/kdf.rs) already pin the HKDF half; the new
-KAT will pin the mnemonic-to-entropy half plus their composition.
+Delivered as [core/tests/data/bip39_recovery_kat.json](core/tests/data/bip39_recovery_kat.json)
+(4 vectors: all-zero, all-FF, two Trezor canonical 24-word) plus the
+`bip39_recovery_kat_vectors` test in [core/tests/unlock.rs](core/tests/unlock.rs),
+which pins three relations end-to-end: mnemonic↔entropy, `info_tag` bytes
+match `TAG_RECOVERY_KEK`, and entropy→Recovery KEK under HKDF-SHA-256.
+Cross-verified against the Trezor `mnemonic` Python package + the
+`cryptography` library's HKDF.
 
 ### 1b. `golden_vault_001/` — blocked on the `vault` module
 
@@ -97,19 +74,27 @@ Not urgent — the existing coverage is meaningful — but worth noting.
 
 ---
 
-## Item 3 — Build-sequence next: `unlock` module
+## ~~Item 3 — Build-sequence next: `unlock` module~~ — DONE 2026-04-27
 
-Per `docs/crypto-design.md` §3 + §4, the unlock module owns:
+Per `docs/crypto-design.md` §3 + §4 + §5 and `docs/vault-format.md` §2 + §3,
+delivered across [core/src/unlock/](core/src/unlock/):
 
-- Master-password unlock path: vault.toml → derive Master KEK
-  (Argon2id) → unwrap Identity Bundle Key → unwrap identity.bundle.enc.
-- Recovery unlock path: 24-word mnemonic → entropy → derive Recovery
-  KEK (HKDF-SHA-256) → unwrap the dual-wrapped Identity Block Key.
-- BIP-39 mnemonic parsing + checksum validation (this also unblocks
-  Item 1a above).
+- [mnemonic.rs](core/src/unlock/mnemonic.rs) — BIP-39 24-word generate +
+  parse with NFKD normalization, checksum validation, and zeroization on drop.
+- [bundle.rs](core/src/unlock/bundle.rs) — `IdentityBundle` plaintext
+  type with canonical CBOR encode/decode (RFC 8949 §4.2.1).
+- [bundle_file.rs](core/src/unlock/bundle_file.rs) — binary envelope for
+  `identity.bundle.enc` (vault-format §3) — encode/decode with strict
+  truncation/version/kind/length error variants.
+- [vault_toml.rs](core/src/unlock/vault_toml.rs) — `vault.toml` cleartext
+  metadata (vault-format §2) — encode/decode with strict v1 KDF param
+  enforcement, lowercase-canonical UUID parsing, and typed `MissingField` /
+  `FieldOutOfRange` / `TimestampOutOfRange` error variants.
+- [mod.rs](core/src/unlock/mod.rs) — `UnlockError` umbrella + the three
+  orchestrators: `create_vault`, `open_with_password`, `open_with_recovery`.
 
-The kdf, aead, kem, sig, identity primitives are all in place.
-[core/src/unlock/mod.rs](core/src/unlock/mod.rs) is the stub to grow.
+Implementation plan and audit trail at
+[docs/superpowers/plans/2026-04-27-unlock-module.md](docs/superpowers/plans/2026-04-27-unlock-module.md).
 
 Sub-project A's design anchor lives at
 `/Users/hherb/.claude/plans/we-are-starting-with-logical-newt.md` —
@@ -149,3 +134,26 @@ For session-context retention. Five commits on `main`:
 
 `FIXME.md` is now removed. Test count: 6 proptest properties + 122
 unit/integration tests, all passing under `cargo test --release`.
+
+## What the next session delivered (2026-04-27 — `feature/unlock-module`)
+
+The unlock module (Item 3) and the BIP-39 recovery KAT (Item 1a),
+shipped via subagent-driven TDD against
+[docs/superpowers/plans/2026-04-27-unlock-module.md](docs/superpowers/plans/2026-04-27-unlock-module.md).
+
+Twenty-three commits on `feature/unlock-module` — five from the original
+Opus run before context compaction (`a69c078..c43988a`, mnemonic + bundle
+plaintext) and eighteen from the resumed run (`a1f9add..3c5e361`,
+bundle_file + vault_toml + UnlockError + create_vault + the two open
+paths + integration tests + BIP-39 KAT + proptest + one latent-bug fix
+for `vault_toml::encode` rejecting timestamps > i64::MAX as a typed
+error rather than a panic — caught by proptest).
+
+Test count after: 153 (was 122 + 6 proptest = 128). Breakdown:
+46 core unit tests + 4 unlock integration tests + 11 proptest
+properties + 92 other crypto/identity integration tests. All clean
+under `cargo test --release --workspace` and
+`cargo clippy --all-targets --workspace -- -D warnings`.
+
+Branch is on `feature/unlock-module` awaiting merge to `main`. Items 1b,
+2, and 4 below remain open for future sessions.


### PR DESCRIPTION
## Summary
- Implements the unlock module per `docs/crypto-design.md` §3–§5 and `docs/vault-format.md` §2–§3: BIP-39 24-word mnemonic, `IdentityBundle` plaintext (canonical CBOR), `identity.bundle.enc` binary envelope, `vault.toml` cleartext metadata, and three orchestrators (`create_vault`, `open_with_password`, `open_with_recovery`) under a unified `UnlockError`.
- Closes Item 1a from `secretary_next_session.md` (§15 BIP-39 recovery KAT) with 4 vectors — all-zero entropy, all-FF entropy, and two Trezor canonical 24-word phrases — cross-verified against the Trezor `mnemonic` Python reference + `cryptography`'s HKDF.
- Test count: workspace 153 → 155, including 5 new proptest properties (CBOR / bundle_file / vault_toml roundtrip + create→open identity + timestamp out-of-range rejection).

## Test plan
- [ ] `cargo test --release --workspace` passes (155 tests)
- [ ] `cargo clippy --all-targets --workspace -- -D warnings` clean
- [ ] BIP-39 recovery KAT pins mnemonic↔entropy and entropy→Recovery KEK across 4 vectors
- [ ] Roundtrip: `create_vault → open_with_password` recovers identical IBK + bundle fields
- [ ] Roundtrip: `create_vault → open_with_recovery` recovers identical IBK + bundle fields
- [ ] Both unlock paths yield identical IBK (cross-path invariant test)
- [ ] Wrong password / wrong mnemonic / invalid mnemonic format → distinct typed errors
- [ ] Tampered `bundle_ct` byte → `CorruptVault` (via both unlock paths)
- [ ] Swapped `identity.bundle.enc` between vaults → `VaultMismatch`
- [ ] Non-UTF-8 `vault.toml` bytes → `MalformedVaultToml`
- [ ] `vault_toml::encode` rejects `created_at_ms > i64::MAX` as typed error (caught by proptest)

## Notes for reviewers
- Followed subagent-driven TDD per the implementation plan at `docs/superpowers/plans/2026-04-27-unlock-module.md`. Each block had spec-compliance + code-quality reviews before progressing.
- Spec amendment `7923b47` was merged early in the work: `docs/crypto-design.md` §5 + §14 now document `ml_dsa_65_sk` as the 32-byte FIPS 204 seed (matching `ml-dsa` 0.1.0-rc.8's non-deprecated API), not the 4032-byte expanded form.
- Two real bugs caught during review and fixed in-branch: (1) `bundle_file::bundle_ct_len` initially mis-encoded the §3 wire format by 16 bytes (caught by spec reviewer); (2) `vault_toml::encode` silently panicked on `created_at_ms > i64::MAX` (caught by proptest). Both have regression tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)