### PR TITLE
Pickup items #3 and #4: type-ignore cleanup + contributors index

### DIFF
--- a/core/tests/python/conformance.py
+++ b/core/tests/python/conformance.py
@@ -1945,7 +1945,8 @@ def py_merge_unknown_map(local_unk: dict, remote_unk: dict) -> dict:
         elif l_hex is not None:
             out[key] = bytes.fromhex(l_hex).hex()
         else:
-            out[key] = bytes.fromhex(r_hex).hex()  # type: ignore[arg-type]
+            assert r_hex is not None
+            out[key] = bytes.fromhex(r_hex).hex()
     return out
 
 

--- a/docs/TODO_FINAL_POLISHING.md
+++ b/docs/TODO_FINAL_POLISHING.md
@@ -7,29 +7,9 @@ to be picked up when adjacent code is next touched.
 
 ---
 
-## 1. Replace `# type: ignore[arg-type]` in `py_merge_unknown_map` with an explicit assert
+## 1. Lift the cross-language hex compare pattern into a helper if a second hex-bearing KAT field appears
 
-**Where:** [core/tests/python/conformance.py:955](core/tests/python/conformance.py#L955)
-
-The fall-through branch in `py_merge_unknown_map` ends with:
-
-```python
-out[key] = bytes.fromhex(r_hex).hex()  # type: ignore[arg-type]
-```
-
-`r_hex` is guaranteed non-`None` at that point because `all_keys` is the union
-of both sides' keys and the prior `elif l_hex is not None` branch already
-handled the local-only case — so at least one side is present. An explicit
-`assert r_hex is not None` would convince mypy without the suppression comment
-and document the invariant inline.
-
-Stylistic, not material. Pick up next time the function is touched.
-
----
-
-## 2. Lift the cross-language hex compare pattern into a helper if a second hex-bearing KAT field appears
-
-**Where:** [core/tests/python/conformance.py:921-956](core/tests/python/conformance.py#L921-L956) (`py_merge_unknown_map`)
+**Where:** [core/tests/python/conformance.py:1914-1949](core/tests/python/conformance.py#L1914-L1949) (`py_merge_unknown_map`)
 
 The case-insensitivity bug fixed in commit `2cb7202` (raw string compare on hex
 disagreeing with Rust's `u8::from_str_radix` byte-level decoding) is currently
@@ -48,9 +28,9 @@ Out of scope for this PR — only one call site exists today.
 
 ---
 
-## 3. Extract a `_record_pass_fail()` helper if Section 6 lands
+## 2. Extract a `_record_pass_fail()` helper if Section 6 lands
 
-**Where:** [core/tests/python/conformance.py:1116-1176](core/tests/python/conformance.py#L1116-L1176)
+**Where:** [core/tests/python/conformance.py:2381-2441](core/tests/python/conformance.py#L2381-L2441)
 (Section 5 — `section5_unknown_map_case_insensitivity`)
 
 Each Section 5 sub-test follows the same shape:

--- a/docs/manual/contributors/index.md
+++ b/docs/manual/contributors/index.md
@@ -1,0 +1,82 @@
+# Contributor-facing internal documentation
+
+This directory holds the **internal** documentation written for the people
+maintaining Secretary's Rust core: wire-protocol contracts that aren't
+otherwise visible from the code, and audit memos that recorded the
+methodology and findings of Phase A.7's three internal hardening passes.
+
+It is **not** user-facing documentation — for that, see
+[../primer/cryptography/index.md](../primer/cryptography/index.md) (the
+plain-language cryptography primer) and
+[../hardening-security.md](../hardening-security.md) (the user-facing
+hardening guide).
+
+## What's in here
+
+### [`differential-replay-protocol.md`](differential-replay-protocol.md)
+
+The wire protocol the Rust integration test
+[`core/tests/differential_replay.rs`](../../../core/tests/differential_replay.rs)
+expects from each fuzz target's `py_decode` / `py_encode` pair in
+[`core/tests/python/conformance.py`](../../../core/tests/python/conformance.py).
+Read this **before** adding a new fuzz target, removing one, or changing the
+encode/decode behaviour of an existing target. Some of the contract is
+machine-checked by `differential_replay.rs`; the rest is convention, easy to
+break silently if you don't know it's there.
+
+### [`side-channel-audit-internal.md`](side-channel-audit-internal.md)
+
+Phase A.7's internal pass over constant-time-sensitive call sites in the
+Rust core. Walks every CT-sensitive comparison flagged by
+[`docs/threat-model.md`](../../threat-model.md) §3.2 / §3.3, identifies the
+underlying upstream primitive, and documents what discipline that primitive
+provides. **Read the relevant section before changing any signature
+verification, AEAD tag check, KEM ciphertext compare, or fingerprint
+comparison** — the memo records which guarantees are upstream-provided
+versus which are defensive at the call site, and a regression in either
+direction is hard to spot from the diff alone.
+
+### [`memory-hygiene-audit-internal.md`](memory-hygiene-audit-internal.md)
+
+Phase A.7's internal pass over zeroize discipline in the Rust core. Walks
+every type that wraps secret bytes, verifies its zeroize-on-drop wrapper
+discipline, and enumerates the stack-residue patterns where a secret value
+could linger in a named-but-unzeroized stack slot. **Read the relevant
+section before adding a new secret-bearing field, widening an existing
+secret's lifetime, or changing the drop ordering of a composite type
+holding multiple secrets.** The "Resolved" section at the bottom is
+load-bearing: it records which originally-deferred items have since been
+fixed (most recently `RecordFieldValue::{Text, Bytes}` → `SecretString` /
+`SecretBytes` and the `MlDsa65Secret` / `MlKem768Secret` newtype-zeroize
+follow-up).
+
+## Relationship to the external review
+
+These three memos are the **principal handoff package** for the planned
+external paid review of the Rust core. The cryptographic-design and
+threat-model documents in [`docs/`](../../) are normative specs (what the
+code must implement); these memos are the audit trail (what the code
+actually does, and where the discipline holds vs. depends on an upstream
+crate's documented behaviour). An external reviewer with FIPS 203 / FIPS
+204 implementer experience should read the threat model first, then these
+three memos, then the corresponding source files.
+
+The external review is a separate, paid, time-bound engagement and is out
+of scope for any in-session pass. See
+[`secretary_next_session.md`](../../../secretary_next_session.md) → "External
+(paid, time-bound)" for the current status.
+
+## When updating these memos
+
+Each memo's introduction states its **scope** and **methodology**.
+Preserve both when extending: a memo that grows to mix ad-hoc additions
+with the original audit becomes hard to verify against. New findings that
+don't fit an existing memo's scope go into a new memo with its own
+methodology statement, not glued onto the side of one that's already
+shipped.
+
+If a memo cites a specific function name, file, or constant, the
+[`core/tests/python/spec_test_name_freshness.py`](../../../core/tests/python/spec_test_name_freshness.py)
+drift check covers it. Run that script (`uv run` from the repo root) before
+shipping a memo update; it will flag any citation that no longer resolves
+in `core/`.


### PR DESCRIPTION
## Summary

Closes the two smaller pickup items from `secretary_next_session.md`:

- **Item #3 (sub-item 1)** — `core/tests/python/conformance.py`: replace `# type: ignore[arg-type]` in `py_merge_unknown_map` fall-through branch with explicit `assert r_hex is not None`. Drops Section 1 of `docs/TODO_FINAL_POLISHING.md` per its "drop the section in the same commit" rule, and refreshes the stale line-number anchors in the two surviving sections.
- **Item #4** — `docs/manual/contributors/index.md`: new index for the Phase A.7 reviewer-handoff package (differential-replay protocol, side-channel audit, memory-hygiene audit) with per-memo scope, "when to read this" guidance, the relationship to the planned external paid review, and the maintenance discipline for extending memos.

Sub-items 2 and 3 of pickup item #3 remain unconditional defers in `TODO_FINAL_POLISHING.md` because their gating conditions (a second hex-bearing KAT field; a Section 6 with 5+ sub-tests) haven't materialised.

## Test plan

- [x] `uv run core/tests/python/conformance.py` — all 5 sections PASS (golden vault hybrid-decap, ML-DSA tamper rejection, 12-vector conflict KAT replay, case-insensitivity guard).
- [x] `uv run core/tests/python/spec_test_name_freshness.py` — 96 resolved + 0 unresolved + 2 allowlisted; the new `index.md` is now scanned (14 docs, was 13) without introducing false positives.
- [x] `cargo test --release --workspace` — 445 passed + 6 ignored (matches baseline).
- [x] `cargo clippy --release --workspace -- -D warnings` — clean.
- [x] No production-code change; FFI surface untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)