### PR TITLE
C.1.1b Task 13 — veto handling (KeepLocal / AcceptTombstone / Missing+Unknown bijection) + prepare_merge fix

### DIFF
--- a/NEXT_SESSION.md
+++ b/NEXT_SESSION.md
@@ -1,1 +1,1 @@
-docs/handoffs/2026-05-20-c1-1b-task-12-shipped.md
+docs/handoffs/2026-05-21-c1-1b-task-13-shipped.md

--- a/core/src/sync/prepare.rs
+++ b/core/src/sync/prepare.rs
@@ -454,22 +454,39 @@ pub fn prepare_merge(
             copy_plaintexts.push(copy_pt);
         }
 
-        // Per-record veto pass. Linear scan: O(records · copies ·
-        // records_per_copy). Acceptable at v1 scale (a handful of
-        // copies × tens of records); a per-copy
-        // `BTreeMap<record_uuid, &Record>` index would be the
-        // tighter shape if Task 15's proptests show this in a hot
-        // path.
-        for (record_uuid, local_rec) in acc_records.iter() {
-            if local_rec.tombstone {
+        // Per-record veto pass. Walk the CANONICAL (pre-merge) records
+        // here, NOT `acc_records` (the post-merge accumulator). The
+        // veto's `local_state` is the canonical record — what
+        // [`crate::sync::commit::apply_decisions::KeepLocal`] will
+        // restore on top of `merged_records` when the user rejects the
+        // peer's tombstone.
+        //
+        // Why pre-merge and not post-merge: when a peer's tombstone is
+        // strictly later than the canonical record's `last_mod_ms`,
+        // [`merge_block`]'s §11.3 tombstone-wins-by-clock rule writes
+        // a tombstoned record into `acc_records`. Iterating
+        // `acc_records` here would see `local_rec.tombstone == true`
+        // and `continue` past the very case the veto is meant to
+        // surface — making the integration veto branch unreachable
+        // under well-formed inputs (proved by the test corpus from
+        // C.1.1b Task 13.1; the pre-fix behavior produced
+        // `vetoes.is_empty()` on a per-block-divergent fixture where
+        // the design says exactly one veto must fire).
+        //
+        // Linear scan: O(canonical_records · copies · records_per_copy).
+        // Acceptable at v1 scale (a handful of copies × tens of records);
+        // a per-copy `BTreeMap<record_uuid, &Record>` index would be the
+        // tighter shape if Task 15's proptests show this in a hot path.
+        for canonical_rec in canonical_pt.records.iter() {
+            if canonical_rec.tombstone {
                 continue;
             }
             let peers: Vec<&Record> = copy_plaintexts
                 .iter()
                 .flat_map(|cpt| cpt.records.iter())
-                .filter(|r| r.record_uuid == *record_uuid)
+                .filter(|r| r.record_uuid == canonical_rec.record_uuid)
                 .collect();
-            if let Some(v) = tombstone_veto_set(local_rec, *block_uuid, &peers) {
+            if let Some(v) = tombstone_veto_set(canonical_rec, *block_uuid, &peers) {
                 vetoes.push(v);
             }
         }

--- a/core/tests/fixtures/mod.rs
+++ b/core/tests/fixtures/mod.rs
@@ -2,7 +2,7 @@
 //! Re-uses the golden_vault_001 inputs JSON sourced by the existing
 //! golden_vault_001 integration test.
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use secretary_core::crypto::secret::SecretBytes;
 use serde::Deserialize;
@@ -32,4 +32,24 @@ pub fn golden_vault_001_password() -> SecretBytes {
     let inputs: Inputs =
         serde_json::from_str(&raw).expect("golden_vault_001_inputs.json must be valid JSON");
     SecretBytes::new(inputs.password.into_bytes())
+}
+
+/// Decode the `vault_uuid` from a vault folder's `vault.toml`. Pinned
+/// in the golden_vault_001 fixture builder; any drift surfaces here as
+/// a decode failure rather than a hard-coded mismatch in callers.
+///
+/// Shared by the C.1 sync integration tests (`sync.rs`, `sync_ingest.rs`,
+/// `sync_ingest_proptest.rs`, `sync_merge.rs`, `sync_merge_vetoes.rs`)
+/// which all need the vault's UUID to build a `SyncState` bound to it.
+///
+/// `#[allow(dead_code)]` because `core/tests/fixtures/mod.rs` is compiled
+/// once per `tests/*.rs` test binary; binaries that import the module
+/// only for [`golden_vault_001_password`] (e.g. `open_vault.rs`) would
+/// see this function as unused.
+#[allow(dead_code)]
+pub fn extract_vault_uuid(folder: &Path) -> [u8; 16] {
+    let s = std::fs::read_to_string(folder.join("vault.toml"))
+        .expect("vault.toml must exist in fixture folder");
+    let vt = secretary_core::unlock::vault_toml::decode(&s).expect("decode vault.toml");
+    vt.vault_uuid
 }

--- a/core/tests/sync.rs
+++ b/core/tests/sync.rs
@@ -250,13 +250,12 @@ fn sync_once_concurrent_manifest_hash_matches_bundle_envelope_bytes() {
     }
 }
 
-/// Helper: extract the golden vault's vault_uuid from its vault.toml
-/// so we don't hard-code the value here — it's pinned in the fixture
-/// builder and any drift would surface as a vault.toml decode failure.
+/// Helper: extract the golden vault's vault_uuid via the shared
+/// [`fixtures::extract_vault_uuid`] helper, fixing the folder to the
+/// in-tree golden_vault_001 since this file's tests run against the
+/// pre-built fixture (not a temp copy).
 fn extract_golden_vault_uuid() -> [u8; 16] {
-    let s = std::fs::read_to_string("tests/data/golden_vault_001/vault.toml").unwrap();
-    let vt = secretary_core::unlock::vault_toml::decode(&s).unwrap();
-    vt.vault_uuid
+    fixtures::extract_vault_uuid(std::path::Path::new("tests/data/golden_vault_001"))
 }
 
 #[test]

--- a/core/tests/sync_helpers/mod.rs
+++ b/core/tests/sync_helpers/mod.rs
@@ -342,6 +342,77 @@ pub fn rewrite_block_with_records(
     new_records: Vec<secretary_core::vault::Record>,
     aead_nonce: &[u8; AEAD_NONCE_LEN],
 ) -> [u8; 32] {
+    let entry = open
+        .manifest
+        .blocks
+        .iter()
+        .find(|b| b.block_uuid == block_uuid)
+        .cloned()
+        .expect("block_uuid not in manifest");
+
+    let (fp, bytes) = encrypt_block_bytes_for_uuid(
+        open,
+        block_uuid,
+        new_records,
+        entry.vector_clock_summary.clone(),
+        entry.block_name.clone(),
+        entry.created_at_ms,
+        entry.last_mod_ms,
+        aead_nonce,
+    );
+
+    let path = block_file_path(folder, &block_uuid);
+    // Ensure blocks/ exists (golden vault always has it, but a future
+    // caller may rewrite into a sparser fixture).
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).expect("create_dir_all blocks/");
+    }
+    std::fs::write(&path, &bytes).expect("write block file");
+
+    fp
+}
+
+/// Pure-encryption variant of [`rewrite_block_with_records`]: build a
+/// `BlockHeader` + `BlockPlaintext` from the supplied parameters, encrypt
+/// via `encrypt_block` under the owner identity reachable from `open`,
+/// CBOR-encode the resulting `BlockFile`, and return the BLAKE3-256
+/// fingerprint + envelope bytes. Performs **no I/O** — callers decide
+/// where on disk to put the resulting envelope (canonical path,
+/// sibling-suffix path, etc.).
+///
+/// Used by both [`rewrite_block_with_records`] (single canonical write)
+/// and [`fresh_vault_two_concurrent_blocks`] (canonical + sibling block
+/// pair). Splitting the encryption from the file write lets the
+/// two-block fixture vary `block_clock` and `block_seed` per envelope
+/// without re-deriving the owner keys.
+///
+/// `block_clock` is written verbatim into both the `BlockHeader.vector_clock`
+/// (signed inside the block envelope) AND the `BlockPlaintext` record
+/// list — the caller is responsible for matching this against the
+/// manifest's `BlockEntry.vector_clock_summary` for self-consistency
+/// (D6 doesn't check it, but `prepare_merge`'s veto detection compares
+/// against the manifest copy, not the block header).
+///
+/// `block_name` / `created_at_ms` / `last_mod_ms` mirror save_block's
+/// step 4-9 pattern. `last_mod_ms` is the moment-of-rewrite stamp; the
+/// canonical block's existing value is preserved when this is called
+/// from the no-mutation path.
+///
+/// `aead_seed` is the 24-byte rewrite seed for `ChaCha20Rng::from_seed`;
+/// see [`rewrite_block_with_records`]'s docstring for the seed-vs-nonce
+/// rationale and AEAD-uniqueness invariant.
+#[allow(dead_code)]
+#[allow(clippy::too_many_arguments)]
+fn encrypt_block_bytes_for_uuid(
+    open: &secretary_core::vault::OpenVault,
+    block_uuid: [u8; SYNC_HELPERS_UUID_LEN],
+    new_records: Vec<secretary_core::vault::Record>,
+    block_clock: Vec<VectorClockEntry>,
+    block_name: String,
+    created_at_ms: u64,
+    last_mod_ms: u64,
+    aead_seed: &[u8; AEAD_NONCE_LEN],
+) -> ([u8; 32], Vec<u8>) {
     use rand_chacha::{rand_core::SeedableRng, ChaCha20Rng};
     use secretary_core::crypto::kem::MlKem768Public;
     use secretary_core::identity::fingerprint::fingerprint;
@@ -355,14 +426,6 @@ pub fn rewrite_block_with_records(
     // (`save_block` core path, `save_block.rs` test fixtures).
     const BLOCK_VERSION_V1: u32 = 1;
     const SCHEMA_VERSION_V1: u32 = 1;
-
-    let entry_idx = open
-        .manifest
-        .blocks
-        .iter()
-        .position(|b| b.block_uuid == block_uuid)
-        .expect("block_uuid not in manifest");
-    let entry = open.manifest.blocks[entry_idx].clone();
 
     // Re-derive owner sender keys (mirrors save_block step 4 setup).
     let owner_card_bytes = open.owner_card.to_canonical_cbor().expect("card cbor");
@@ -395,14 +458,14 @@ pub fn rewrite_block_with_records(
         file_kind: FILE_KIND_BLOCK,
         vault_uuid: open.manifest.vault_uuid,
         block_uuid,
-        created_at_ms: entry.created_at_ms,
-        last_mod_ms: entry.last_mod_ms,
-        vector_clock: entry.vector_clock_summary.clone(),
+        created_at_ms,
+        last_mod_ms,
+        vector_clock: block_clock,
     };
     let plaintext = BlockPlaintext {
         block_version: BLOCK_VERSION_V1,
         block_uuid,
-        block_name: entry.block_name.clone(),
+        block_name,
         schema_version: SCHEMA_VERSION_V1,
         records: new_records,
         unknown: std::collections::BTreeMap::new(),
@@ -417,7 +480,7 @@ pub fn rewrite_block_with_records(
     // would break determinism, which the `distinct_seeds_produce_
     // distinct_ciphertexts` invariant depends on.
     let mut seed = [0u8; 32];
-    seed[..AEAD_NONCE_LEN].copy_from_slice(aead_nonce);
+    seed[..AEAD_NONCE_LEN].copy_from_slice(aead_seed);
     let mut rng = ChaCha20Rng::from_seed(seed);
 
     let block_file = encrypt_block(
@@ -432,17 +495,8 @@ pub fn rewrite_block_with_records(
     )
     .expect("encrypt_block");
     let bytes = encode_block_file(&block_file).expect("encode_block_file");
-    let fingerprint_out = *secretary_core::crypto::hash::hash(&bytes).as_bytes();
-
-    let path = block_file_path(folder, &block_uuid);
-    // Ensure blocks/ exists (golden vault always has it, but a future
-    // caller may rewrite into a sparser fixture).
-    if let Some(parent) = path.parent() {
-        std::fs::create_dir_all(parent).expect("create_dir_all blocks/");
-    }
-    std::fs::write(&path, &bytes).expect("write block file");
-
-    fingerprint_out
+    let fp = *secretary_core::crypto::hash::hash(&bytes).as_bytes();
+    (fp, bytes)
 }
 
 /// Rewrite the block at `block_uuid` with `new_records` (via
@@ -563,6 +617,240 @@ pub fn rewrite_block_with_records_and_update_manifest(
     std::fs::write(folder.join(MANIFEST_FILENAME), &manifest_bytes).expect("write manifest");
 
     new_fingerprint
+}
+
+/// Per-block-divergent two-manifest fixture for C.1.1b Task 13's veto
+/// tests. Writes BOTH a canonical block file (with `canonical_records`)
+/// AND a sibling block file at
+/// `blocks/<uuid>.cbor.enc<sibling_block_suffix>` (with `sibling_records`),
+/// then re-signs the canonical manifest AND writes a sibling manifest
+/// such that:
+///
+/// 1. The canonical manifest's `BlockEntry[block_uuid]` has
+///    `fingerprint = BLAKE3(canonical_block_bytes)` and
+///    `vector_clock_summary = canonical_block_clock`.
+/// 2. The sibling manifest's `BlockEntry[block_uuid]` has
+///    `fingerprint = BLAKE3(sibling_block_bytes)` and
+///    `vector_clock_summary = sibling_block_clock`.
+/// 3. Both manifests' top-level `vector_clock` are set per the
+///    `*_manifest_clock` arguments.
+///
+/// This drives the C.1.1a ingest layer to emit a non-empty
+/// `bundle.diverging_blocks` (because the canonical + sibling
+/// `vector_clock_summary` for the same block_uuid are concurrent) and
+/// `prepare_merge`'s [`crate::sync::parent_block_clock`] fingerprint
+/// match to bind each block envelope to the correct manifest's
+/// per-block clock.
+///
+/// The post-fixture vault opens cleanly: D6 only checks the CANONICAL
+/// manifest's `BlockEntry.fingerprint` against the on-disk file at
+/// `blocks/<uuid>.cbor.enc` — the sibling block file is invisible to
+/// `verify_block_fingerprints`. The sibling manifest's claim of a
+/// different fingerprint is fine because D6 doesn't inspect sibling
+/// manifests.
+///
+/// Pre-condition: `block_uuid` MUST exist in `golden_vault_001`'s
+/// manifest (caller obtains via [`golden_vault_001_first_block_uuid`]
+/// for the single-block fixture, or knows the UUID a priori for a
+/// fresh-built multi-block fixture).
+///
+/// Constraints on caller:
+/// - `canonical_block_clock` and `sibling_block_clock` MUST be
+///   concurrent (or sibling strictly dominate canonical) — otherwise
+///   `ingest_block_divergence` skips this block and the bundle's
+///   `diverging_blocks` is empty (same outcome as Task 9's smoke test).
+/// - `canonical_manifest_clock` and `sibling_manifest_clock` MUST be
+///   concurrent — otherwise `sync_once` returns a non-`ConcurrentDetected`
+///   outcome and the merge pipeline never engages.
+/// - `sibling_block_suffix` MUST start with a non-empty separator
+///   (e.g. `".sync-conflict-from-device-bb"`) so the resulting filename
+///   is recognized as a sibling by
+///   [`crate::sync::enumerate_block_siblings`] (any filename strictly
+///   starting with `<uuid>.cbor.enc` and not equal to it qualifies).
+/// - `sibling_manifest_filename` MUST start with `"manifest.cbor.enc"`
+///   for the same reason — see Task 8's existing helpers for the
+///   convention.
+///
+/// `now_ms` is written into both blocks' `header.last_mod_ms` AND both
+/// manifests' `BlockEntry.last_mod_ms` for the block_uuid (mirroring
+/// `commit_with_decisions`'s step 5-6 production behavior at the
+/// fixture level).
+///
+/// Returns `(folder, tmp)` — caller keeps `tmp` alive for the test scope.
+#[allow(dead_code)]
+#[allow(clippy::too_many_arguments)]
+pub fn fresh_vault_two_concurrent_blocks(
+    block_uuid: [u8; SYNC_HELPERS_UUID_LEN],
+    canonical_records: Vec<secretary_core::vault::Record>,
+    canonical_block_clock: Vec<VectorClockEntry>,
+    canonical_manifest_clock: Vec<VectorClockEntry>,
+    sibling_records: Vec<secretary_core::vault::Record>,
+    sibling_block_clock: Vec<VectorClockEntry>,
+    sibling_manifest_clock: Vec<VectorClockEntry>,
+    sibling_manifest_filename: &str,
+    sibling_block_suffix: &str,
+    now_ms: u64,
+) -> (PathBuf, tempfile::TempDir) {
+    // Step 1: fresh copy of golden_vault_001 into a temp dir. The
+    // canonical manifest's top-level clock is set to a placeholder
+    // (we'll overwrite it in step 5); using an empty clock here means
+    // the temp vault opens cleanly via the standard fresh helper.
+    let (folder, tmp) = fresh_vault_with_clock(Vec::new());
+
+    // Step 2: open the vault to cache identity material. The cached
+    // handle drives both block encryptions AND both manifest re-signs
+    // without ever re-reading disk during the fingerprint-inconsistent
+    // window (mirrors the pattern in
+    // [`rewrite_block_with_records_and_update_manifest`]).
+    let password = fixtures::golden_vault_001_password();
+    let open = open_vault(&folder, Unlocker::Password(&password), None).expect("open_vault");
+
+    // Step 3: encrypt the canonical block + sibling block in-process.
+    // Both use the existing per-block name + created_at_ms from the
+    // golden vault entry; the block_clock + records + AEAD seed vary
+    // per envelope.
+    let golden_entry = open
+        .manifest
+        .blocks
+        .iter()
+        .find(|b| b.block_uuid == block_uuid)
+        .cloned()
+        .expect("block_uuid not in golden manifest");
+
+    let (canonical_fp, canonical_bytes) = encrypt_block_bytes_for_uuid(
+        &open,
+        block_uuid,
+        canonical_records,
+        canonical_block_clock.clone(),
+        golden_entry.block_name.clone(),
+        golden_entry.created_at_ms,
+        now_ms,
+        &BLOCK_NONCE_E,
+    );
+    let (sibling_fp, sibling_bytes) = encrypt_block_bytes_for_uuid(
+        &open,
+        block_uuid,
+        sibling_records,
+        sibling_block_clock.clone(),
+        golden_entry.block_name.clone(),
+        golden_entry.created_at_ms,
+        now_ms,
+        &BLOCK_NONCE_F,
+    );
+
+    // Step 4: write both block files. Canonical goes to the
+    // production path; sibling goes to the suffix path.
+    let canonical_path = block_file_path(&folder, &block_uuid);
+    if let Some(parent) = canonical_path.parent() {
+        std::fs::create_dir_all(parent).expect("create_dir_all blocks/");
+    }
+    std::fs::write(&canonical_path, &canonical_bytes).expect("write canonical block");
+
+    let sibling_path = canonical_path.with_file_name(format!(
+        "{stem}{suffix}",
+        stem = canonical_path
+            .file_name()
+            .and_then(|n| n.to_str())
+            .expect("canonical path utf-8"),
+        suffix = sibling_block_suffix,
+    ));
+    std::fs::write(&sibling_path, &sibling_bytes).expect("write sibling block");
+
+    // Step 5: build + sign the canonical manifest. Update its
+    // BlockEntry.fingerprint / vector_clock_summary / last_mod_ms for
+    // block_uuid; set the manifest-level vector_clock.
+    write_manifest_with_block_entry(
+        &folder,
+        &open,
+        MANIFEST_FILENAME,
+        block_uuid,
+        canonical_fp,
+        canonical_block_clock,
+        canonical_manifest_clock,
+        now_ms,
+        &CANONICAL_NONCE_A,
+    );
+
+    // Step 6: build + sign the sibling manifest. Same structure as
+    // canonical but with sibling fingerprint + clocks, written to the
+    // sibling filename.
+    write_manifest_with_block_entry(
+        &folder,
+        &open,
+        sibling_manifest_filename,
+        block_uuid,
+        sibling_fp,
+        sibling_block_clock,
+        sibling_manifest_clock,
+        now_ms,
+        &SIBLING_NONCE_B,
+    );
+
+    drop(open);
+    (folder, tmp)
+}
+
+/// Build + sign a manifest from a cached `OpenVault`, replacing one
+/// `BlockEntry`'s `fingerprint` / `vector_clock_summary` / `last_mod_ms`
+/// AND the manifest-level `vector_clock`, then write the result to
+/// `folder.join(filename)`.
+///
+/// Lifted out of [`fresh_vault_two_concurrent_blocks`] so the canonical
+/// and sibling manifest writes share one signing path. Mirrors the
+/// step 5-7 sequence inside `commit_with_decisions::commit_with_decisions`
+/// but is driven by the test's cached `OpenVault` rather than a fresh
+/// `open_vault` call (necessary because the disk is in a fingerprint-
+/// inconsistent state between block writes and manifest writes — D6
+/// would reject a fresh open).
+#[allow(clippy::too_many_arguments)]
+fn write_manifest_with_block_entry(
+    folder: &Path,
+    open: &secretary_core::vault::OpenVault,
+    filename: &str,
+    block_uuid: [u8; SYNC_HELPERS_UUID_LEN],
+    block_fingerprint: [u8; 32],
+    block_clock: Vec<VectorClockEntry>,
+    manifest_clock: Vec<VectorClockEntry>,
+    block_last_mod_ms: u64,
+    manifest_aead_nonce: &[u8; AEAD_NONCE_LEN],
+) {
+    let mut manifest = open.manifest.clone();
+    let idx = manifest
+        .blocks
+        .iter()
+        .position(|b| b.block_uuid == block_uuid)
+        .unwrap_or_else(|| panic!("block_uuid {block_uuid:?} not present in cached manifest"));
+    manifest.blocks[idx].fingerprint = block_fingerprint;
+    manifest.blocks[idx].vector_clock_summary = block_clock;
+    manifest.blocks[idx].last_mod_ms = block_last_mod_ms;
+    manifest.vector_clock = manifest_clock;
+
+    let owner_card_bytes = open.owner_card.to_canonical_cbor().expect("card cbor");
+    let owner_fp = fingerprint(&owner_card_bytes);
+    let mut ed_sk_bytes = *open.identity.ed25519_sk.expose();
+    let owner_ed_sk: Ed25519Secret = Sensitive::new(ed_sk_bytes);
+    ed_sk_bytes.zeroize();
+    let owner_pq_sk =
+        MlDsa65Secret::from_bytes(open.identity.ml_dsa_65_sk.expose()).expect("ml-dsa sk");
+
+    let new_header = ManifestHeader {
+        vault_uuid: open.manifest_file.header.vault_uuid,
+        created_at_ms: open.manifest_file.header.created_at_ms,
+        last_mod_ms: open.manifest_file.header.last_mod_ms,
+    };
+    let new_manifest_file = sign_manifest(
+        new_header,
+        &manifest,
+        &open.identity_block_key,
+        manifest_aead_nonce,
+        owner_fp,
+        &owner_ed_sk,
+        &owner_pq_sk,
+    )
+    .expect("sign_manifest");
+
+    let manifest_bytes = encode_manifest_file(&new_manifest_file).expect("encode_manifest_file");
+    std::fs::write(folder.join(filename), &manifest_bytes).expect("write manifest");
 }
 
 #[cfg(test)]
@@ -738,6 +1026,90 @@ mod helper_tests {
         assert_ne!(
             bytes_after_e, bytes_after_f,
             "distinct seeds must yield distinct on-disk envelopes (AEAD uniqueness proof)"
+        );
+    }
+
+    /// Smoke: [`fresh_vault_two_concurrent_blocks`] produces a vault
+    /// folder where:
+    ///
+    /// 1. The canonical manifest opens cleanly via the standard
+    ///    `open_vault` path (D6 fingerprint gate sees the canonical
+    ///    block file matches `BlockEntry.fingerprint`).
+    /// 2. Both the canonical block file AND the sibling block file
+    ///    exist on disk under the expected paths.
+    /// 3. The canonical manifest's BlockEntry for `block_uuid` carries
+    ///    the canonical block's fingerprint + the supplied
+    ///    `canonical_block_clock`.
+    /// 4. The two block files have distinct on-disk bytes (proves the
+    ///    canonical vs sibling encryptions used distinct AEAD seeds).
+    ///
+    /// Acceptance for downstream Task 13 tests: this fixture produces
+    /// a per-block-divergent state that `sync_once` will detect as
+    /// concurrent AND `ingest_block_divergence` will include in
+    /// `bundle.diverging_blocks`.
+    #[test]
+    fn fresh_vault_two_concurrent_blocks_produces_consistent_canonical_with_sibling_on_disk() {
+        let device_a = [0x0A; SYNC_HELPERS_UUID_LEN];
+        let device_b = [0x0B; SYNC_HELPERS_UUID_LEN];
+
+        let canonical_block_clock = vec![VectorClockEntry {
+            device_uuid: device_a,
+            counter: 1,
+        }];
+        let canonical_manifest_clock = canonical_block_clock.clone();
+        let sibling_block_clock = vec![VectorClockEntry {
+            device_uuid: device_b,
+            counter: 1,
+        }];
+        let sibling_manifest_clock = sibling_block_clock.clone();
+
+        // Discover the golden vault's first block_uuid via a throwaway
+        // open. Using the same UUID for both canonical + sibling is
+        // the per-block-divergent shape Task 13's tests require.
+        let (probe_folder, _probe_tmp) = fresh_vault_with_clock(Vec::new());
+        let block_uuid = golden_vault_001_first_block_uuid(&probe_folder);
+
+        let (folder, _tmp) = fresh_vault_two_concurrent_blocks(
+            block_uuid,
+            Vec::new(),
+            canonical_block_clock.clone(),
+            canonical_manifest_clock,
+            Vec::new(),
+            sibling_block_clock,
+            sibling_manifest_clock,
+            "manifest.cbor.enc.sync-conflict-from-device-bb",
+            ".sync-conflict-from-device-bb",
+            1_000_000,
+        );
+
+        // D6 round-trip: the canonical manifest must open cleanly.
+        let password = fixtures::golden_vault_001_password();
+        let open = open_vault(&folder, Unlocker::Password(&password), None)
+            .expect("canonical manifest must open after fixture build");
+        let entry = open
+            .manifest
+            .blocks
+            .iter()
+            .find(|b| b.block_uuid == block_uuid)
+            .expect("block_uuid in canonical manifest");
+        assert_eq!(
+            entry.vector_clock_summary, canonical_block_clock,
+            "canonical manifest must carry the fixture-supplied canonical_block_clock",
+        );
+
+        let canonical_path = block_file_path(&folder, &block_uuid);
+        let sibling_path = canonical_path.with_file_name(format!(
+            "{stem}.sync-conflict-from-device-bb",
+            stem = canonical_path
+                .file_name()
+                .and_then(|n| n.to_str())
+                .expect("utf-8"),
+        ));
+        let canonical_bytes = std::fs::read(&canonical_path).expect("read canonical block");
+        let sibling_bytes = std::fs::read(&sibling_path).expect("read sibling block");
+        assert_ne!(
+            canonical_bytes, sibling_bytes,
+            "canonical and sibling block files must have distinct on-disk bytes",
         );
     }
 }

--- a/core/tests/sync_helpers/mod.rs
+++ b/core/tests/sync_helpers/mod.rs
@@ -1042,6 +1042,15 @@ mod helper_tests {
     ///    `canonical_block_clock`.
     /// 4. The two block files have distinct on-disk bytes (proves the
     ///    canonical vs sibling encryptions used distinct AEAD seeds).
+    /// 5. The SIBLING manifest decrypts cleanly under the same identity
+    ///    and carries SIBLING-side data: its `BlockEntry` references the
+    ///    sibling block's fingerprint + `sibling_block_clock`, and its
+    ///    top-level `vector_clock` equals `sibling_manifest_clock`. This
+    ///    rules out an accidental copy of canonical data into the
+    ///    sibling manifest by `write_manifest_with_block_entry` — the
+    ///    downstream Task 13 tests would catch a swap via
+    ///    `plan.diverging_blocks` non-empty, but the failure mode would
+    ///    point at `ingest_block_divergence`, not the fixture builder.
     ///
     /// Acceptance for downstream Task 13 tests: this fixture produces
     /// a per-block-divergent state that `sync_once` will detect as
@@ -1049,6 +1058,9 @@ mod helper_tests {
     /// `bundle.diverging_blocks`.
     #[test]
     fn fresh_vault_two_concurrent_blocks_produces_consistent_canonical_with_sibling_on_disk() {
+        use secretary_core::crypto::aead::AEAD_TAG_LEN;
+        use secretary_core::vault::manifest::{decode_manifest_file, decrypt_manifest_body};
+
         let device_a = [0x0A; SYNC_HELPERS_UUID_LEN];
         let device_b = [0x0B; SYNC_HELPERS_UUID_LEN];
 
@@ -1069,16 +1081,19 @@ mod helper_tests {
         let (probe_folder, _probe_tmp) = fresh_vault_with_clock(Vec::new());
         let block_uuid = golden_vault_001_first_block_uuid(&probe_folder);
 
+        const SIBLING_MF_FILENAME: &str = "manifest.cbor.enc.sync-conflict-from-device-bb";
+        const SIBLING_BLOCK_SUFFIX: &str = ".sync-conflict-from-device-bb";
+
         let (folder, _tmp) = fresh_vault_two_concurrent_blocks(
             block_uuid,
             Vec::new(),
             canonical_block_clock.clone(),
             canonical_manifest_clock,
             Vec::new(),
-            sibling_block_clock,
-            sibling_manifest_clock,
-            "manifest.cbor.enc.sync-conflict-from-device-bb",
-            ".sync-conflict-from-device-bb",
+            sibling_block_clock.clone(),
+            sibling_manifest_clock.clone(),
+            SIBLING_MF_FILENAME,
+            SIBLING_BLOCK_SUFFIX,
             1_000_000,
         );
 
@@ -1099,7 +1114,7 @@ mod helper_tests {
 
         let canonical_path = block_file_path(&folder, &block_uuid);
         let sibling_path = canonical_path.with_file_name(format!(
-            "{stem}.sync-conflict-from-device-bb",
+            "{stem}{SIBLING_BLOCK_SUFFIX}",
             stem = canonical_path
                 .file_name()
                 .and_then(|n| n.to_str())
@@ -1110,6 +1125,50 @@ mod helper_tests {
         assert_ne!(
             canonical_bytes, sibling_bytes,
             "canonical and sibling block files must have distinct on-disk bytes",
+        );
+
+        // Decrypt + inspect the sibling manifest. Closes the gap where a
+        // bug in [`write_manifest_with_block_entry`] could write
+        // canonical data to both manifests — the downstream Task 13
+        // tests rely on the sibling manifest carrying the sibling
+        // fingerprint to drive `bundle.diverging_blocks` non-empty.
+        let sibling_mf_bytes =
+            std::fs::read(folder.join(SIBLING_MF_FILENAME)).expect("read sibling manifest");
+        let sibling_mf =
+            decode_manifest_file(&sibling_mf_bytes).expect("decode sibling manifest envelope");
+        let mut ct_with_tag = Vec::with_capacity(sibling_mf.aead_ct.len() + AEAD_TAG_LEN);
+        ct_with_tag.extend_from_slice(&sibling_mf.aead_ct);
+        ct_with_tag.extend_from_slice(&sibling_mf.aead_tag);
+        let sibling_body = decrypt_manifest_body(
+            &sibling_mf.header,
+            &ct_with_tag,
+            &open.identity_block_key,
+            &sibling_mf.aead_nonce,
+        )
+        .expect("decrypt sibling manifest body");
+
+        assert_eq!(
+            sibling_body.vector_clock, sibling_manifest_clock,
+            "sibling manifest's top-level vector_clock must equal sibling_manifest_clock",
+        );
+
+        let sibling_entry = sibling_body
+            .blocks
+            .iter()
+            .find(|b| b.block_uuid == block_uuid)
+            .expect("block_uuid in sibling manifest");
+        assert_eq!(
+            sibling_entry.vector_clock_summary, sibling_block_clock,
+            "sibling manifest's BlockEntry must reference sibling_block_clock, not canonical",
+        );
+        let sibling_fp = *secretary_core::crypto::hash::hash(&sibling_bytes).as_bytes();
+        assert_eq!(
+            sibling_entry.fingerprint, sibling_fp,
+            "sibling manifest's BlockEntry.fingerprint must reference the sibling block file's bytes",
+        );
+        assert_ne!(
+            sibling_entry.fingerprint, entry.fingerprint,
+            "sibling manifest's BlockEntry.fingerprint must differ from canonical's",
         );
     }
 }

--- a/core/tests/sync_ingest.rs
+++ b/core/tests/sync_ingest.rs
@@ -45,13 +45,7 @@ fn open_identity(folder: &std::path::Path) -> secretary_core::unlock::UnlockedId
     open_with_password(&vault_toml, &bundle, &password).expect("open_with_password")
 }
 
-/// Read the vault_uuid from `golden_vault_001`'s `vault.toml` so test
-/// SyncState values bind to the right vault.
-fn extract_vault_uuid(folder: &std::path::Path) -> [u8; 16] {
-    let s = std::fs::read_to_string(folder.join("vault.toml")).unwrap();
-    let vt = secretary_core::unlock::vault_toml::decode(&s).unwrap();
-    vt.vault_uuid
-}
+use fixtures::extract_vault_uuid;
 
 /// Build a SyncState whose `highest_vector_clock_seen` is concurrent
 /// with `canonical_clock`: both clocks reference one device the other

--- a/core/tests/sync_ingest_proptest.rs
+++ b/core/tests/sync_ingest_proptest.rs
@@ -31,11 +31,7 @@ fn open_identity(folder: &std::path::Path) -> secretary_core::unlock::UnlockedId
     open_with_password(&vault_toml, &bundle, &password).unwrap()
 }
 
-fn extract_vault_uuid(folder: &std::path::Path) -> [u8; 16] {
-    let s = std::fs::read_to_string(folder.join("vault.toml")).unwrap();
-    let vt = secretary_core::unlock::vault_toml::decode(&s).unwrap();
-    vt.vault_uuid
-}
+use fixtures::extract_vault_uuid;
 
 proptest! {
     // Cases reduced from the default 256 because each iteration runs

--- a/core/tests/sync_merge.rs
+++ b/core/tests/sync_merge.rs
@@ -8,7 +8,6 @@
 //! to the component-wise max of the canonical and copy clocks.
 
 use std::collections::BTreeMap;
-use std::path::Path;
 
 use secretary_core::crypto::secret::SecretString;
 use secretary_core::sync::{
@@ -21,17 +20,7 @@ use secretary_core::vault::{open_vault, Record, RecordField, RecordFieldValue, U
 mod fixtures;
 mod sync_helpers;
 
-/// Read the vault_uuid from the fixture folder's `vault.toml`. Mirrors
-/// the helper used in `core/tests/sync.rs`; pulled into this file so
-/// the merge-layer integration tests don't depend on the sync.rs test
-/// module. (A follow-up could lift this into `fixtures/mod.rs` if more
-/// test files need it, but it's deferred — out of scope for Task 8.)
-fn extract_vault_uuid(folder: &Path) -> [u8; 16] {
-    let s = std::fs::read_to_string(folder.join("vault.toml"))
-        .expect("vault.toml must exist in fixture folder");
-    let vt = secretary_core::unlock::vault_toml::decode(&s).expect("decode vault.toml");
-    vt.vault_uuid
-}
+use fixtures::extract_vault_uuid;
 
 /// Concurrent canonical + sibling manifests with no per-block changes:
 /// `bundle.diverging_blocks` is empty, so `prepare_merge` runs zero

--- a/core/tests/sync_merge_vetoes.rs
+++ b/core/tests/sync_merge_vetoes.rs
@@ -425,3 +425,75 @@ fn commit_with_decisions_missing_veto_decision_aborts_with_typed_error() {
         "MissingVetoDecision must abort with NO block writes; canonical block bytes changed",
     );
 }
+
+/// Task 13.4 — Unknown veto decision aborts the commit with a typed
+/// error pointing at the stray decision's `record_id`.
+///
+/// Fixture is identical to Tasks 13.1-13.3. The caller passes one
+/// matching decision (`KeepLocal { [0xAA; 16] }`) AND one stray
+/// decision (`KeepLocal { [0xFF; 16] }`) whose `record_id` doesn't
+/// match any veto. The bijection check sees
+/// `decision_ids - veto_ids = {[0xFF; 16]}` and returns
+/// `SyncError::UnknownVetoDecision { record_id: [0xFF; 16] }`.
+///
+/// Asserts:
+/// 1. `commit_with_decisions(...)` returns
+///    `Err(SyncError::UnknownVetoDecision { record_id: [0xFF; 16] })`.
+/// 2. The on-disk canonical block file is byte-identical to its
+///    pre-commit state (same no-disk-write rationale as Task 13.3).
+///
+/// The `[0xFF; 16]` stray UUID is chosen to be lexicographically
+/// greater than the matching `[0xAA; 16]` veto so the
+/// `BTreeSet::difference` order is unambiguous — if a future change
+/// to the bijection check were to surface the smallest stray instead
+/// of the only stray, this test's assertion (one-element diff) would
+/// still pin the correct UUID.
+#[test]
+fn commit_with_decisions_unknown_veto_decision_aborts_with_typed_error() {
+    let (folder, identity, bundle, plan, _tmp) = make_veto_fixture();
+    let block_uuid = sync_helpers::golden_vault_001_first_block_uuid(&folder);
+
+    let draft = prepare_merge(&folder, &identity, &bundle, &plan).expect("prepare_merge");
+    assert_eq!(
+        draft.vetoes.len(),
+        1,
+        "fixture must produce exactly one veto for the per-block-divergent record",
+    );
+
+    let block_path = sync_helpers::block_file_path(&folder, &block_uuid);
+    let block_bytes_before = std::fs::read(&block_path).expect("read canonical block pre-commit");
+
+    let stray_record_id: [u8; 16] = [0xFF; 16];
+    let password = fixtures::golden_vault_001_password();
+    let err = commit_with_decisions(
+        &folder,
+        &password,
+        draft,
+        vec![
+            VetoDecision::KeepLocal {
+                record_id: VETO_RECORD_UUID,
+            },
+            VetoDecision::KeepLocal {
+                record_id: stray_record_id,
+            },
+        ],
+        COMMIT_NOW_MS,
+    )
+    .expect_err("commit_with_decisions must reject a decision whose record_id is not in vetoes");
+
+    match err {
+        secretary_core::sync::SyncError::UnknownVetoDecision { record_id } => {
+            assert_eq!(
+                record_id, stray_record_id,
+                "UnknownVetoDecision must report the stray decision's record_id",
+            );
+        }
+        other => panic!("expected SyncError::UnknownVetoDecision, got {other:?}"),
+    }
+
+    let block_bytes_after = std::fs::read(&block_path).expect("read canonical block post-abort");
+    assert_eq!(
+        block_bytes_before, block_bytes_after,
+        "UnknownVetoDecision must abort with NO block writes; canonical block bytes changed",
+    );
+}

--- a/core/tests/sync_merge_vetoes.rs
+++ b/core/tests/sync_merge_vetoes.rs
@@ -288,3 +288,76 @@ fn commit_with_decisions_keep_local_overrides_peer_tombstone() {
         "new SyncState must include sibling-side device entry",
     );
 }
+
+/// Task 13.2 — `AcceptTombstone` finalizes the peer's tombstone: the
+/// merged tombstoned record is persisted unchanged.
+///
+/// Fixture is identical to Task 13.1's. The caller passes
+/// `VetoDecision::AcceptTombstone { record_id: [0xAA; 16] }`;
+/// `apply_decisions` treats `AcceptTombstone` as a no-op (the merge
+/// already wrote the tombstone into `merged_records` via
+/// `merge_block`'s §11.3 tombstone-wins-by-clock rule), the commit
+/// re-encrypts the canonical block, and the new on-disk record set
+/// holds the TOMBSTONED record (`tombstone == true`,
+/// `tombstoned_at_ms == 200`).
+///
+/// Asserts:
+/// 1. `commit_with_decisions(...)` succeeds with the
+///    `AcceptTombstone` decision.
+/// 2. Post-commit, the canonical block decrypts to one record with
+///    `tombstone == true` and `tombstoned_at_ms == 200` (the peer's
+///    death clock).
+/// 3. The merged record's `last_mod_ms` advances to the peer's
+///    `tombstoned_at_ms` (per `merge_record`'s
+///    `last_mod_ms = local.last_mod_ms.max(remote.last_mod_ms)`).
+#[test]
+fn commit_with_decisions_accept_tombstone_finalizes_peer_delete() {
+    let (folder, identity, bundle, plan, _tmp) = make_veto_fixture();
+    let block_uuid = sync_helpers::golden_vault_001_first_block_uuid(&folder);
+
+    let draft = prepare_merge(&folder, &identity, &bundle, &plan).expect("prepare_merge");
+    assert_eq!(
+        draft.vetoes.len(),
+        1,
+        "fixture must produce exactly one veto for the per-block-divergent record",
+    );
+
+    let password = fixtures::golden_vault_001_password();
+    commit_with_decisions(
+        &folder,
+        &password,
+        draft,
+        vec![VetoDecision::AcceptTombstone {
+            record_id: VETO_RECORD_UUID,
+        }],
+        COMMIT_NOW_MS,
+    )
+    .expect("commit_with_decisions");
+
+    // Post-commit on-disk state: the canonical block now holds the
+    // TOMBSTONED record. The merge wrote the death clock and
+    // `AcceptTombstone` did not override it (no-op on the merged set).
+    let records = read_canonical_block_records(&folder, block_uuid);
+    assert_eq!(
+        records.len(),
+        1,
+        "post-commit block must contain exactly the tombstoned record (tombstones are kept-for-undelete per §6.3)",
+    );
+    assert_eq!(records[0].record_uuid, VETO_RECORD_UUID);
+    assert!(
+        records[0].tombstone,
+        "AcceptTombstone must leave the record TOMBSTONED on disk",
+    );
+    assert_eq!(
+        records[0].tombstoned_at_ms, DISK_TOMBSTONE_AT_MS,
+        "post-commit record must carry the peer's tombstoned_at_ms (death clock)",
+    );
+    // §11.5 invariant: `tombstoned_at_ms == last_mod_ms` on tombstoned
+    // records. `merge_record`'s `last_mod_ms = max(local, remote)` plus
+    // the §11.3 staleness filter together enforce this — the assertion
+    // pins the post-merge shape against an accidental drift.
+    assert_eq!(
+        records[0].last_mod_ms, DISK_TOMBSTONE_AT_MS,
+        "tombstoned record must satisfy §11.5 invariant `tombstoned_at_ms == last_mod_ms`",
+    );
+}

--- a/core/tests/sync_merge_vetoes.rs
+++ b/core/tests/sync_merge_vetoes.rs
@@ -361,3 +361,67 @@ fn commit_with_decisions_accept_tombstone_finalizes_peer_delete() {
         "tombstoned record must satisfy §11.5 invariant `tombstoned_at_ms == last_mod_ms`",
     );
 }
+
+/// Task 13.3 — Missing veto decision aborts the commit with a typed
+/// error pointing at the un-adjudicated `record_id`.
+///
+/// Fixture is identical to Task 13.1's. The caller passes EMPTY
+/// `decisions` even though `draft.vetoes` carries one veto. The
+/// bijection check in `commit::apply_decisions` (see §"bijection
+/// rules") sees `veto_ids - decision_ids = {[0xAA; 16]}` and returns
+/// `SyncError::MissingVetoDecision { record_id: [0xAA; 16] }`. The
+/// abort happens BEFORE any block re-encrypt or manifest rewrite.
+///
+/// Asserts:
+/// 1. `commit_with_decisions(...)` returns
+///    `Err(SyncError::MissingVetoDecision { record_id: [0xAA; 16] })`.
+/// 2. The on-disk canonical block file is byte-identical to its
+///    pre-commit state — the abort happens before any commit-side
+///    write, so the fixture's block survives unchanged. (The
+///    manifest is also pre-commit-identical, but the manifest's
+///    no-write invariant is already covered by Task 12's
+///    `commit_with_decisions_stale_manifest_hash_aborts_with_no_disk_writes`;
+///    this test focuses on the block-side proof.)
+#[test]
+fn commit_with_decisions_missing_veto_decision_aborts_with_typed_error() {
+    let (folder, identity, bundle, plan, _tmp) = make_veto_fixture();
+    let block_uuid = sync_helpers::golden_vault_001_first_block_uuid(&folder);
+
+    let draft = prepare_merge(&folder, &identity, &bundle, &plan).expect("prepare_merge");
+    assert_eq!(
+        draft.vetoes.len(),
+        1,
+        "fixture must produce exactly one veto for the per-block-divergent record",
+    );
+
+    // Snapshot the canonical block bytes BEFORE the (expected-to-abort)
+    // commit so the no-disk-write post-condition can be proved.
+    let block_path = sync_helpers::block_file_path(&folder, &block_uuid);
+    let block_bytes_before = std::fs::read(&block_path).expect("read canonical block pre-commit");
+
+    let password = fixtures::golden_vault_001_password();
+    let err = commit_with_decisions(&folder, &password, draft, Vec::new(), COMMIT_NOW_MS)
+        .expect_err(
+            "commit_with_decisions must reject an empty decisions vec when vetoes are non-empty",
+        );
+
+    match err {
+        secretary_core::sync::SyncError::MissingVetoDecision { record_id } => {
+            assert_eq!(
+                record_id, VETO_RECORD_UUID,
+                "MissingVetoDecision must report the un-adjudicated record_id",
+            );
+        }
+        other => panic!("expected SyncError::MissingVetoDecision, got {other:?}"),
+    }
+
+    // Post-condition: the canonical block file is byte-identical to its
+    // pre-commit state. `apply_decisions` runs at commit step 3 (BEFORE
+    // step 5's per-block re-encrypt), so the typed error fires with
+    // zero block writes happening downstream.
+    let block_bytes_after = std::fs::read(&block_path).expect("read canonical block post-abort");
+    assert_eq!(
+        block_bytes_before, block_bytes_after,
+        "MissingVetoDecision must abort with NO block writes; canonical block bytes changed",
+    );
+}

--- a/core/tests/sync_merge_vetoes.rs
+++ b/core/tests/sync_merge_vetoes.rs
@@ -1,0 +1,290 @@
+//! Integration tests for C.1.1b Task 13 — the four veto-handling
+//! commit paths (`KeepLocal`, `AcceptTombstone`, `MissingVetoDecision`,
+//! `UnknownVetoDecision`). All four share the per-block-divergent
+//! fixture [`sync_helpers::fresh_vault_two_concurrent_blocks`] (Task
+//! 13a): canonical block holds record `[0xAA; 16]` LIVE at
+//! `last_mod_ms = 100`; sibling block holds the same record TOMBSTONED
+//! at `tombstoned_at_ms = 200`. The per-record veto pass in
+//! `prepare_merge::tombstone_veto_set` emits one
+//! `RecordTombstoneVeto { record_id: [0xAA; 16], … }`; downstream tests
+//! cover all four bijection / decision combinations.
+//!
+//! This file is separate from `core/tests/sync_merge.rs` because each
+//! `tests/*.rs` is its own test binary, and `sync_merge.rs` already
+//! sits at ~500 LOC after Task 12. New per-veto tests live here so the
+//! veto concern is in one file.
+
+use std::collections::BTreeMap;
+
+use secretary_core::crypto::secret::SecretString;
+use secretary_core::sync::{
+    commit_with_decisions, prepare_merge, sync_once, SyncOutcome, SyncState, VetoDecision,
+};
+use secretary_core::unlock::open_with_password;
+use secretary_core::vault::block::VectorClockEntry;
+use secretary_core::vault::{open_vault, Record, RecordField, RecordFieldValue, Unlocker};
+
+mod fixtures;
+mod sync_helpers;
+
+use fixtures::extract_vault_uuid;
+
+/// Record UUID shared across all four Task 13 fixtures. Single byte
+/// (`0xAA`) replicated 16× so the bytes stay readable in failing-test
+/// output.
+const VETO_RECORD_UUID: [u8; 16] = [0xAA; 16];
+/// Canonical device clock anchor. The local edit (live record) carries
+/// `last_mod_ms = LOCAL_LAST_MOD_MS` and the canonical block's
+/// `vector_clock_summary` references this device.
+const CANONICAL_DEVICE_UUID: [u8; 16] = [0x0A; 16];
+/// Sibling device clock anchor. The peer's tombstone carries
+/// `tombstoned_at_ms = DISK_TOMBSTONE_AT_MS` and the sibling block's
+/// `vector_clock_summary` references this device.
+const SIBLING_DEVICE_UUID: [u8; 16] = [0x0B; 16];
+/// Local device clock anchor. Distinct from canonical / sibling so the
+/// `SyncState.highest_vector_clock_seen` vs disk-manifest clock is
+/// `Concurrent` (sync_once precondition for `ConcurrentDetected`).
+const LOCAL_DEVICE_UUID: [u8; 16] = [0x0C; 16];
+/// Live record `last_mod_ms` — strictly less than `DISK_TOMBSTONE_AT_MS`
+/// so the peer's tombstone is "after" the local edit and the per-record
+/// veto pass fires.
+const LOCAL_LAST_MOD_MS: u64 = 100;
+/// Sibling tombstone timestamp. Strictly greater than `LOCAL_LAST_MOD_MS`
+/// so `tombstone_veto_set` returns `Some(_)`.
+const DISK_TOMBSTONE_AT_MS: u64 = 200;
+/// Commit timestamp passed to `commit_with_decisions`.
+const COMMIT_NOW_MS: u64 = 1_000_000;
+/// Sibling manifest filename — must start with `manifest.cbor.enc` per
+/// `enumerate_manifest_siblings`. The Syncthing-style suffix is used
+/// throughout the C.1.1a / C.1.1b tests for consistency.
+const SIBLING_MANIFEST_FILENAME: &str = "manifest.cbor.enc.sync-conflict-from-device-bb";
+/// Sibling block-file suffix — must start with a non-empty separator so
+/// the resulting filename is recognised by `enumerate_block_siblings`.
+const SIBLING_BLOCK_SUFFIX: &str = ".sync-conflict-from-device-bb";
+
+/// Build the LIVE local record carried by the canonical block. One
+/// field with a synthetic key so the tombstone-veto check sees a non-
+/// empty `last_modifier_device` signal.
+fn live_record() -> Record {
+    let mut fields = BTreeMap::new();
+    fields.insert(
+        "k".to_string(),
+        RecordField {
+            value: RecordFieldValue::Text(SecretString::from("local")),
+            last_mod: LOCAL_LAST_MOD_MS,
+            device_uuid: CANONICAL_DEVICE_UUID,
+            unknown: BTreeMap::new(),
+        },
+    );
+    Record {
+        record_uuid: VETO_RECORD_UUID,
+        record_type: "kv".to_string(),
+        fields,
+        tags: Vec::new(),
+        created_at_ms: 50,
+        last_mod_ms: LOCAL_LAST_MOD_MS,
+        tombstone: false,
+        tombstoned_at_ms: 0,
+        unknown: BTreeMap::new(),
+    }
+}
+
+/// Build the TOMBSTONED peer record carried by the sibling block. The
+/// `tombstoned_at_ms` is strictly greater than `LOCAL_LAST_MOD_MS` so
+/// the per-record veto pass fires (`tombstone_veto_set`'s strict-greater
+/// branch).
+fn tombstoned_record() -> Record {
+    let mut fields = BTreeMap::new();
+    fields.insert(
+        "k".to_string(),
+        RecordField {
+            value: RecordFieldValue::Text(SecretString::from("ignored")),
+            last_mod: DISK_TOMBSTONE_AT_MS,
+            device_uuid: SIBLING_DEVICE_UUID,
+            unknown: BTreeMap::new(),
+        },
+    );
+    Record {
+        record_uuid: VETO_RECORD_UUID,
+        record_type: "kv".to_string(),
+        fields,
+        tags: Vec::new(),
+        created_at_ms: 50,
+        last_mod_ms: DISK_TOMBSTONE_AT_MS,
+        tombstone: true,
+        tombstoned_at_ms: DISK_TOMBSTONE_AT_MS,
+        unknown: BTreeMap::new(),
+    }
+}
+
+/// Drive the shared fixture forward to the
+/// `(folder, identity, bundle, plan)` quadruple used by every Task 13
+/// test. Encapsulates the boilerplate: copy golden_vault_001 + force
+/// per-block divergence on the first block + open the identity + run
+/// `sync_once` + assert `ConcurrentDetected`.
+///
+/// Returns the temp dir folder, the unlocked identity, the bundle, the
+/// plan, AND the `tempfile::TempDir` (must outlive every test).
+fn make_veto_fixture() -> (
+    std::path::PathBuf,
+    secretary_core::unlock::UnlockedIdentity,
+    secretary_core::sync::VaultBundle,
+    secretary_core::sync::DiffPlan,
+    tempfile::TempDir,
+) {
+    // Discover the golden vault's first block_uuid in a throwaway open.
+    let (probe_folder, _probe_tmp) = sync_helpers::fresh_vault_with_clock(Vec::new());
+    let block_uuid = sync_helpers::golden_vault_001_first_block_uuid(&probe_folder);
+
+    let canonical_block_clock = vec![VectorClockEntry {
+        device_uuid: CANONICAL_DEVICE_UUID,
+        counter: 1,
+    }];
+    let sibling_block_clock = vec![VectorClockEntry {
+        device_uuid: SIBLING_DEVICE_UUID,
+        counter: 1,
+    }];
+
+    let (folder, tmp) = sync_helpers::fresh_vault_two_concurrent_blocks(
+        block_uuid,
+        vec![live_record()],
+        canonical_block_clock.clone(),
+        canonical_block_clock,
+        vec![tombstoned_record()],
+        sibling_block_clock.clone(),
+        sibling_block_clock,
+        SIBLING_MANIFEST_FILENAME,
+        SIBLING_BLOCK_SUFFIX,
+        COMMIT_NOW_MS,
+    );
+
+    let password = fixtures::golden_vault_001_password();
+    let vt_bytes = std::fs::read(folder.join("vault.toml")).expect("read vault.toml");
+    let bundle_bytes =
+        std::fs::read(folder.join("identity.bundle.enc")).expect("read identity bundle");
+    let identity =
+        open_with_password(&vt_bytes, &bundle_bytes, &password).expect("open_with_password");
+
+    let vault_uuid = extract_vault_uuid(&folder);
+    let local_clock = vec![VectorClockEntry {
+        device_uuid: LOCAL_DEVICE_UUID,
+        counter: 1,
+    }];
+    let state = SyncState::new(vault_uuid, local_clock).expect("SyncState::new");
+
+    let outcome = sync_once(&folder, &identity, &state, 0u64).expect("sync_once");
+    let (bundle, plan) = match outcome {
+        SyncOutcome::ConcurrentDetected { bundle, plan, .. } => (bundle, plan),
+        other => panic!("expected ConcurrentDetected, got {other:?}"),
+    };
+    assert!(
+        !plan.diverging_blocks.is_empty(),
+        "Task 13 fixture must force per-block divergence — plan.diverging_blocks is empty",
+    );
+
+    (folder, identity, bundle, plan, tmp)
+}
+
+/// Read the canonical block file post-commit and return the records
+/// inside. Used by Tasks 13.1 + 13.2 to assert the on-disk record
+/// state matches the caller's decision.
+fn read_canonical_block_records(folder: &std::path::Path, block_uuid: [u8; 16]) -> Vec<Record> {
+    let password = fixtures::golden_vault_001_password();
+    let open = open_vault(folder, Unlocker::Password(&password), None).expect("post-commit open");
+    let block_path = sync_helpers::block_file_path(folder, &block_uuid);
+    let bytes = std::fs::read(&block_path).expect("read post-commit canonical block");
+    let plaintext =
+        sync_helpers::decrypt_block_using_open(&open, &bytes).expect("decrypt post-commit block");
+    plaintext.records
+}
+
+/// Task 13.1 — `KeepLocal` rejects the peer's tombstone, the live local
+/// record survives on disk.
+///
+/// Fixture: canonical block has record `[0xAA]` LIVE at `t = 100`;
+/// sibling block has record `[0xAA]` TOMBSTONED at `t = 200`. The
+/// per-record veto pass in `prepare_merge` emits one
+/// `RecordTombstoneVeto { record_id: [0xAA; 16], … }` because the peer
+/// tombstone is strictly later than the local last_mod. The caller
+/// passes `VetoDecision::KeepLocal { record_id: [0xAA; 16] }` to
+/// `commit_with_decisions`; `apply_decisions` restores the veto's
+/// `local_state` over the merge's tombstoned record, the commit
+/// re-encrypts the canonical block, and the new on-disk record set
+/// holds the LIVE record (`tombstone == false`,
+/// `last_mod_ms == 100`).
+///
+/// Asserts:
+/// 1. `commit_with_decisions(...)` succeeds with the supplied decision.
+/// 2. Post-commit, the canonical block decrypts to exactly one record:
+///    the live record with `tombstone == false` and `last_mod_ms == 100`.
+/// 3. The returned `SyncState.highest_vector_clock_seen` carries both
+///    the canonical + sibling block devices' entries (manifest-level
+///    clock fold).
+#[test]
+fn commit_with_decisions_keep_local_overrides_peer_tombstone() {
+    let (folder, identity, bundle, plan, _tmp) = make_veto_fixture();
+    let block_uuid = sync_helpers::golden_vault_001_first_block_uuid(&folder);
+
+    let draft = prepare_merge(&folder, &identity, &bundle, &plan).expect("prepare_merge");
+    assert_eq!(
+        draft.vetoes.len(),
+        1,
+        "fixture must produce exactly one veto for the per-block-divergent record",
+    );
+    assert_eq!(
+        draft.vetoes[0].record_id, VETO_RECORD_UUID,
+        "veto must target the live record",
+    );
+
+    let password = fixtures::golden_vault_001_password();
+    let new_state = commit_with_decisions(
+        &folder,
+        &password,
+        draft,
+        vec![VetoDecision::KeepLocal {
+            record_id: VETO_RECORD_UUID,
+        }],
+        COMMIT_NOW_MS,
+    )
+    .expect("commit_with_decisions");
+
+    // Post-commit on-disk state: the canonical block holds the LIVE
+    // record. The merge would have written the tombstoned record (per
+    // `merge_block`'s tombstone-wins-by-clock semantics); `KeepLocal`
+    // restored the veto's `local_state`, which `commit_with_decisions`
+    // re-encrypted into the new canonical block.
+    let records = read_canonical_block_records(&folder, block_uuid);
+    assert_eq!(
+        records.len(),
+        1,
+        "post-commit block must contain exactly the kept record",
+    );
+    assert_eq!(records[0].record_uuid, VETO_RECORD_UUID);
+    assert!(
+        !records[0].tombstone,
+        "KeepLocal must leave the record LIVE on disk",
+    );
+    assert_eq!(
+        records[0].last_mod_ms, LOCAL_LAST_MOD_MS,
+        "post-commit record must carry the local last_mod_ms (not the peer's tombstone clock)",
+    );
+
+    // Manifest-level clock fold: the returned SyncState carries both
+    // manifest devices' entries (canonical_block_clock for device A and
+    // sibling_block_clock for device B both flowed into the
+    // manifest-level vector_clock via `post_merge_clock`).
+    assert!(
+        new_state
+            .highest_vector_clock_seen
+            .iter()
+            .any(|e| e.device_uuid == CANONICAL_DEVICE_UUID && e.counter == 1),
+        "new SyncState must include canonical-side device entry",
+    );
+    assert!(
+        new_state
+            .highest_vector_clock_seen
+            .iter()
+            .any(|e| e.device_uuid == SIBLING_DEVICE_UUID && e.counter == 1),
+        "new SyncState must include sibling-side device entry",
+    );
+}

--- a/docs/handoffs/2026-05-21-c1-1b-task-13-shipped.md
+++ b/docs/handoffs/2026-05-21-c1-1b-task-13-shipped.md
@@ -1,0 +1,208 @@
+# NEXT_SESSION.md
+
+**Session date:** 2026-05-21 (implementation session — C.1.1b Tasks 13a + 13.1-13.4 of 17 shipped; per-block-divergent veto handling proves through to disk + flushes out a real production bug in `prepare_merge`'s veto pass)
+**Status:** PR to be opened. `feature/c1-1b-sync-merge` carries 6 commits on top of `324c4cb` (post-Task-12 main) — one pre-refactor (lift `extract_vault_uuid`), one fixture helper, one bug-fix-plus-test (Task 13.1 + the `prepare_merge` veto-pass canonical-vs-accumulator fix), and three more tests. 4 tasks remain (14-17).
+
+## (1) What we shipped this session
+
+| Commit | Task | What it adds |
+|---|---|---|
+| [`63b32a7`](https://github.com/hherb/secretary/commit/63b32a7) | 13a pre-refactor | **`extract_vault_uuid` lifted into `fixtures` helper.** Centralizes the previously-four-times-duplicated `extract_vault_uuid(folder: &Path) -> [u8; 16]` into `core/tests/fixtures/mod.rs::extract_vault_uuid`. Trigger met (the 5th consumer in `sync_merge_vetoes.rs` would have inlined another copy). Removed inline copies from `sync_merge.rs`, `sync_ingest.rs`, `sync_ingest_proptest.rs`. `sync.rs::extract_golden_vault_uuid` kept as a zero-arg adapter that delegates to the lifted helper (its tests use the in-tree pre-built fixture, not a temp copy — preserving the existing call shape). `#[allow(dead_code)]` on the lifted helper because `core/tests/fixtures/mod.rs` is compiled once per `tests/*.rs` binary; binaries that import the module only for `golden_vault_001_password` (e.g. `open_vault.rs`) would otherwise see it as unused under `-D dead_code`. Net: 29 insertions, 31 deletions across 5 files. No test-count change. |
+| [`833b981`](https://github.com/hherb/secretary/commit/833b981) | 13a | **`fresh_vault_two_concurrent_blocks` fixture helper.** Per-block-divergent two-manifest fixture: writes canonical block (with caller-supplied `canonical_records`) AND a sibling block file at `blocks/<uuid>.cbor.enc<sibling_block_suffix>` (with `sibling_records`) using distinct AEAD seeds (`BLOCK_NONCE_E` canonical, `BLOCK_NONCE_F` sibling), then re-signs the canonical manifest AND writes a sibling manifest with distinct `BlockEntry.fingerprint` + `BlockEntry.vector_clock_summary` + top-level `vector_clock` per side. The resulting state opens cleanly under D6 (canonical block matches `BlockEntry.fingerprint`) AND drives the C.1.1a ingest layer to emit non-empty `bundle.diverging_blocks` (canonical + sibling `vector_clock_summary` are concurrent). Inner refactor: extracted `encrypt_block_bytes_for_uuid` pure helper (returns `([u8; 32], Vec<u8>) = (fingerprint, bytes)` — no I/O); `rewrite_block_with_records` now calls it; the new fixture helper calls it twice with distinct seeds. Also extracted `write_manifest_with_block_entry` to share manifest re-signing between canonical and sibling. New smoke test pins the helper: `fresh_vault_two_concurrent_blocks_produces_consistent_canonical_with_sibling_on_disk` proves D6 round-trip + both block files present + distinct ciphertexts. Test count: 767 → 771 (+4 from the helper smoke cross-binary, which runs in all 4 test crates that `mod sync_helpers`). **File size:** `core/tests/sync_helpers/mod.rs` is now 1115 LOC, up from 743 at #95 filing. The submodule sketch in #95 still fits; the refactor stays deferred (parallel to merge-layer work). [Comment posted to #95](https://github.com/hherb/secretary/issues/95#issuecomment-4514600227) with the updated LOC. |
+| [`7cd8a37`](https://github.com/hherb/secretary/commit/7cd8a37) | 13.1 | **Veto pass canonical-vs-accumulator fix + KeepLocal integration test.** Production-code bug: `prepare_merge`'s per-record veto pass iterated `acc_records.iter()` (post-iterative-fold accumulator) and passed each entry as `local` to `tombstone_veto_set`. Under well-formed inputs this made the integration veto branch UNREACHABLE: when canonical has a LIVE record at `last_mod_ms = L` and a peer has the same record TOMBSTONED at `tombstoned_at_ms = T > L`, `merge_block`'s §11.3 tombstone-wins-by-clock rule writes a tombstoned record into `acc_records`, and the veto pass's `if local_rec.tombstone { continue; }` then skipped the very case the veto is meant to surface. For any other case, the strict-greater inequality `peer.tombstoned_at_ms > merged.last_mod_ms` cannot hold because `merged.last_mod_ms = max(local, all_peers)` (so `merged ≥ peer.tombstoned_at_ms` always). Net: `vetoes.is_empty()` after EVERY `prepare_merge` invocation, regardless of input. Dead code in production — but the helper's own unit tests all passed because they exercise `tombstone_veto_set` in isolation with a canonical-style live record. The bug only surfaced because Task 13.1's integration test was the FIRST test ever to drive `prepare_merge` on a per-block-divergent fixture. **Fix:** walk `canonical_pt.records` (pre-merge) in the veto pass, not `acc_records`. Matches `tombstone_veto_set`'s docstring ("the local (canonical) record"), the design doc §"prepare_merge" step 2, and `commit/apply.rs::keep_local_overrides_tombstoned_record`'s unit-test fixture pattern (vetoes carry LIVE `local_state`, `merged_records` carries TOMBSTONED records — only achievable if vetoes are emitted from canonical). **Test:** `commit_with_decisions_keep_local_overrides_peer_tombstone` in the new `core/tests/sync_merge_vetoes.rs`. Fixture builds canonical LIVE@100 + sibling TOMB@200 → one veto → `KeepLocal { [0xAA; 16] }` decision → post-commit canonical block on disk decrypts to one LIVE record with `last_mod_ms = 100`. Returned `SyncState` carries both manifest devices' clock entries. **Why one commit:** the fix and the test are TDD-coupled (the test is the RED-then-GREEN signal for the fix). Splitting them would either land a failing test (test-first) or a fix with no automated proof (fix-first; bisect points to the test commit, not the fix commit, when a future regression surfaces). Test count: 771 → 777 (+6: +1 KeepLocal in `sync_merge_vetoes` binary + 5 helper_tests cross-binary re-runs in the new test binary). |
+| [`262d444`](https://github.com/hherb/secretary/commit/262d444) | 13.2 | **`AcceptTombstone` integration test.** Same fixture as Task 13.1. Decision: `VetoDecision::AcceptTombstone { record_id: [0xAA; 16] }`. `apply_decisions` treats `AcceptTombstone` as a no-op (the merge already wrote the tombstone), the commit re-encrypts the canonical block, and the new on-disk record set holds the TOMBSTONED record (`tombstone=true`, `tombstoned_at_ms=200`). Also pins the §11.5 invariant `tombstoned_at_ms == last_mod_ms` on the post-merge record — catches accidental drift in `merge_record`'s timestamp logic. Test count: 777 → 778. |
+| [`ab1c701`](https://github.com/hherb/secretary/commit/ab1c701) | 13.3 | **`MissingVetoDecision` integration test.** Same fixture. Decision: `Vec::new()` — caller fails to adjudicate. Bijection check computes `veto_ids - decision_ids = {[0xAA; 16]}` → typed `SyncError::MissingVetoDecision { record_id: [0xAA; 16] }`. Block-side no-disk-write proof: snapshot canonical block bytes pre-commit, verify byte-identical post-abort. Counterpart to Task 12's manifest-side `EvidenceStale` no-disk-write proof. Test count: 778 → 779. |
+| [`8c6149a`](https://github.com/hherb/secretary/commit/8c6149a) | 13.4 | **`UnknownVetoDecision` integration test.** Same fixture. Decision: two entries — one matching (`KeepLocal { [0xAA; 16] }`), one stray (`KeepLocal { [0xFF; 16] }`). Bijection check computes `decision_ids - veto_ids = {[0xFF; 16]}` → typed `SyncError::UnknownVetoDecision { record_id: [0xFF; 16] }`. Same no-disk-write post-condition as Task 13.3. Together with Task 13.3 closes the bijection-violation disk-side proof: any non-bijective `(vetoes, decisions)` pair aborts before block re-encrypt. Test count: 779 → 780. |
+
+**Branch hygiene:** Session opened on `feature/c1-1b-sync-merge` carrying 5 already-merged commits (Task 12's PR #102 squash-merged after the previous session). Per the previous baton's instruction, reset to `origin/main` (`324c4cb`) at session start — the local pre-merge commits' file changes were already on main via the squash, so the reset discarded only duplicates. Local branch now carries exactly 6 new commits on top of `324c4cb`.
+
+**Gauntlet on `feature/c1-1b-sync-merge` after Task 13.4:**
+
+- `cargo test --release --workspace --no-fail-fast` → **780 / 0 / 10** (767 baseline at `324c4cb` + 4 helper_tests cross-binary re-runs from the new `sync_merge_vetoes` binary + 4 new veto tests + 1 helper smoke test = 13).
+- `cargo clippy --release --workspace --tests -- -D warnings` → clean.
+- `cargo fmt --all -- --check` → clean.
+- `uv run core/tests/python/conformance.py` → PASS.
+- `uv run core/tests/python/spec_test_name_freshness.py` → PASS (96 resolved / 0 unresolved / 2 suppressed; the C.1.1b plan + design docs sit outside the script's corpus).
+
+## (2) What's next — execute Task 14
+
+### (a) First action next session: execute Task 14 (after PR for Task 13 merges)
+
+Open the plan at [`docs/superpowers/plans/2026-05-18-c1-1b-sync-merge.md`](docs/superpowers/plans/2026-05-18-c1-1b-sync-merge.md) → **Task 14 — Crash-recovery integration test (partial-write reconverge)**. The D6 proof: simulate a crash between step 5's block re-encrypt and step 6's manifest write, then prove the next `sync_once → prepare_merge → commit_with_decisions` reconverges to the same final state via CRDT idempotence.
+
+Plan-cited shape:
+
+1. Fixture: per-block-divergent state (reuse Task 13's `fresh_vault_two_concurrent_blocks`).
+2. Drive a partial commit: call `commit_with_decisions` but interrupt it before the manifest write. Strategies tried in the plan:
+   - Mock/intercept `write_atomic` to fail on the manifest path. Cleanest, no production-code change needed.
+   - OR: manually orchestrate the half-commit by calling `commit_with_decisions`'s individual steps in a test-only harness.
+3. The interrupted state on disk: rewritten block + stale manifest (`BlockEntry.fingerprint` references the old block).
+4. Next `open_vault` fires `VaultError::BlockFingerprintMismatch` (D6 gate) → caller surfaces, retries.
+5. Re-run `sync_once → prepare_merge → commit_with_decisions` — CRDT idempotence guarantees the second pass produces the same final state.
+
+Expected workspace test count after Task 14: 780 → 781 (+1).
+
+```bash
+cd /Users/hherb/src/secretary/.worktrees/c1-1b-sync-merge
+# AFTER Task 13's PR merges:
+git fetch --prune origin
+git reset --hard origin/main                                    # discard merged commits
+# THEN open the plan:
+$EDITOR docs/superpowers/plans/2026-05-18-c1-1b-sync-merge.md   # jump to "Task 14"
+```
+
+Per `feedback_stay_in_inner_loop`, keep the one-task-one-commit-one-review cadence. Task 14 is a single new test; a single PR with one commit (plus baton commit) is the natural shape.
+
+### (b) Plan structure at a glance (4 remaining of 17)
+
+| Task | What it builds | New / modified files |
+|---|---|---|
+| ~~1-10~~ | ~~Tasks 1-10 shipped~~ ✅ in PRs #84-#97 |
+| ~~11~~ | ~~`commit_with_decisions` + DraftMerge per-block + commit/ split + happy-path test~~ ✅ PR #99 (`52093aa`) |
+| ~~12~~ | ~~`EvidenceStale` integration test (manifest-hash freshness)~~ ✅ PR #102 (`324c4cb`) |
+| ~~13a + 13.1-13.4~~ | ~~`fresh_vault_two_concurrent_blocks` helper + 4 veto integration tests + `prepare_merge` veto-pass bug fix~~ ✅ this session (6 commits, PR pending) |
+| **14** | **Crash-recovery test (partial-write reconverge — D6 proof)** | `core/tests/sync_merge_vetoes.rs` or new `core/tests/sync_merge_crash.rs` |
+| 15 | 4 property tests | `core/tests/sync_merge_proptest.rs` NEW |
+| 16 | 7 KAT vectors + replay extension | `core/tests/data/sync_kat.json`, `core/tests/sync_kat.rs` |
+| 17 | README + ROADMAP + NEXT_SESSION baton + handoff snapshot + final gauntlet + open PR | `README.md`, `ROADMAP.md`, `NEXT_SESSION.md`, `docs/handoffs/*` |
+
+### (c) Acceptance criteria for the C.1.1b PR (final)
+
+- [x] `cargo test --release --workspace --no-fail-fast` → 766+ / 0 / 10 (currently 780 / 0 / 10 — well above the floor)
+- [x] `cargo clippy --release --workspace --tests -- -D warnings` → clean
+- [x] `cargo fmt --all -- --check` → clean
+- [x] `uv run core/tests/python/conformance.py` → PASS
+- [x] `uv run core/tests/python/spec_test_name_freshness.py` → PASS (no unresolved citations)
+- [x] `verify_block_fingerprints` runs eagerly in `open_vault`; corrupted-block test fires `VaultError::BlockFingerprintMismatch` ✅ Task 5
+- [x] `DraftMerge` / `RecordTombstoneVeto` / `VetoDecision` defined with zeroize discipline + module tests ✅ Task 6
+- [x] `tombstone_veto_set` pure helper with 7 table tests ✅ Task 7
+- [x] `prepare_merge` orchestrator wires decap + iterative fold + veto detection + post_merge_clock ✅ Task 8
+- [x] `rewrite_block_with_records_and_update_manifest` helper exists; post-rewrite vault opens cleanly under D6 ✅ Task 9
+- [x] `apply_decisions` pure helper enforces `vetoes ↔ decisions` bijection ✅ Task 10
+- [x] `commit_with_decisions` re-opens vault, freshness-checks manifest hash, applies decisions, re-encrypts diverging blocks, atomic block-first manifest-last write ✅ Task 11
+- [x] `EvidenceStale` integration test fires on stale manifest_hash + asserts NO disk writes ✅ Task 12
+- [x] **Bijection: `MissingVetoDecision` + `UnknownVetoDecision` typed errors fire on every non-bijective `(vetoes, decisions)` pair — disk-side proof** ✅ Tasks 13.3 + 13.4
+- [x] **`KeepLocal` and `AcceptTombstone` decisions persist correctly to disk** ✅ Tasks 13.1 + 13.2
+- [x] **`prepare_merge`'s veto pass actually fires on per-block-divergent fixtures (was unreachable pre-Task-13.1)** ✅ Task 13.1
+- [ ] Crash-recovery test (Task 14) proves CRDT-idempotent reconvergence after partial commit
+- [ ] All four CRDT proptests (commutativity, associativity, idempotence, well-formedness) still pass — **must not weaken**
+- [ ] **Before merging Task 17:** grep every `#[allow(dead_code)]` introduced in Tasks 1-10 and confirm each has at least one real consumer in Tasks 11-16. Task 13a retired `BLOCK_NONCE_F`'s and `fresh_vault_two_concurrent_blocks`'s `#[allow(dead_code)]` markers (both now consumed). `BLOCK_NONCE_G` + `SIBLING_NONCE_D` + `fresh_vault_four_concurrent_manifests` remain `#[allow(dead_code)]` — Task 14 (crash recovery) may consume them.
+
+## (3) Open decisions and risks
+
+### Plan deviation from this session (carry into PR review)
+
+- **`prepare_merge` veto-pass bug fix is a production-code change in a test-driven task.** Task 13 was scoped as "veto integration tests only", but Task 13.1's red signal revealed that `prepare_merge`'s veto pass (line 463 pre-fix) was iterating `acc_records` (post-merge) instead of `canonical_pt.records` (pre-merge), making the integration veto branch UNREACHABLE. Per [[feedback_act_on_issues_dont_mention]] and [[feedback_security_no_assumptions]], fixed in-task rather than filing-and-deferring. The fix is 2 lines + 18 lines of explanatory comment. Reviewer: confirm the design intent matches the helper's docstring ("the local (canonical) record") and the design doc §"prepare_merge" step 2 ("local.is_alive()" with local being canonical).
+- **One commit for the fix + the test.** Per the commit body's "Why one commit": the fix and test are TDD-coupled; splitting would either land a RED test (test-first) or a fix with no automated proof (fix-first; bisect would point at the wrong commit). Reviewer: this is the explicit deviation from "step by step, one issue per commit" — the issue here IS "prepare_merge veto branch unreachable; surface it with an integration test and fix the implementation", one issue, one commit.
+- **`extract_vault_uuid` lifted pre-Task-13.** Trigger condition met (5th consumer would have inlined another copy). Single refactor PR-resident pre-step.
+- **`sync_helpers/mod.rs` grew 743 → 1115 LOC.** Task 13a's `fresh_vault_two_concurrent_blocks` + `encrypt_block_bytes_for_uuid` + `write_manifest_with_block_entry` + smoke test added ~370 LOC. Past the 800 trigger named in the Task 12 baton's implementer-call #4. [Updated #95](https://github.com/hherb/secretary/issues/95#issuecomment-4514600227) with the new LOC; the submodule sketch still fits. **Deferred to a follow-up split PR** (parallel to merge-layer work) rather than expanding Task 13's scope. Plan is to land it as a standalone refactor between Tasks 14 and 17 (or at Task 17 close).
+- **`sync_merge_vetoes.rs` is a new test binary, not an extension of `sync_merge.rs`.** Reason: `sync_merge.rs` is already at ~500 LOC after Task 12. Adding 4 new veto tests (~280 LOC) plus the shared `make_veto_fixture` + `live_record` + `tombstoned_record` helpers (~120 LOC) would push it past 900. New binary keeps the veto concern isolated; Task 14 (crash-recovery) can decide whether to extend this file or open `sync_merge_crash.rs`. Per the Task 12 baton's note "if sync_merge.rs crosses 500 BEFORE Task 17, split into `core/tests/sync_merge_*.rs` files".
+
+### Carry-over from earlier PRs
+
+- **`apply_decisions` is `pub(crate)`, not `pub`.** Unchanged this session.
+- **PR #99 in-PR refactor (`1193072`)** — `MANIFEST_FILENAME` consolidation already merged.
+- **PR #102 (Task 12)** — already merged at session start.
+- **Implementer-call decisions from Task 12 baton still live:**
+  - #1 `commit_with_decisions` identity argument: stays `&SecretBytes`, re-opens internally. Task 13.1-13.4 tests all use `open_with_password` (standalone identity, no lifetime tie to a vault folder) so no `drop(open)` needed.
+  - #2 `DraftMerge.per_block_clocks` + `per_block_records` shape: frozen, no change this session.
+  - #3 `extract_vault_uuid` helper duplication: **closed this session** (lifted via `63b32a7`).
+  - #4 `sync_helpers/mod.rs` file size: still open, now at 1115 LOC. Track via [#95](https://github.com/hherb/secretary/issues/95).
+  - #5 `commit/` directory split (PR #99): no change this session — Task 13.1-13.4 are tests-only, didn't grow `write.rs`.
+  - #6 `prepare.rs` file size (869 LOC pre-Task-13.1): now ~890 LOC after the veto-pass fix (+18 lines of explanatory comment). Still pre-existing growth; file a tracking issue at C.1.1b close (Task 17), or split as a standalone refactor if Tasks 14-16 push it further.
+
+### Implementer's-call decisions (live for Tasks 14-16)
+
+1. **`commit_with_decisions` identity argument.** Unchanged from Task 12 baton (`&SecretBytes`).
+2. **`DraftMerge` shape.** Unchanged.
+3. **Veto-pass iteration source.** Resolved this session: walk `canonical_pt.records`, not `acc_records`. If Task 15's proptests add cases where the canonical's record is tombstoned but a peer LIVE record contests the tombstone, the current code's `canonical_rec.tombstone → continue` is the right call (no veto needed because LWW already wins).
+4. **`sync_helpers/mod.rs` file size.** 1115 LOC. Past the 800 trigger but #95 stays the umbrella for the split refactor.
+5. **`commit/` directory split.** Unchanged.
+6. **`prepare.rs` file size.** ~890 LOC post-fix. Still in the "tracking issue at C.1.1b close" bucket — no urgency from Task 13.
+7. **New test binary `sync_merge_vetoes.rs`.** Decided to add Task 13's tests in a new binary rather than extending `sync_merge.rs`. Task 14 can extend `sync_merge_vetoes.rs` OR open `sync_merge_crash.rs` — pick at Task 14 PR-open time based on whether the crash test shares enough fixtures with the veto tests to justify co-location.
+
+### Risks (from the design doc, restated for plan execution)
+
+- **`DraftMerge` zeroize discipline** — ✅ in place from Task 6 + Task 11 extension; unchanged this session.
+- **AEAD nonce per rewrite** — Task 13.1 + 13.2 EXERCISE the rewrite path for the first time (`commit_with_decisions` re-encrypts the divergent block). `OsRng` drives the rewrite, so each commit produces a fresh nonce. Tasks 13.3 + 13.4 abort before the rewrite; no AEAD exposure there.
+- **`tempfile` exact pin** (`=3.27.0`) — unchanged this session.
+- **CRDT proptests must not weaken** — Task 13's tests do not touch `core/src/vault/conflict.rs`. `commit_with_decisions` consumes merge-primitive output, not produces it. Confirmed via gauntlet: 4 conflict proptests still pass.
+- **`SyncOutcome::ConcurrentDetected` is large** — unchanged.
+- **Exhaustive `VaultError` matchers in `secretary-ffi-bridge`** — no new core variants this session.
+- **File size of `core/src/sync/commit/write.rs`** — 389 LOC (unchanged). Task 14 (crash-recovery test) is tests-only; if Task 14 surfaces a need for production-side helpers (e.g. a `commit_one_block` exposed for the test harness), split per the Task 12 baton's implementer-call #5.
+- **File size of `core/src/sync/prepare.rs`** — ~890 LOC (+18 from this session). See #95's pattern (file an umbrella issue at C.1.1b close).
+- **File size of `core/tests/sync_helpers/mod.rs`** — 1115 LOC. See #95.
+- **File size of `core/tests/sync_merge_vetoes.rs`** — 472 LOC after Task 13.4. Comfortably under 500. Task 14 (one crash test, ~100 LOC) would push it to ~570 — close to the cap. If Task 14 lands in this file, consider splitting at Task 14 PR-open time (or open `sync_merge_crash.rs` from the start).
+- **File size of `core/src/vault/orchestrators.rs`** — ~2180 LOC (unchanged). Pre-existing.
+
+### Issues currently open
+
+- **[#37](https://github.com/hherb/secretary/issues/37)** — Sub-project C design discipline umbrella. C.1.1b closes the merge-layer portion.
+- **[#38](https://github.com/hherb/secretary/issues/38)** — `save_block` proptest case-count budget.
+- **[#45](https://github.com/hherb/secretary/issues/45)** — three `pub(crate) #[allow(dead_code)]` accessors on `OpenVaultManifest`. Not consumed by Task 13's veto tests.
+- **[#75](https://github.com/hherb/secretary/issues/75)** — replace `#[doc(hidden)] pub __test_dispatch` with `pub(crate)` + lib-internal tests.
+- **[#76](https://github.com/hherb/secretary/issues/76)** — Python clean-room replay of `sync_kat.json`. Task 16's seven new vectors will join when #76 lands.
+- **[#78](https://github.com/hherb/secretary/issues/78)** — C.1.1a integration-test gaps. Task 13's veto-fixture work may close some of #78 as a side effect — worth re-checking on Task 13 PR merge.
+- **[#79](https://github.com/hherb/secretary/issues/79)** — sync_kat.json ingestion vectors. Not directly C.1.1b.
+- **[#81](https://github.com/hherb/secretary/issues/81)** — `MAX_BLOCK_FILE_SIZE` undocumented vs format-max recipient table. C.4 doc pass.
+- **[#87](https://github.com/hherb/secretary/issues/87)** — dedup `golden_vault_001_password` reader. Refactor follow-up.
+- **[#88](https://github.com/hherb/secretary/issues/88)** — `VaultError::Io` does not carry the failing block UUID on fingerprint-check I/O failures.
+- **[#90](https://github.com/hherb/secretary/issues/90)** — consolidate four `copy_dir_recursive` test-helper copies. Cross-crate scope.
+- **[#95](https://github.com/hherb/secretary/issues/95)** — split `core/tests/sync_helpers/mod.rs`. Now 1115 LOC; [comment posted](https://github.com/hherb/secretary/issues/95#issuecomment-4514600227) with the updated LOC. Revisit at Task 17 or as standalone refactor BEFORE Task 14.
+- **[#98](https://github.com/hherb/secretary/issues/98)** — `apply_decisions` duplicate-decision tightening.
+- **[#103](https://github.com/hherb/secretary/issues/103)** — Task 12 follow-on: prove EvidenceStale abort beats step 5's per-block rewrites on a divergence-bearing fixture. Could be closed alongside Task 13's PR if a small test addition fits, OR roll into Task 14's crash-recovery surface. Recommended: keep separate (Task 14 has its own crash-recovery story; #103 is a narrower EvidenceStale variant).
+
+### Open PRs at close
+
+**To be opened at end of this session** — `feature/c1-1b-sync-merge` carries 6 commits on top of `324c4cb` (post-Task-12 main). PR body will reference this baton. Single PR groups all 6 commits because they form a tightly coupled feature (the bug fix + 4 tests + 1 helper + 1 lift-refactor all close the C.1.1b veto-handling surface) — per Task 12's experience that "grouping commits into one PR is fine when they're tightly coupled".
+
+## (4) Exact commands to resume
+
+```bash
+cd /Users/hherb/src/secretary
+git fetch --prune origin
+git status --short                                              # expect: clean
+git worktree list                                               # expect: main + .worktrees/c1-1b-sync-merge
+
+cd .worktrees/c1-1b-sync-merge
+pwd                                                             # confirm worktree
+git branch --show-current                                       # → feature/c1-1b-sync-merge
+git log --oneline -8                                            # last 8: baton + 6 task commits + main HEAD
+
+# Baseline gauntlet (expect 780 / 0 / 10 on this branch BEFORE Task 14 starts;
+# becomes 766+ baseline relative to next session's post-merge main):
+cargo test --release --workspace --no-fail-fast 2>&1 | grep -E "^test result:" | awk '{passed+=$4; failed+=$6; ignored+=$8} END {print "PASSED:", passed, "FAILED:", failed, "IGNORED:", ignored}'
+cargo clippy --release --workspace --tests -- -D warnings 2>&1 | tail -3
+cargo fmt --all -- --check
+uv run core/tests/python/conformance.py 2>&1 | tail -3
+uv run core/tests/python/spec_test_name_freshness.py 2>&1 | tail -3
+
+# AFTER Task 13's PR merges, reset feature branch + open the plan for Task 14:
+git fetch --prune origin
+git reset --hard origin/main
+$EDITOR docs/superpowers/plans/2026-05-18-c1-1b-sync-merge.md   # jump to "Task 14"
+```
+
+## Closing inventory
+
+- **Branch state on close:** `main` at `324c4cb` (PR #102 squash-merged Task 12). `feature/c1-1b-sync-merge` rebased onto `324c4cb` carrying 6 new commits (`63b32a7` lift + `833b981` Task 13a + `7cd8a37` Task 13.1 + fix + `262d444` Task 13.2 + `ab1c701` Task 13.3 + `8c6149a` Task 13.4) + this baton commit.
+- **Workspace tests on `feature/c1-1b-sync-merge`:** 780 passed + 10 ignored. Clippy + fmt + Python conformance + spec-citation freshness all clean.
+- **README.md:** unchanged this session. Per plan Task 17, updates land at end of C.1.1b.
+- **ROADMAP.md:** unchanged this session. Per plan Task 17, updates land at end of C.1.1b.
+- **CLAUDE.md:** unchanged this session.
+- **Open issues:** [#37](https://github.com/hherb/secretary/issues/37) / [#38](https://github.com/hherb/secretary/issues/38) / [#45](https://github.com/hherb/secretary/issues/45) / [#75](https://github.com/hherb/secretary/issues/75) / [#76](https://github.com/hherb/secretary/issues/76) / [#78](https://github.com/hherb/secretary/issues/78) / [#79](https://github.com/hherb/secretary/issues/79) / [#81](https://github.com/hherb/secretary/issues/81) / [#87](https://github.com/hherb/secretary/issues/87) / [#88](https://github.com/hherb/secretary/issues/88) / [#90](https://github.com/hherb/secretary/issues/90) / [#95](https://github.com/hherb/secretary/issues/95) / [#98](https://github.com/hherb/secretary/issues/98) / [#103](https://github.com/hherb/secretary/issues/103).
+- **Open PRs:** one to be opened at end of this session covering Tasks 13a + 13.1-13.4 + the `prepare_merge` veto-pass fix.
+- **Worktrees on disk:** `main` + `.worktrees/c1-1b-sync-merge`.
+- **Frozen baton snapshots:**
+  - [`docs/handoffs/2026-05-19-c1-1b-tasks-1-3-shipped.md`](docs/handoffs/2026-05-19-c1-1b-tasks-1-3-shipped.md) — Tasks 1-3 close.
+  - [`docs/handoffs/2026-05-19-c1-1b-pr-84-review-fixes.md`](docs/handoffs/2026-05-19-c1-1b-pr-84-review-fixes.md) — PR #84 review-fix cycle.
+  - [`docs/handoffs/2026-05-19-c1-1b-task-4-shipped.md`](docs/handoffs/2026-05-19-c1-1b-task-4-shipped.md) — Task 4 close.
+  - [`docs/handoffs/2026-05-19-c1-1b-task-5-shipped.md`](docs/handoffs/2026-05-19-c1-1b-task-5-shipped.md) — Task 5 close.
+  - [`docs/handoffs/2026-05-19-c1-1b-task-6-shipped.md`](docs/handoffs/2026-05-19-c1-1b-task-6-shipped.md) — Task 6 close.
+  - [`docs/handoffs/2026-05-19-c1-1b-task-7-shipped.md`](docs/handoffs/2026-05-19-c1-1b-task-7-shipped.md) — Task 7 close.
+  - [`docs/handoffs/2026-05-19-c1-1b-task-8-shipped.md`](docs/handoffs/2026-05-19-c1-1b-task-8-shipped.md) — Task 8 close.
+  - [`docs/handoffs/2026-05-19-c1-1b-task-9-shipped.md`](docs/handoffs/2026-05-19-c1-1b-task-9-shipped.md) — Task 9 close.
+  - [`docs/handoffs/2026-05-19-c1-1b-task-10-shipped.md`](docs/handoffs/2026-05-19-c1-1b-task-10-shipped.md) — Task 10 close.
+  - [`docs/handoffs/2026-05-20-c1-1b-task-11-shipped.md`](docs/handoffs/2026-05-20-c1-1b-task-11-shipped.md) — Task 11 close.
+  - [`docs/handoffs/2026-05-20-c1-1b-task-12-shipped.md`](docs/handoffs/2026-05-20-c1-1b-task-12-shipped.md) — Task 12 close.
+  - [`docs/handoffs/2026-05-21-c1-1b-task-13-shipped.md`](docs/handoffs/2026-05-21-c1-1b-task-13-shipped.md) — Task 13 close (this session).


### PR DESCRIPTION
## Summary

C.1.1b Task 13 closes the per-record veto disposition surface: four integration tests cover the two valid `VetoDecision` branches (`KeepLocal`, `AcceptTombstone`) AND the two bijection-violation branches (`MissingVetoDecision`, `UnknownVetoDecision`). Bug surfaced + fixed: `prepare_merge`'s veto pass was iterating the post-iterative-fold accumulator (`acc_records`) instead of canonical's pre-merge records, making the integration veto branch UNREACHABLE under well-formed inputs.

## Commits (6 + 1 baton)

| | | |
|---|---|---|
| `63b32a7` | 13a pre-refactor | Lift `extract_vault_uuid` into `fixtures::extract_vault_uuid`; remove 4 inline copies |
| `833b981` | 13a | `fresh_vault_two_concurrent_blocks` per-block-divergent fixture helper + shared `encrypt_block_bytes_for_uuid` extraction + smoke test |
| `7cd8a37` | 13.1 + fix | `commit_with_decisions_keep_local_overrides_peer_tombstone` integration test + `prepare_merge` veto-pass canonical-vs-accumulator fix |
| `262d444` | 13.2 | `commit_with_decisions_accept_tombstone_finalizes_peer_delete` |
| `ab1c701` | 13.3 | `commit_with_decisions_missing_veto_decision_aborts_with_typed_error` + no-block-write post-condition |
| `8c6149a` | 13.4 | `commit_with_decisions_unknown_veto_decision_aborts_with_typed_error` + no-block-write post-condition |
| `9139fab` | baton | NEXT_SESSION.md symlink retarget + handoff doc |

## The bug fix (`7cd8a37`)

`prepare_merge`'s per-record veto pass (`prepare.rs` line 463 pre-fix) iterated `acc_records.iter()` and passed each entry as `local` to `tombstone_veto_set`. Under well-formed inputs this made the integration veto branch UNREACHABLE: when canonical has a LIVE record at `last_mod_ms = L` and a peer has the same record TOMBSTONED at `tombstoned_at_ms = T > L`, `merge_block`'s §11.3 tombstone-wins-by-clock rule writes a tombstoned record into `acc_records`, and the veto pass's `if local_rec.tombstone { continue; }` then skipped the very case the veto is meant to surface.

The pre-fix unit tests on `tombstone_veto_set` itself all passed because they exercise the helper in isolation with a canonical-style live record. The bug only surfaced because Task 13.1's integration test was the FIRST test ever to drive `prepare_merge` on a per-block-divergent fixture — exactly the scenario this commit is meant to cover.

Fix: walk `canonical_pt.records` (pre-merge) in the veto pass, not `acc_records`. Matches `tombstone_veto_set`'s docstring ("the local (canonical) record"), the design doc §"prepare_merge" step 2 ("local.is_alive()" with local being canonical), and `commit/apply.rs::keep_local_overrides_tombstoned_record`'s unit-test fixture pattern (vetoes carry LIVE `local_state`, `merged_records` carries TOMBSTONED records — only achievable if vetoes were emitted from canonical, not from the merge output).

## Test count

767 → 780 (+13):
- +1 helper smoke (`fresh_vault_two_concurrent_blocks_…`)
- +4 helper_tests cross-binary re-runs in the new `sync_merge_vetoes` test binary
- +4 new veto integration tests (Tasks 13.1-13.4)
- +4 helper_tests cross-binary re-runs (the `sync_merge_vetoes` binary picks up the existing 5 helper tests from `sync_helpers::helper_tests`, one of which is the new smoke counted above — net +4 cross-binary re-runs of the older 4 helper tests)

## Test plan

- [x] `cargo test --release --workspace --no-fail-fast` → 780 / 0 / 10
- [x] `cargo clippy --release --workspace --tests -- -D warnings` → clean
- [x] `cargo fmt --all -- --check` → clean
- [x] `uv run core/tests/python/conformance.py` → PASS
- [x] `uv run core/tests/python/spec_test_name_freshness.py` → PASS (96 resolved / 0 unresolved / 2 suppressed)

## Open decisions documented in baton

1. **Production-code change in a test task** — `prepare_merge` veto-pass fix is part of Task 13.1 because the test's RED signal was the trigger. Per [[feedback_act_on_issues_dont_mention]], fix in-task rather than defer.
2. **One commit for fix + test** — TDD-coupled per the commit body's rationale. Bisect-deterministic.
3. **`sync_helpers/mod.rs` grew to 1115 LOC** — past #95's 800 trigger. [Commented](https://github.com/hherb/secretary/issues/95#issuecomment-4514600227) with the new LOC. Split still deferred to a standalone refactor PR per implementer-call #4 in the Task 12 baton.
4. **`sync_merge_vetoes.rs` is a new test binary** — `sync_merge.rs` was already at ~500 LOC after Task 12; adding 4 more tests would push it past 900. New binary keeps the veto concern isolated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)