### PR TITLE
refactor(ffi-uniffi): split errors.rs into directory module (closes #29)

### DIFF
--- a/ffi/secretary-ffi-uniffi/src/errors/mod.rs
+++ b/ffi/secretary-ffi-uniffi/src/errors/mod.rs
@@ -1,0 +1,31 @@
+//! uniffi-side error types and bridge-to-uniffi error translations.
+//!
+//! Both `UnlockError` and `VaultError` mirror the bridge crate's
+//! `FfiUnlockError` / `FfiVaultError` shape. uniffi auto-marshals these to
+//! Swift `enum ...: Error` and Kotlin `sealed class ...`. The structured
+//! field is named `detail` rather than `message` because uniffi 0.31's
+//! Kotlin codegen produces an "overload resolution ambiguity" between
+//! `Throwable.message` and a user-defined `message` field.
+//!
+//! `VaultError` carries one extra variant (`InvalidArgument`) that has no
+//! counterpart in the bridge's `FfiVaultError` — it's uniffi-side only
+//! because uniffi 0.31 has no native `ValueError` equivalent at the
+//! namespace-fn level, so wrong-length / malformed FFI inputs need to ride
+//! inside `VaultError`. Pythoning out wrong-length inputs as `ValueError`
+//! is the parallel pattern in `secretary-ffi-py`.
+//!
+//! # Module layout
+//!
+//! - [`unlock`] — `UnlockError` enum + `From<FfiUnlockError>` translation.
+//! - [`vault`] — `VaultError` enum + `From<FfiVaultError>` translation
+//!   plus the uniffi-only `InvalidArgument` variant.
+//!
+//! The types are re-exported at this module's root so `lib.rs`'s
+//! `pub use errors::{UnlockError, VaultError};` line (which feeds uniffi
+//! scaffolding's `crate::TypeName` path) keeps working unchanged.
+
+pub mod unlock;
+pub mod vault;
+
+pub use unlock::UnlockError;
+pub use vault::VaultError;

--- a/ffi/secretary-ffi-uniffi/src/errors/unlock.rs
+++ b/ffi/secretary-ffi-uniffi/src/errors/unlock.rs
@@ -1,0 +1,145 @@
+//! uniffi-side `UnlockError` mirroring the bridge crate's `FfiUnlockError`.
+
+use secretary_ffi_bridge::FfiUnlockError;
+
+/// uniffi-side error type. uniffi auto-marshals this to Swift `enum
+/// UnlockError: Error` and Kotlin `sealed class UnlockError`. Mirrors
+/// the bridge crate's `FfiUnlockError` shape exactly.
+///
+/// The structured field is named `detail` rather than `message` because
+/// uniffi 0.31's Kotlin codegen produces an "overload resolution
+/// ambiguity" between `Throwable.message` and a user-defined `message`
+/// field. `detail` keeps the field structured-accessible on Swift /
+/// Kotlin while avoiding the codegen collision. The field name must
+/// stay in sync with `secretary.udl`.
+#[derive(Debug, thiserror::Error)]
+pub enum UnlockError {
+    /// Wrong password OR vault corruption — deliberately conflated per
+    /// `docs/threat-model.md` §13. Returned by `open_with_password`.
+    #[error("wrong password or vault corruption")]
+    WrongPasswordOrCorrupt,
+    /// Wrong recovery phrase OR vault corruption — parallel to the password
+    /// path. Returned by `open_with_recovery`.
+    #[error("wrong recovery phrase or vault corruption")]
+    WrongMnemonicOrCorrupt,
+    /// Invalid recovery phrase — pre-decryption BIP-39 validation failure
+    /// (wrong word count, unknown word, bad checksum, or invalid UTF-8).
+    /// NOT a security oracle.
+    #[error("invalid recovery phrase: {detail}")]
+    InvalidMnemonic {
+        /// Diagnostic text; free-form.
+        detail: String,
+    },
+    /// `vault.toml` and `identity.bundle.enc` reference different vaults.
+    #[error("vault.toml and identity.bundle.enc reference different vaults")]
+    VaultMismatch,
+    /// Vault data integrity failure — covers BOTH directions: open-path
+    /// failure (vault file is malformed / unreadable) AND create-path
+    /// failure (couldn't even produce the vault bytes; rare, e.g. Argon2id
+    /// system-OOM or CBOR serialization failure of the in-memory bundle).
+    /// Carries a diagnostic `detail` string for debugging; not
+    /// pattern-matchable on the inner cause.
+    #[error("vault data integrity failure: {detail}")]
+    CorruptVault {
+        /// Diagnostic text from the inner `core::UnlockError` variant's
+        /// `Display` impl. Free-form; not part of the API contract.
+        detail: String,
+    },
+}
+
+impl From<FfiUnlockError> for UnlockError {
+    fn from(e: FfiUnlockError) -> Self {
+        match e {
+            FfiUnlockError::WrongPasswordOrCorrupt => Self::WrongPasswordOrCorrupt,
+            FfiUnlockError::WrongMnemonicOrCorrupt => Self::WrongMnemonicOrCorrupt,
+            FfiUnlockError::InvalidMnemonic { detail } => Self::InvalidMnemonic { detail },
+            FfiUnlockError::VaultMismatch => Self::VaultMismatch,
+            FfiUnlockError::CorruptVault { detail } => Self::CorruptVault { detail },
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // -------------------------------------------------------------------
+    // B.2: pin the From<FfiUnlockError> for UnlockError mapping.
+    //
+    // The bridge crate already tests core → FfiUnlockError; these tests
+    // pin the FfiUnlockError → uniffi-side UnlockError translation
+    // explicitly so a future variant rename / reorder can't silently
+    // remap one variant to another.
+    // -------------------------------------------------------------------
+
+    #[test]
+    fn from_bridge_wrong_password_or_corrupt_maps_one_to_one() {
+        let bridge_err = FfiUnlockError::WrongPasswordOrCorrupt;
+        let uniffi_err: UnlockError = bridge_err.into();
+        assert!(matches!(uniffi_err, UnlockError::WrongPasswordOrCorrupt));
+    }
+
+    #[test]
+    fn from_bridge_vault_mismatch_maps_one_to_one() {
+        let bridge_err = FfiUnlockError::VaultMismatch;
+        let uniffi_err: UnlockError = bridge_err.into();
+        assert!(matches!(uniffi_err, UnlockError::VaultMismatch));
+    }
+
+    #[test]
+    fn from_bridge_corrupt_vault_preserves_detail() {
+        // B.3a renamed the bridge's CorruptVault field from `message` to
+        // `detail` for naming uniformity with InvalidMnemonic { detail }.
+        // Both layers now use `detail`; the From translation is a struct-
+        // shorthand pass-through.
+        let bridge_err = FfiUnlockError::CorruptVault {
+            detail: "fnord".to_string(),
+        };
+        let uniffi_err: UnlockError = bridge_err.into();
+        let UnlockError::CorruptVault { detail } = uniffi_err else {
+            panic!("expected CorruptVault");
+        };
+        assert_eq!(detail, "fnord");
+    }
+
+    #[test]
+    fn from_bridge_wrong_mnemonic_or_corrupt_maps_one_to_one() {
+        let bridge_err = FfiUnlockError::WrongMnemonicOrCorrupt;
+        let uniffi_err: UnlockError = bridge_err.into();
+        assert!(matches!(uniffi_err, UnlockError::WrongMnemonicOrCorrupt));
+    }
+
+    #[test]
+    fn from_bridge_invalid_mnemonic_preserves_detail() {
+        let bridge_err = FfiUnlockError::InvalidMnemonic {
+            detail: "expected 24 words, got 3".to_string(),
+        };
+        let uniffi_err: UnlockError = bridge_err.into();
+        let UnlockError::InvalidMnemonic { detail } = uniffi_err else {
+            panic!("expected InvalidMnemonic");
+        };
+        assert_eq!(detail, "expected 24 words, got 3");
+    }
+
+    #[test]
+    fn corrupt_vault_display_uses_path_neutral_text() {
+        // Mirror of the bridge crate's tripwire (see ffi/secretary-ffi-bridge/
+        // src/error.rs). The uniffi-side UnlockError carries its own Display
+        // attributes (because uniffi codegen uses this enum to produce the
+        // Swift / Kotlin error messages); this test pins the path-neutral
+        // wording so a future revert here is a deliberate decision.
+        let err = UnlockError::CorruptVault {
+            detail: "fnord".to_string(),
+        };
+        let rendered = format!("{err}");
+        assert!(
+            rendered.contains("vault data integrity failure"),
+            "Display did not contain the path-neutral text: {rendered}",
+        );
+        assert!(rendered.contains("fnord"), "Display did not include detail");
+        assert!(
+            !rendered.contains("corrupt or unreadable"),
+            "Display still contains the old read-path-only text: {rendered}",
+        );
+    }
+}

--- a/ffi/secretary-ffi-uniffi/src/errors/vault.rs
+++ b/ffi/secretary-ffi-uniffi/src/errors/vault.rs
@@ -1,88 +1,10 @@
-//! uniffi-side error types and bridge-to-uniffi error translations.
-//!
-//! Both `UnlockError` and `VaultError` mirror the bridge crate's
-//! `FfiUnlockError` / `FfiVaultError` shape. uniffi auto-marshals these to
-//! Swift `enum ...: Error` and Kotlin `sealed class ...`. The structured
-//! field is named `detail` rather than `message` because uniffi 0.31's
-//! Kotlin codegen produces an "overload resolution ambiguity" between
-//! `Throwable.message` and a user-defined `message` field.
-//!
-//! `VaultError` carries one extra variant (`InvalidArgument`) that has no
-//! counterpart in the bridge's `FfiVaultError` — it's uniffi-side only
-//! because uniffi 0.31 has no native `ValueError` equivalent at the
-//! namespace-fn level, so wrong-length / malformed FFI inputs need to ride
-//! inside `VaultError`. Pythoning out wrong-length inputs as `ValueError`
-//! is the parallel pattern in `secretary-ffi-py`.
+//! uniffi-side `VaultError` mirroring `FfiVaultError` + the uniffi-only
+//! `InvalidArgument` variant for wrong-shape FFI inputs.
 
-use secretary_ffi_bridge::{FfiUnlockError, FfiVaultError};
-
-// =============================================================================
-// UnlockError (mirrors FfiUnlockError 5-variant shape)
-// =============================================================================
-
-/// uniffi-side error type. uniffi auto-marshals this to Swift `enum
-/// UnlockError: Error` and Kotlin `sealed class UnlockError`. Mirrors
-/// the bridge crate's `FfiUnlockError` shape exactly.
-///
-/// The structured field is named `detail` rather than `message` because
-/// uniffi 0.31's Kotlin codegen produces an "overload resolution
-/// ambiguity" between `Throwable.message` and a user-defined `message`
-/// field. `detail` keeps the field structured-accessible on Swift /
-/// Kotlin while avoiding the codegen collision. The field name must
-/// stay in sync with `secretary.udl`.
-#[derive(Debug, thiserror::Error)]
-pub enum UnlockError {
-    /// Wrong password OR vault corruption — deliberately conflated per
-    /// `docs/threat-model.md` §13. Returned by `open_with_password`.
-    #[error("wrong password or vault corruption")]
-    WrongPasswordOrCorrupt,
-    /// Wrong recovery phrase OR vault corruption — parallel to the password
-    /// path. Returned by `open_with_recovery`.
-    #[error("wrong recovery phrase or vault corruption")]
-    WrongMnemonicOrCorrupt,
-    /// Invalid recovery phrase — pre-decryption BIP-39 validation failure
-    /// (wrong word count, unknown word, bad checksum, or invalid UTF-8).
-    /// NOT a security oracle.
-    #[error("invalid recovery phrase: {detail}")]
-    InvalidMnemonic {
-        /// Diagnostic text; free-form.
-        detail: String,
-    },
-    /// `vault.toml` and `identity.bundle.enc` reference different vaults.
-    #[error("vault.toml and identity.bundle.enc reference different vaults")]
-    VaultMismatch,
-    /// Vault data integrity failure — covers BOTH directions: open-path
-    /// failure (vault file is malformed / unreadable) AND create-path
-    /// failure (couldn't even produce the vault bytes; rare, e.g. Argon2id
-    /// system-OOM or CBOR serialization failure of the in-memory bundle).
-    /// Carries a diagnostic `detail` string for debugging; not
-    /// pattern-matchable on the inner cause.
-    #[error("vault data integrity failure: {detail}")]
-    CorruptVault {
-        /// Diagnostic text from the inner `core::UnlockError` variant's
-        /// `Display` impl. Free-form; not part of the API contract.
-        detail: String,
-    },
-}
-
-impl From<FfiUnlockError> for UnlockError {
-    fn from(e: FfiUnlockError) -> Self {
-        match e {
-            FfiUnlockError::WrongPasswordOrCorrupt => Self::WrongPasswordOrCorrupt,
-            FfiUnlockError::WrongMnemonicOrCorrupt => Self::WrongMnemonicOrCorrupt,
-            FfiUnlockError::InvalidMnemonic { detail } => Self::InvalidMnemonic { detail },
-            FfiUnlockError::VaultMismatch => Self::VaultMismatch,
-            FfiUnlockError::CorruptVault { detail } => Self::CorruptVault { detail },
-        }
-    }
-}
-
-// =============================================================================
-// VaultError (mirrors FfiVaultError 8 variants + uniffi-only InvalidArgument)
-// =============================================================================
+use secretary_ffi_bridge::FfiVaultError;
 
 /// uniffi projection of FfiVaultError + one extra variant for FFI input-
-/// shape errors (`InvalidArgument`). Nine flat variants matching the UDL
+/// shape errors (`InvalidArgument`). Flat variants matching the UDL
 /// declaration.
 ///
 /// The structured-field rename rationale is the same as UnlockError's:
@@ -90,7 +12,7 @@ impl From<FfiUnlockError> for UnlockError {
 /// `Throwable.message` and a UDL-declared `message` field, so structured
 /// fields are named `detail`.
 ///
-/// The eighth variant `InvalidArgument` has no counterpart in the bridge's
+/// The `InvalidArgument` variant has no counterpart in the bridge's
 /// `FfiVaultError` — it's uniffi-side only because uniffi 0.31 has no
 /// native `ValueError` equivalent at the namespace-fn level, so wrong-
 /// length / malformed FFI inputs (e.g. `block_uuid` ≠ 16 bytes) need to
@@ -186,86 +108,6 @@ mod tests {
     use super::*;
 
     // -------------------------------------------------------------------
-    // B.2: pin the From<FfiUnlockError> for UnlockError mapping.
-    //
-    // The bridge crate already tests core → FfiUnlockError; these tests
-    // pin the FfiUnlockError → uniffi-side UnlockError translation
-    // explicitly so a future variant rename / reorder can't silently
-    // remap one variant to another.
-    // -------------------------------------------------------------------
-
-    #[test]
-    fn from_bridge_wrong_password_or_corrupt_maps_one_to_one() {
-        let bridge_err = FfiUnlockError::WrongPasswordOrCorrupt;
-        let uniffi_err: UnlockError = bridge_err.into();
-        assert!(matches!(uniffi_err, UnlockError::WrongPasswordOrCorrupt));
-    }
-
-    #[test]
-    fn from_bridge_vault_mismatch_maps_one_to_one() {
-        let bridge_err = FfiUnlockError::VaultMismatch;
-        let uniffi_err: UnlockError = bridge_err.into();
-        assert!(matches!(uniffi_err, UnlockError::VaultMismatch));
-    }
-
-    #[test]
-    fn from_bridge_corrupt_vault_preserves_detail() {
-        // B.3a renamed the bridge's CorruptVault field from `message` to
-        // `detail` for naming uniformity with InvalidMnemonic { detail }.
-        // Both layers now use `detail`; the From translation is a struct-
-        // shorthand pass-through.
-        let bridge_err = FfiUnlockError::CorruptVault {
-            detail: "fnord".to_string(),
-        };
-        let uniffi_err: UnlockError = bridge_err.into();
-        let UnlockError::CorruptVault { detail } = uniffi_err else {
-            panic!("expected CorruptVault");
-        };
-        assert_eq!(detail, "fnord");
-    }
-
-    #[test]
-    fn from_bridge_wrong_mnemonic_or_corrupt_maps_one_to_one() {
-        let bridge_err = FfiUnlockError::WrongMnemonicOrCorrupt;
-        let uniffi_err: UnlockError = bridge_err.into();
-        assert!(matches!(uniffi_err, UnlockError::WrongMnemonicOrCorrupt));
-    }
-
-    #[test]
-    fn from_bridge_invalid_mnemonic_preserves_detail() {
-        let bridge_err = FfiUnlockError::InvalidMnemonic {
-            detail: "expected 24 words, got 3".to_string(),
-        };
-        let uniffi_err: UnlockError = bridge_err.into();
-        let UnlockError::InvalidMnemonic { detail } = uniffi_err else {
-            panic!("expected InvalidMnemonic");
-        };
-        assert_eq!(detail, "expected 24 words, got 3");
-    }
-
-    #[test]
-    fn corrupt_vault_display_uses_path_neutral_text() {
-        // Mirror of the bridge crate's tripwire (see ffi/secretary-ffi-bridge/
-        // src/error.rs). The uniffi-side UnlockError carries its own Display
-        // attributes (because uniffi codegen uses this enum to produce the
-        // Swift / Kotlin error messages); this test pins the path-neutral
-        // wording so a future revert here is a deliberate decision.
-        let err = UnlockError::CorruptVault {
-            detail: "fnord".to_string(),
-        };
-        let rendered = format!("{err}");
-        assert!(
-            rendered.contains("vault data integrity failure"),
-            "Display did not contain the path-neutral text: {rendered}",
-        );
-        assert!(rendered.contains("fnord"), "Display did not include detail");
-        assert!(
-            !rendered.contains("corrupt or unreadable"),
-            "Display still contains the old read-path-only text: {rendered}",
-        );
-    }
-
-    // -------------------------------------------------------------------
     // B.4a: pin the From<FfiVaultError> for VaultError mapping.
     // -------------------------------------------------------------------
 
@@ -314,8 +156,8 @@ mod tests {
 
     #[test]
     fn vault_error_block_not_found_maps_one_to_one() {
-        // Pin the 7th variant translation. A future rename would fail
-        // here first.
+        // Pin the BlockNotFound variant translation. A future rename would
+        // fail here first.
         use FfiVaultError as B;
         let bnf = VaultError::from(B::BlockNotFound {
             uuid_hex: "abc123".to_string(),
@@ -328,7 +170,7 @@ mod tests {
 
     #[test]
     fn invalid_argument_display_pins_detail_text() {
-        // Pin the Display contract for the new uniffi-only variant. uniffi
+        // Pin the Display contract for the uniffi-only variant. uniffi
         // 0.31 codegen uses the #[error(...)] attribute to drive the
         // Swift / Kotlin generated message text; a future rename of the
         // attribute would silently change the foreign-side exception
@@ -350,8 +192,9 @@ mod tests {
 
     #[test]
     fn vault_error_save_crypto_failure_maps_one_to_one() {
-        // Pin the 9th variant translation. A future rename or accidental
-        // remap to CorruptVault / FolderInvalid would fail here first.
+        // Pin the SaveCryptoFailure variant translation. A future rename
+        // or accidental remap to CorruptVault / FolderInvalid would fail
+        // here first.
         let bridge_err = FfiVaultError::SaveCryptoFailure {
             detail: "test detail".to_string(),
         };
@@ -380,8 +223,8 @@ mod tests {
     }
 
     // -------------------------------------------------------------------
-    // B.4d: pin the 4 new share_block variants — Display + From mapping.
-    // Same pattern as B.4c's SaveCryptoFailure pair (a31e6e6).
+    // B.4d: pin the 4 share_block variants — Display + From mapping.
+    // Same pattern as B.4c's SaveCryptoFailure pair.
     // -------------------------------------------------------------------
 
     #[test]
@@ -489,6 +332,10 @@ mod tests {
             "Display did not include detail"
         );
     }
+
+    // -------------------------------------------------------------------
+    // B.5: pin the 2 trash/restore variants — Display + From mapping.
+    // -------------------------------------------------------------------
 
     #[test]
     fn ffi_to_uniffi_block_uuid_already_live() {


### PR DESCRIPTION
## Summary

- Mirror the bridge crate's `error/` directory module pattern (PR #53) for the uniffi-side error layer
- Split flat 532-line [`errors.rs`](ffi/secretary-ffi-uniffi/src/errors.rs) into [`errors/{mod.rs, unlock.rs, vault.rs}`](ffi/secretary-ffi-uniffi/src/errors/) (31 / 145 / 379 lines)
- No semantic change — every type, variant, error message, `From` mapping and test moved verbatim
- `lib.rs` is untouched: the existing `pub use errors::{UnlockError, VaultError}` line already feeds uniffi scaffolding's `crate::TypeName` paths from the new mod

## Why

- Closes the last open item from issue #29 (PyO3 + bridge splits already landed via #43 / #53)
- 532 > 500-line guideline in CLAUDE.md; ~60% of the file was tests
- Reading single-concept files (one error enum per file + its translation impl + its pinned tests) is materially easier than scanning a flat file with two concerns interleaved

## Test plan

- [x] `cargo test --release --workspace --no-fail-fast` → 640 passed; 0 failed; 9 ignored (unchanged baseline)
- [x] `cargo clippy --release --workspace -- -D warnings` → clean
- [x] `cargo fmt --all -- --check` → OK
- [x] `uv run core/tests/python/conformance.py` → PASS
- [x] `uv run core/tests/python/spec_test_name_freshness.py` → PASS (96/0/2 unchanged)
- [x] `bash ffi/secretary-ffi-uniffi/tests/swift/run.sh` → 37/37 PASS
- [x] `bash ffi/secretary-ffi-uniffi/tests/kotlin/run.sh` → 37/37 PASS

Closes #29.

🤖 Generated with [Claude Code](https://claude.com/claude-code)