### PR TITLE
docs(fuzz-regression): extend panic-bounds precedent to contact_card OOMs

### DIFF
--- a/core/tests/fuzz_regressions.rs
+++ b/core/tests/fuzz_regressions.rs
@@ -19,6 +19,20 @@
 //! could be added later, but pinning a wall-clock value without a
 //! reproducible underlying bug is gold-plating, so we deliberately don't.
 //!
+//! The same applies to the `oom-*` artifacts under `contact_card/`:
+//! libFuzzer flagged those when per-process RSS drifted across its
+//! default 2 GB threshold during multi-million-exec sessions, but
+//! single-input replay finishes in 0–1 ms with no allocation pressure
+//! (`from_canonical_cbor(&[])` returns `Err(EOF)` immediately, never
+//! reaching an allocation path). The drift is ASAN bookkeeping
+//! (quarantine zone, instrumentation tables) accumulating across
+//! executions, not the decoder — empirically logarithmic, not linear:
+//! a 5M-exec run from the existing corpus measured peak RSS 1190 MB
+//! with the per-Mexec slope falling ~50× between exec 1e4 and exec 5e6.
+//! Pinned on the same panic-bounds rationale as the slow-units:
+//! defense-in-depth against a future regression that turns these
+//! inputs into a real panic.
+//!
 //! See docs/superpowers/specs/2026-04-30-fuzz-harness-design.md §
 //! "Regression mechanics".
 


### PR DESCRIPTION
## Summary

- Three `oom-*` artifacts surfaced under `core/fuzz/artifacts/contact_card/` during multi-million-exec sessions — none reproduce as crashes on single-input replay.
- Diagnosed as libFuzzer attributing accumulated process-wide RSS to whichever input was last dispatched when the default 2 GB threshold check fires; the contact_card decoder itself is leak-free (verified empirically — see commit message for the 5M-exec measurement).
- Doc-comment in `core/tests/fuzz_regressions.rs` extended so the `panic-bounds, not memory-bounds` precedent (already established for `slow-unit-*` under `vault_toml/`) explicitly covers the contact_card OOM class. Empirical numbers inline so a future reader doesn't need to chase commit hashes.

No code changes; doc-comment only. The two existing `oom-*` regression KATs under `core/tests/data/fuzz_regressions/contact_card/` remain pinned (defense-in-depth against a future regression that turns those inputs into a real panic) — no policy change there.

## Test plan

- [x] `cargo test --release --workspace --test fuzz_regressions` — 6 tests pass (rustc 1.95.0)
- [x] `cargo fuzz run contact_card artifacts/contact_card/oom-031e9f63...` — single-input replay completes in 1 ms with no crash (consistent with the diagnosis)
- [x] 5M-exec leak diagnostic from existing corpus — RSS slope decays ~50× (logarithmic, asymptotic; not linear) — see commit message

🤖 Generated with [Claude Code](https://claude.com/claude-code)