### PR TITLE
C.1.1b Task 15 — merge-layer property tests (fixpoint, deterministic, order-independent, bijection)

### DIFF
--- a/NEXT_SESSION.md
+++ b/NEXT_SESSION.md
@@ -1,1 +1,1 @@
-docs/handoffs/2026-05-22-c1-1b-task-14-shipped.md
+docs/handoffs/2026-05-22-c1-1b-task-15-shipped.md

--- a/core/tests/sync_merge_proptest.rs
+++ b/core/tests/sync_merge_proptest.rs
@@ -90,7 +90,7 @@ proptest! {
     ) {
         let (folder, _tmp, _block_uuid) =
             build_no_veto_fixture(counter_canonical, counter_sibling);
-        let (bundle, plan, _state_pre) = drive_sync_once_concurrent(&folder);
+        let (bundle, plan) = drive_sync_once_concurrent(&folder);
         let identity = open_identity(&folder);
 
         let draft = prepare_merge(&folder, &identity, &bundle, &plan).expect("prepare_merge");
@@ -150,18 +150,22 @@ proptest! {
         counter_canonical in 1u64..1000,
         counter_sibling in 1u64..1000,
     ) {
-        let (folder_a, _tmp_a, block_uuid_a) =
+        // Both UUIDs come from the same deterministic
+        // `golden_vault_001_first_block_uuid` probe inside the fixture
+        // builder, so they are structurally identical and no runtime
+        // equality check is needed.
+        let (folder_a, _tmp_a, block_uuid) =
             build_no_veto_fixture(counter_canonical, counter_sibling);
-        let (folder_b, _tmp_b, block_uuid_b) =
+        let (folder_b, _tmp_b, _block_uuid_b) =
             build_no_veto_fixture(counter_canonical, counter_sibling);
-        prop_assert_eq!(
-            block_uuid_a,
-            block_uuid_b,
-            "both fixtures must derive the same block_uuid from golden_vault_001",
-        );
 
+        // `assert!` (not `prop_assert!`) inside the closure: proptest's
+        // `prop_assert!` macro expands to `return Err(...)` from the
+        // enclosing test fn, which cannot cross a closure boundary.
+        // Panics from `assert!` are still caught by proptest and
+        // reported as case failures — only shrinking metadata is lost.
         let run = |folder: &std::path::Path| {
-            let (bundle, plan, _state_pre) = drive_sync_once_concurrent(folder);
+            let (bundle, plan) = drive_sync_once_concurrent(folder);
             let identity = open_identity(folder);
             let draft = prepare_merge(folder, &identity, &bundle, &plan).expect("prepare_merge");
             assert!(
@@ -173,8 +177,8 @@ proptest! {
             let new_state =
                 commit_with_decisions(folder, &password, draft, Vec::new(), COMMIT_NOW_MS)
                     .expect("commit_with_decisions");
-            let records = read_canonical_block_records(folder, block_uuid_a);
-            let block_path = sync_helpers::block_file_path(folder, &block_uuid_a);
+            let records = read_canonical_block_records(folder, block_uuid);
+            let block_path = sync_helpers::block_file_path(folder, &block_uuid);
             let block_bytes = std::fs::read(&block_path).expect("read canonical block");
             (new_state, records, block_bytes)
         };
@@ -244,8 +248,13 @@ proptest! {
         let decision_a = make_decision(RECORD_A_UUID, keep_local_a);
         let decision_b = make_decision(RECORD_B_UUID, keep_local_b);
 
+        // `assert_eq!` (not `prop_assert_eq!`) inside the closure: see
+        // the same note on the property-2 `run` closure — proptest's
+        // assertion macros can't cross a closure boundary, and a
+        // panic-based check is functionally equivalent at the cost of
+        // shrinking metadata.
         let commit = |folder: &std::path::Path, decisions: Vec<VetoDecision>| {
-            let (bundle, plan, _state_pre) = drive_sync_once_concurrent(folder);
+            let (bundle, plan) = drive_sync_once_concurrent(folder);
             let identity = open_identity(folder);
             let draft = prepare_merge(folder, &identity, &bundle, &plan).expect("prepare_merge");
             assert_eq!(
@@ -320,7 +329,7 @@ proptest! {
         let (folder, _tmp, _block_uuid) =
             build_single_veto_fixture(counter_canonical, counter_sibling);
 
-        let (bundle, plan, _state_pre) = drive_sync_once_concurrent(&folder);
+        let (bundle, plan) = drive_sync_once_concurrent(&folder);
         let identity = open_identity(&folder);
         let password = fixtures::golden_vault_001_password();
 

--- a/core/tests/sync_merge_proptest.rs
+++ b/core/tests/sync_merge_proptest.rs
@@ -389,7 +389,6 @@ fn drive_sync_once_concurrent(
 /// Read the canonical block's decrypted records via a fresh `open_vault`
 /// so the caller's stale state doesn't contaminate the assertion.
 /// Consumed by properties 2 and 3.
-#[allow(dead_code)]
 fn read_canonical_block_records(folder: &std::path::Path, block_uuid: [u8; 16]) -> Vec<Record> {
     let password = fixtures::golden_vault_001_password();
     let open = open_vault(folder, Unlocker::Password(&password), None).expect("open_vault");
@@ -459,6 +458,103 @@ proptest! {
             outcome,
             SyncOutcome::NothingToDo,
             "post-commit sync_once must report NothingToDo (state.clock vs disk.clock must be Equal)",
+        );
+    }
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig {
+        cases: PROPTEST_CASES,
+        .. ProptestConfig::default()
+    })]
+
+    /// Property 2 — The three-step
+    /// `sync_once → prepare_merge → commit_with_decisions` is a
+    /// deterministic function of its inputs: running it on two
+    /// independent vaults built with identical fixture parameters
+    /// produces:
+    ///
+    /// - The same returned [`SyncState`] (post_merge_clock is a pure
+    ///   function of the input manifest clocks).
+    /// - The same decrypted canonical block records (CRDT merge is a
+    ///   pure function of its inputs).
+    /// - DIFFERENT canonical block envelope bytes (AEAD nonces are
+    ///   drawn from `OsRng` per rewrite — a deterministic-nonce
+    ///   regression would emit identical ciphertext).
+    ///
+    /// The first two assertions are the idempotence claim: the merge
+    /// surface has no hidden state that would let two equivalent
+    /// invocations diverge in their observable output. The third
+    /// assertion pins the AEAD-nonce-per-rewrite contract at the
+    /// proptest level (the integration-test surface in
+    /// `sync_merge_crash.rs` already covers the same contract for the
+    /// retry path; this adds property-level coverage over a different
+    /// dimension — across independent vaults).
+    ///
+    /// Inputs: same as property 1 (canonical + sibling manifest-clock
+    /// counters).
+    #[test]
+    fn prop_three_step_idempotent_on_repeated_invocation(
+        counter_canonical in 1u64..1000,
+        counter_sibling in 1u64..1000,
+    ) {
+        // Two independent fixtures with identical inputs. The two
+        // `tempfile::TempDir`s must stay alive until the test ends.
+        let (folder_a, _tmp_a, block_uuid_a) =
+            build_no_veto_fixture(counter_canonical, counter_sibling);
+        let (folder_b, _tmp_b, block_uuid_b) =
+            build_no_veto_fixture(counter_canonical, counter_sibling);
+        prop_assert_eq!(
+            block_uuid_a,
+            block_uuid_b,
+            "both fixtures must derive the same block_uuid from golden_vault_001",
+        );
+
+        let password = fixtures::golden_vault_001_password();
+
+        let run_three_step = |folder: &std::path::Path| -> (SyncState, Vec<Record>, Vec<u8>) {
+            let (bundle, plan, _state_pre) = drive_sync_once_concurrent(folder);
+            let vt_bytes = std::fs::read(folder.join("vault.toml")).expect("read vault.toml");
+            let bundle_bytes = std::fs::read(folder.join("identity.bundle.enc"))
+                .expect("read identity bundle");
+            let identity = open_with_password(&vt_bytes, &bundle_bytes, &password)
+                .expect("open_with_password");
+
+            let draft = prepare_merge(folder, &identity, &bundle, &plan).expect("prepare_merge");
+            assert!(
+                draft.vetoes.is_empty(),
+                "no_veto_fixture must produce zero vetoes (got {})",
+                draft.vetoes.len(),
+            );
+            let new_state =
+                commit_with_decisions(folder, &password, draft, Vec::new(), COMMIT_NOW_MS)
+                    .expect("commit_with_decisions");
+            let records = read_canonical_block_records(folder, block_uuid_a);
+            let block_path = sync_helpers::block_file_path(folder, &block_uuid_a);
+            let block_bytes = std::fs::read(&block_path).expect("read canonical block");
+            (new_state, records, block_bytes)
+        };
+
+        let (state_a, records_a, bytes_a) = run_three_step(&folder_a);
+        let (state_b, records_b, bytes_b) = run_three_step(&folder_b);
+
+        // Pure function of inputs: SyncState matches.
+        prop_assert_eq!(
+            state_a,
+            state_b,
+            "two equivalent fixtures must yield the same post-commit SyncState",
+        );
+        // Pure function of inputs: decrypted block records match.
+        prop_assert_eq!(
+            records_a,
+            records_b,
+            "two equivalent fixtures must yield the same decrypted canonical block records",
+        );
+        // AEAD-nonce-per-rewrite contract: envelope bytes diverge.
+        prop_assert_ne!(
+            bytes_a,
+            bytes_b,
+            "two independent commits must produce different ciphertext (AEAD nonces from OsRng)",
         );
     }
 }

--- a/core/tests/sync_merge_proptest.rs
+++ b/core/tests/sync_merge_proptest.rs
@@ -49,7 +49,9 @@ use std::collections::BTreeMap;
 
 use proptest::prelude::*;
 use secretary_core::crypto::secret::SecretString;
-use secretary_core::sync::{commit_with_decisions, prepare_merge, sync_once, SyncOutcome, SyncState};
+use secretary_core::sync::{
+    commit_with_decisions, prepare_merge, sync_once, SyncOutcome, SyncState, VetoDecision,
+};
 use secretary_core::unlock::open_with_password;
 use secretary_core::vault::block::VectorClockEntry;
 use secretary_core::vault::{open_vault, Record, RecordField, RecordFieldValue, Unlocker};
@@ -296,10 +298,20 @@ fn build_single_veto_fixture(
     (folder, tmp, block_uuid)
 }
 
+/// Map a boolean choice to a [`VetoDecision`] for a given `record_id`.
+/// `true` → `KeepLocal`, `false` → `AcceptTombstone`. Used by property
+/// 3 to vary the decision kind per veto across cases.
+fn make_decision(record_id: [u8; 16], keep_local: bool) -> VetoDecision {
+    if keep_local {
+        VetoDecision::KeepLocal { record_id }
+    } else {
+        VetoDecision::AcceptTombstone { record_id }
+    }
+}
+
 /// Build a per-block-divergent fixture with TWO disjoint vetoes. Both
 /// records are LIVE on canonical, TOMBSTONED on sibling at the later
 /// death clock. Used by property 3 to vary decision ordering.
-#[allow(dead_code)]
 fn build_two_veto_fixture(
     counter_canonical: u64,
     counter_sibling: u64,
@@ -555,6 +567,94 @@ proptest! {
             bytes_a,
             bytes_b,
             "two independent commits must produce different ciphertext (AEAD nonces from OsRng)",
+        );
+    }
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig {
+        cases: PROPTEST_CASES,
+        .. ProptestConfig::default()
+    })]
+
+    /// Property 3 — Given a draft with two vetoes on disjoint
+    /// `record_id`s, the order of decisions inside the
+    /// `Vec<VetoDecision>` passed to `commit_with_decisions` does NOT
+    /// affect the post-commit observable state. Two equivalent
+    /// fixtures are built; one commits with decisions `[d_a, d_b]`,
+    /// the other with `[d_b, d_a]`. Assert:
+    ///
+    /// - Same returned [`SyncState`].
+    /// - Same decrypted canonical block records (set equality — both
+    ///   come from `prepare_merge`'s BTreeMap-into-Vec output, so they
+    ///   are already sorted by `record_uuid`; element-wise equality is
+    ///   the strict check).
+    ///
+    /// Why this is non-trivial: `apply_decisions` iterates decisions
+    /// in their input order to apply per-record `KeepLocal` restores.
+    /// If the per-decision side effects were not commutative (e.g., a
+    /// future refactor accidentally shared mutable state across
+    /// per-decision steps), the two orderings would diverge. The
+    /// property pins commutativity over the full decision set.
+    ///
+    /// Inputs: clock counters + two booleans (`keep_local_a`,
+    /// `keep_local_b`) that vary the decision kind per veto. This
+    /// covers the (KeepLocal, KeepLocal), (KeepLocal, AcceptTombstone),
+    /// (AcceptTombstone, KeepLocal), and
+    /// (AcceptTombstone, AcceptTombstone) decision pairings across the
+    /// 16 case budget.
+    #[test]
+    fn prop_commit_associative_under_disjoint_vetoes(
+        counter_canonical in 1u64..1000,
+        counter_sibling in 1u64..1000,
+        keep_local_a: bool,
+        keep_local_b: bool,
+    ) {
+        let (folder_a, _tmp_a, block_uuid) =
+            build_two_veto_fixture(counter_canonical, counter_sibling);
+        let (folder_b, _tmp_b, _block_uuid_b) =
+            build_two_veto_fixture(counter_canonical, counter_sibling);
+
+        let password = fixtures::golden_vault_001_password();
+        let decision_a = make_decision(RECORD_A_UUID, keep_local_a);
+        let decision_b = make_decision(RECORD_B_UUID, keep_local_b);
+
+        let commit = |folder: &std::path::Path, decisions: Vec<VetoDecision>| -> (SyncState, Vec<Record>) {
+            let (bundle, plan, _state_pre) = drive_sync_once_concurrent(folder);
+            let vt_bytes = std::fs::read(folder.join("vault.toml")).expect("read vault.toml");
+            let bundle_bytes = std::fs::read(folder.join("identity.bundle.enc"))
+                .expect("read identity bundle");
+            let identity = open_with_password(&vt_bytes, &bundle_bytes, &password)
+                .expect("open_with_password");
+            let draft = prepare_merge(folder, &identity, &bundle, &plan).expect("prepare_merge");
+            assert_eq!(
+                draft.vetoes.len(),
+                2,
+                "two_veto_fixture must produce exactly two vetoes (got {})",
+                draft.vetoes.len(),
+            );
+            let new_state =
+                commit_with_decisions(folder, &password, draft, decisions, COMMIT_NOW_MS)
+                    .expect("commit_with_decisions");
+            let records = read_canonical_block_records(folder, block_uuid);
+            (new_state, records)
+        };
+
+        // Order 1: [d_a, d_b]
+        let (state_ab, records_ab) =
+            commit(&folder_a, vec![decision_a.clone(), decision_b.clone()]);
+        // Order 2: [d_b, d_a] — swapped
+        let (state_ba, records_ba) = commit(&folder_b, vec![decision_b, decision_a]);
+
+        prop_assert_eq!(
+            state_ab,
+            state_ba,
+            "decision order must not affect the returned SyncState",
+        );
+        prop_assert_eq!(
+            records_ab,
+            records_ba,
+            "decision order must not affect the post-commit canonical block records",
         );
     }
 }

--- a/core/tests/sync_merge_proptest.rs
+++ b/core/tests/sync_merge_proptest.rs
@@ -19,396 +19,45 @@
 //!    (disjoint `record_id`s), committing with decisions `[d1, d2]` on
 //!    one vault and `[d2, d1]` on an identically-built second vault
 //!    produces the same returned [`SyncState`] and the same decrypted
-//!    canonical block records. The two veto sets are non-overlapping by
-//!    construction (`apply_decisions` indexes by `record_id`, which is
-//!    unique per veto).
+//!    canonical block records.
 //! 4. **Bijection enforcement** — for random `(matching, stray_count)`
 //!    inputs against a single-veto fixture, `commit_with_decisions`
-//!    returns:
-//!    - [`SyncError::MissingVetoDecision`] when the matching decision
-//!      is omitted (whether or not strays are present — Missing is
-//!      checked before Unknown in
-//!      [`apply_decisions`](secretary_core::sync::__never_imported_apply_decisions)).
-//!    - [`SyncError::UnknownVetoDecision`] when the matching decision is
-//!      present AND at least one stray decision is present.
-//!    - `Ok(_)` when the matching decision is present and no strays are
-//!      present.
+//!    returns `MissingVetoDecision` / `UnknownVetoDecision` / `Ok` per
+//!    the bijection rules (Missing checked before Unknown).
 //!
 //! ## Cost model
 //!
 //! Each case runs at least one `fresh_vault_two_concurrent_blocks` build
 //! (open_vault Argon2 + two block encryptions + two manifest signs) plus
 //! at least one `commit_with_decisions` (re-encrypt + re-sign). Properties
-//! 2-3 build two fixtures per case. The per-property `cases` cap is set
-//! so each property completes in well under a minute on the project's
-//! reference hardware.
+//! 2-3 build two fixtures per case. The per-property `cases` cap
+//! ([`sync_merge_proptest_helpers::PROPTEST_CASES`]) is set so each
+//! property completes in well under a minute on the project's reference
+//! hardware.
+//!
+//! ## File layout
+//!
+//! Helpers (constants, record builders, fixture builders, drivers) live
+//! in [`sync_merge_proptest_helpers`] so this file holds only the four
+//! `proptest!` blocks. See the helpers module for the fixture
+//! parametrisation and the cost-budget rationale.
 
 #![forbid(unsafe_code)]
 
-use std::collections::BTreeMap;
-
 use proptest::prelude::*;
-use secretary_core::crypto::secret::SecretString;
 use secretary_core::sync::{
-    commit_with_decisions, prepare_merge, sync_once, SyncError, SyncOutcome, SyncState,
-    VetoDecision,
+    commit_with_decisions, prepare_merge, sync_once, SyncError, SyncOutcome, VetoDecision,
 };
-use secretary_core::unlock::open_with_password;
-use secretary_core::vault::block::VectorClockEntry;
-use secretary_core::vault::{open_vault, Record, RecordField, RecordFieldValue, Unlocker};
 
 mod fixtures;
 mod sync_helpers;
+mod sync_merge_proptest_helpers;
 
-use fixtures::extract_vault_uuid;
-
-// === Fixed (non-randomised) fixture inputs ===
-//
-// Property cases vary the manifest clock counters and (for prop 4) the
-// stray decision UUIDs. Holding the other fixture inputs fixed avoids
-// re-deriving record bodies / device UUIDs on every iteration and keeps
-// each case's failure mode unambiguous (a flake names the same record
-// UUIDs every time).
-
-/// Record UUID for the FIRST veto-bearing record (canonical LIVE,
-/// sibling TOMBSTONED at later death-clock).
-const RECORD_A_UUID: [u8; 16] = [0xAA; 16];
-/// Record UUID for the SECOND veto-bearing record. Strictly greater
-/// than [`RECORD_A_UUID`] so `apply_decisions`'s canonical-sort error
-/// reporting is deterministic (Missing fires on the smallest
-/// un-adjudicated id). Consumed by property 3.
-#[allow(dead_code)]
-const RECORD_B_UUID: [u8; 16] = [0xBB; 16];
-/// Record UUID for the FIRST non-conflicting record on the canonical
-/// side (used in properties 1 & 2 where vetoes are not desired).
-const NONCONFLICTING_RECORD_CANONICAL_UUID: [u8; 16] = [0xAA; 16];
-/// Record UUID for the FIRST non-conflicting record on the sibling
-/// side. Distinct from
-/// [`NONCONFLICTING_RECORD_CANONICAL_UUID`] so the merge produces a
-/// clean union with no vetoes.
-const NONCONFLICTING_RECORD_SIBLING_UUID: [u8; 16] = [0xBB; 16];
-/// Canonical device clock anchor. Records' `last_modifier_device` and
-/// the canonical block's `vector_clock_summary` reference this device.
-const CANONICAL_DEVICE_UUID: [u8; 16] = [0x0A; 16];
-/// Sibling device clock anchor. Records' `last_modifier_device` and
-/// the sibling block's `vector_clock_summary` reference this device.
-const SIBLING_DEVICE_UUID: [u8; 16] = [0x0B; 16];
-/// Local device clock anchor — the persisted `SyncState`'s clock entry.
-/// Distinct from canonical / sibling so the pre-commit
-/// `ClockRelation` is `Concurrent` (sync_once precondition for the
-/// `ConcurrentDetected` arm).
-const LOCAL_DEVICE_UUID: [u8; 16] = [0x0C; 16];
-/// `last_mod_ms` on every canonical LIVE record. Constant; nothing else
-/// fixes the value.
-const LOCAL_LAST_MOD_MS: u64 = 100;
-/// `last_mod_ms` AND `tombstoned_at_ms` on every sibling TOMBSTONED
-/// record. Strictly greater than [`LOCAL_LAST_MOD_MS`] so the per-record
-/// veto pass fires (`tombstone_veto_set`'s strict-greater branch).
-/// Consumed by properties 3 and 4.
-#[allow(dead_code)]
-const SIBLING_TOMBSTONE_AT_MS: u64 = 200;
-/// `last_mod_ms` on the non-conflicting sibling record (properties 1 &
-/// 2). Same magnitude as [`SIBLING_TOMBSTONE_AT_MS`] but the record is
-/// LIVE — only the UUID disjointness matters for vetoless merges.
-const SIBLING_NONCONFLICTING_LAST_MOD_MS: u64 = 200;
-/// Commit timestamp passed to `commit_with_decisions`. Reused across
-/// every fixture's invocations so manifest `last_mod_ms` is uniform.
-const COMMIT_NOW_MS: u64 = 1_000_000;
-/// Sibling manifest filename — must start with `manifest.cbor.enc` per
-/// `enumerate_manifest_siblings`. The Syncthing-style suffix is the
-/// project convention across C.1.1a / C.1.1b tests.
-const SIBLING_MANIFEST_FILENAME: &str = "manifest.cbor.enc.sync-conflict-from-device-bb";
-/// Sibling block-file suffix — must start with a non-empty separator
-/// so the resulting filename is recognised by
-/// `enumerate_block_siblings`.
-const SIBLING_BLOCK_SUFFIX: &str = ".sync-conflict-from-device-bb";
-/// `cases` cap shared across the four properties. Each case builds one
-/// or two `fresh_vault_two_concurrent_blocks` fixtures (open_vault
-/// Argon2 + two block encryptions + two manifest signs) and runs at
-/// least one `commit_with_decisions` (re-encrypt + re-sign). 16 cases
-/// per property keeps the whole file comfortably under a minute on the
-/// project's reference hardware while still exploring two independent
-/// dimensions per property (typically the canonical + sibling clock
-/// counters).
-const PROPTEST_CASES: u32 = 16;
-
-/// Build a LIVE record with one field. `uuid` controls the
-/// `record_uuid`; `device_uuid` + `last_mod_ms` flow into the field
-/// envelope so the merge sees a coherent timestamp.
-fn live_record(uuid: [u8; 16], device_uuid: [u8; 16], last_mod_ms: u64, marker: &str) -> Record {
-    let mut fields = BTreeMap::new();
-    fields.insert(
-        "k".to_string(),
-        RecordField {
-            value: RecordFieldValue::Text(SecretString::from(marker)),
-            last_mod: last_mod_ms,
-            device_uuid,
-            unknown: BTreeMap::new(),
-        },
-    );
-    Record {
-        record_uuid: uuid,
-        record_type: "kv".to_string(),
-        fields,
-        tags: Vec::new(),
-        created_at_ms: 50,
-        last_mod_ms,
-        tombstone: false,
-        tombstoned_at_ms: 0,
-        unknown: BTreeMap::new(),
-    }
-}
-
-/// Build a TOMBSTONED record. `last_mod_ms == tombstoned_at_ms` per the
-/// §11.5 invariant that tombstoned records pin both timestamps to the
-/// death clock. Consumed by properties 3 and 4.
-#[allow(dead_code)]
-fn tombstoned_record(uuid: [u8; 16], device_uuid: [u8; 16], tombstoned_at_ms: u64) -> Record {
-    let mut fields = BTreeMap::new();
-    fields.insert(
-        "k".to_string(),
-        RecordField {
-            value: RecordFieldValue::Text(SecretString::from("ignored")),
-            last_mod: tombstoned_at_ms,
-            device_uuid,
-            unknown: BTreeMap::new(),
-        },
-    );
-    Record {
-        record_uuid: uuid,
-        record_type: "kv".to_string(),
-        fields,
-        tags: Vec::new(),
-        created_at_ms: 50,
-        last_mod_ms: tombstoned_at_ms,
-        tombstone: true,
-        tombstoned_at_ms,
-        unknown: BTreeMap::new(),
-    }
-}
-
-/// Build a per-block-divergent fixture with NO veto-producing records.
-/// The canonical block holds [`NONCONFLICTING_RECORD_CANONICAL_UUID`]
-/// LIVE; the sibling block holds
-/// [`NONCONFLICTING_RECORD_SIBLING_UUID`] LIVE. UUIDs are distinct, so
-/// the merge produces a clean union and `draft.vetoes` is empty.
-///
-/// `counter_canonical` / `counter_sibling` are the per-device counters
-/// at the canonical / sibling manifest level (the block-level
-/// vector_clock_summary uses counter `1` because the records are local
-/// edits from a single anchor; only the manifest-level clock varies).
-fn build_no_veto_fixture(
-    counter_canonical: u64,
-    counter_sibling: u64,
-) -> (std::path::PathBuf, tempfile::TempDir, [u8; 16]) {
-    let (probe_folder, _probe_tmp) = sync_helpers::fresh_vault_with_clock(Vec::new());
-    let block_uuid = sync_helpers::golden_vault_001_first_block_uuid(&probe_folder);
-
-    let canonical_block_clock = vec![VectorClockEntry {
-        device_uuid: CANONICAL_DEVICE_UUID,
-        counter: 1,
-    }];
-    let sibling_block_clock = vec![VectorClockEntry {
-        device_uuid: SIBLING_DEVICE_UUID,
-        counter: 1,
-    }];
-    let canonical_manifest_clock = vec![VectorClockEntry {
-        device_uuid: CANONICAL_DEVICE_UUID,
-        counter: counter_canonical,
-    }];
-    let sibling_manifest_clock = vec![VectorClockEntry {
-        device_uuid: SIBLING_DEVICE_UUID,
-        counter: counter_sibling,
-    }];
-
-    let (folder, tmp) = sync_helpers::fresh_vault_two_concurrent_blocks(
-        block_uuid,
-        vec![live_record(
-            NONCONFLICTING_RECORD_CANONICAL_UUID,
-            CANONICAL_DEVICE_UUID,
-            LOCAL_LAST_MOD_MS,
-            "canonical",
-        )],
-        canonical_block_clock,
-        canonical_manifest_clock,
-        vec![live_record(
-            NONCONFLICTING_RECORD_SIBLING_UUID,
-            SIBLING_DEVICE_UUID,
-            SIBLING_NONCONFLICTING_LAST_MOD_MS,
-            "sibling",
-        )],
-        sibling_block_clock,
-        sibling_manifest_clock,
-        SIBLING_MANIFEST_FILENAME,
-        SIBLING_BLOCK_SUFFIX,
-        COMMIT_NOW_MS,
-    );
-    (folder, tmp, block_uuid)
-}
-
-/// Build a per-block-divergent fixture with a SINGLE veto. The veto
-/// targets [`RECORD_A_UUID`] (canonical LIVE at
-/// [`LOCAL_LAST_MOD_MS`], sibling TOMBSTONED at
-/// [`SIBLING_TOMBSTONE_AT_MS`]). Consumed by property 4.
-fn build_single_veto_fixture(
-    counter_canonical: u64,
-    counter_sibling: u64,
-) -> (std::path::PathBuf, tempfile::TempDir, [u8; 16]) {
-    let (probe_folder, _probe_tmp) = sync_helpers::fresh_vault_with_clock(Vec::new());
-    let block_uuid = sync_helpers::golden_vault_001_first_block_uuid(&probe_folder);
-
-    let canonical_block_clock = vec![VectorClockEntry {
-        device_uuid: CANONICAL_DEVICE_UUID,
-        counter: 1,
-    }];
-    let sibling_block_clock = vec![VectorClockEntry {
-        device_uuid: SIBLING_DEVICE_UUID,
-        counter: 1,
-    }];
-    let canonical_manifest_clock = vec![VectorClockEntry {
-        device_uuid: CANONICAL_DEVICE_UUID,
-        counter: counter_canonical,
-    }];
-    let sibling_manifest_clock = vec![VectorClockEntry {
-        device_uuid: SIBLING_DEVICE_UUID,
-        counter: counter_sibling,
-    }];
-
-    let (folder, tmp) = sync_helpers::fresh_vault_two_concurrent_blocks(
-        block_uuid,
-        vec![live_record(
-            RECORD_A_UUID,
-            CANONICAL_DEVICE_UUID,
-            LOCAL_LAST_MOD_MS,
-            "canonical",
-        )],
-        canonical_block_clock,
-        canonical_manifest_clock,
-        vec![tombstoned_record(
-            RECORD_A_UUID,
-            SIBLING_DEVICE_UUID,
-            SIBLING_TOMBSTONE_AT_MS,
-        )],
-        sibling_block_clock,
-        sibling_manifest_clock,
-        SIBLING_MANIFEST_FILENAME,
-        SIBLING_BLOCK_SUFFIX,
-        COMMIT_NOW_MS,
-    );
-    (folder, tmp, block_uuid)
-}
-
-/// Map a boolean choice to a [`VetoDecision`] for a given `record_id`.
-/// `true` → `KeepLocal`, `false` → `AcceptTombstone`. Used by property
-/// 3 to vary the decision kind per veto across cases.
-fn make_decision(record_id: [u8; 16], keep_local: bool) -> VetoDecision {
-    if keep_local {
-        VetoDecision::KeepLocal { record_id }
-    } else {
-        VetoDecision::AcceptTombstone { record_id }
-    }
-}
-
-/// Build a per-block-divergent fixture with TWO disjoint vetoes. Both
-/// records are LIVE on canonical, TOMBSTONED on sibling at the later
-/// death clock. Used by property 3 to vary decision ordering.
-fn build_two_veto_fixture(
-    counter_canonical: u64,
-    counter_sibling: u64,
-) -> (std::path::PathBuf, tempfile::TempDir, [u8; 16]) {
-    let (probe_folder, _probe_tmp) = sync_helpers::fresh_vault_with_clock(Vec::new());
-    let block_uuid = sync_helpers::golden_vault_001_first_block_uuid(&probe_folder);
-
-    let canonical_block_clock = vec![VectorClockEntry {
-        device_uuid: CANONICAL_DEVICE_UUID,
-        counter: 1,
-    }];
-    let sibling_block_clock = vec![VectorClockEntry {
-        device_uuid: SIBLING_DEVICE_UUID,
-        counter: 1,
-    }];
-    let canonical_manifest_clock = vec![VectorClockEntry {
-        device_uuid: CANONICAL_DEVICE_UUID,
-        counter: counter_canonical,
-    }];
-    let sibling_manifest_clock = vec![VectorClockEntry {
-        device_uuid: SIBLING_DEVICE_UUID,
-        counter: counter_sibling,
-    }];
-
-    let (folder, tmp) = sync_helpers::fresh_vault_two_concurrent_blocks(
-        block_uuid,
-        vec![
-            live_record(
-                RECORD_A_UUID,
-                CANONICAL_DEVICE_UUID,
-                LOCAL_LAST_MOD_MS,
-                "canonical-a",
-            ),
-            live_record(
-                RECORD_B_UUID,
-                CANONICAL_DEVICE_UUID,
-                LOCAL_LAST_MOD_MS,
-                "canonical-b",
-            ),
-        ],
-        canonical_block_clock,
-        canonical_manifest_clock,
-        vec![
-            tombstoned_record(RECORD_A_UUID, SIBLING_DEVICE_UUID, SIBLING_TOMBSTONE_AT_MS),
-            tombstoned_record(RECORD_B_UUID, SIBLING_DEVICE_UUID, SIBLING_TOMBSTONE_AT_MS),
-        ],
-        sibling_block_clock,
-        sibling_manifest_clock,
-        SIBLING_MANIFEST_FILENAME,
-        SIBLING_BLOCK_SUFFIX,
-        COMMIT_NOW_MS,
-    );
-    (folder, tmp, block_uuid)
-}
-
-/// Drive `sync_once` against a built fixture and unwrap the
-/// `ConcurrentDetected` payload. Property cases use this once per
-/// fixture; failures fail-fast with [`prop_assert!`] in the caller.
-fn drive_sync_once_concurrent(
-    folder: &std::path::Path,
-) -> (
-    secretary_core::sync::VaultBundle,
-    secretary_core::sync::DiffPlan,
-    SyncState,
-) {
-    let password = fixtures::golden_vault_001_password();
-    let vt_bytes = std::fs::read(folder.join("vault.toml")).expect("read vault.toml");
-    let bundle_bytes =
-        std::fs::read(folder.join("identity.bundle.enc")).expect("read identity bundle");
-    let identity =
-        open_with_password(&vt_bytes, &bundle_bytes, &password).expect("open_with_password");
-
-    let vault_uuid = extract_vault_uuid(folder);
-    let local_clock = vec![VectorClockEntry {
-        device_uuid: LOCAL_DEVICE_UUID,
-        counter: 1,
-    }];
-    let state = SyncState::new(vault_uuid, local_clock).expect("SyncState::new");
-    let outcome = sync_once(folder, &identity, &state, 0u64).expect("sync_once");
-    let (bundle, plan) = match outcome {
-        SyncOutcome::ConcurrentDetected { bundle, plan, .. } => (bundle, plan),
-        other => panic!("expected ConcurrentDetected, got {other:?}"),
-    };
-    (bundle, plan, state)
-}
-
-/// Read the canonical block's decrypted records via a fresh `open_vault`
-/// so the caller's stale state doesn't contaminate the assertion.
-/// Consumed by properties 2 and 3.
-fn read_canonical_block_records(folder: &std::path::Path, block_uuid: [u8; 16]) -> Vec<Record> {
-    let password = fixtures::golden_vault_001_password();
-    let open = open_vault(folder, Unlocker::Password(&password), None).expect("open_vault");
-    let block_path = sync_helpers::block_file_path(folder, &block_uuid);
-    let bytes = std::fs::read(&block_path).expect("read block file");
-    let plaintext = sync_helpers::decrypt_block_using_open(&open, &bytes).expect("decrypt block");
-    plaintext.records
-}
+use sync_merge_proptest_helpers::{
+    build_no_veto_fixture, build_single_veto_fixture, build_two_veto_fixture,
+    drive_sync_once_concurrent, make_decision, open_identity, read_canonical_block_records,
+    COMMIT_NOW_MS, PROPTEST_CASES, RECORD_A_UUID, RECORD_B_UUID,
+};
 
 proptest! {
     #![proptest_config(ProptestConfig {
@@ -416,10 +65,9 @@ proptest! {
         .. ProptestConfig::default()
     })]
 
-    /// Property 1 — Post-commit, the returned [`SyncState`] is a
-    /// fixpoint with respect to the disk's canonical manifest clock:
-    /// re-running `sync_once` yields
-    /// [`SyncOutcome::NothingToDo`].
+    /// Property 1 — Post-commit, the returned `SyncState` is a fixpoint
+    /// with respect to the disk's canonical manifest clock: re-running
+    /// `sync_once` yields [`SyncOutcome::NothingToDo`].
     ///
     /// Inputs: two unsigned counters that vary the canonical + sibling
     /// manifest-level clocks. The fixture is per-block-divergent with
@@ -431,11 +79,10 @@ proptest! {
     /// sibling manifest clocks) into both the returned `SyncState` and
     /// the on-disk manifest. The next `sync_once` reads only the
     /// canonical manifest and dispatches purely on
-    /// [`secretary_core::vault::conflict::clock_relation`] between
-    /// state and disk — `Equal` triggers `NothingToDo`. The property
-    /// pins that the two writes agree, so the relation cannot land in
-    /// any other branch (Concurrent / IncomingDominates /
-    /// IncomingDominated) post-commit.
+    /// `clock_relation` between state and disk — `Equal` triggers
+    /// `NothingToDo`. The property pins that the two writes agree, so
+    /// the relation cannot land in any other branch (Concurrent /
+    /// IncomingDominates / IncomingDominated) post-commit.
     #[test]
     fn prop_commit_then_sync_once_yields_nothing_to_do(
         counter_canonical in 1u64..1000,
@@ -444,13 +91,7 @@ proptest! {
         let (folder, _tmp, _block_uuid) =
             build_no_veto_fixture(counter_canonical, counter_sibling);
         let (bundle, plan, _state_pre) = drive_sync_once_concurrent(&folder);
-
-        let password = fixtures::golden_vault_001_password();
-        let vt_bytes = std::fs::read(folder.join("vault.toml")).expect("read vault.toml");
-        let bundle_bytes =
-            std::fs::read(folder.join("identity.bundle.enc")).expect("read identity bundle");
-        let identity =
-            open_with_password(&vt_bytes, &bundle_bytes, &password).expect("open_with_password");
+        let identity = open_identity(&folder);
 
         let draft = prepare_merge(&folder, &identity, &bundle, &plan).expect("prepare_merge");
         prop_assert!(
@@ -459,13 +100,15 @@ proptest! {
             draft.vetoes.len(),
         );
 
+        let password = fixtures::golden_vault_001_password();
         let new_state =
             commit_with_decisions(&folder, &password, draft, Vec::new(), COMMIT_NOW_MS)
                 .expect("commit_with_decisions");
 
-        // Re-run sync_once against the SAME identity using the returned
-        // SyncState. Equal → NothingToDo is the only acceptable outcome.
-        let outcome = sync_once(&folder, &identity, &new_state, 0u64).expect("sync_once post-commit");
+        // Re-run sync_once with the returned SyncState. Equal →
+        // NothingToDo is the only acceptable outcome.
+        let outcome = sync_once(&folder, &identity, &new_state, 0u64)
+            .expect("sync_once post-commit");
         prop_assert_eq!(
             outcome,
             SyncOutcome::NothingToDo,
@@ -486,7 +129,7 @@ proptest! {
     /// independent vaults built with identical fixture parameters
     /// produces:
     ///
-    /// - The same returned [`SyncState`] (post_merge_clock is a pure
+    /// - The same returned `SyncState` (`post_merge_clock` is a pure
     ///   function of the input manifest clocks).
     /// - The same decrypted canonical block records (CRDT merge is a
     ///   pure function of its inputs).
@@ -502,16 +145,11 @@ proptest! {
     /// `sync_merge_crash.rs` already covers the same contract for the
     /// retry path; this adds property-level coverage over a different
     /// dimension — across independent vaults).
-    ///
-    /// Inputs: same as property 1 (canonical + sibling manifest-clock
-    /// counters).
     #[test]
     fn prop_three_step_idempotent_on_repeated_invocation(
         counter_canonical in 1u64..1000,
         counter_sibling in 1u64..1000,
     ) {
-        // Two independent fixtures with identical inputs. The two
-        // `tempfile::TempDir`s must stay alive until the test ends.
         let (folder_a, _tmp_a, block_uuid_a) =
             build_no_veto_fixture(counter_canonical, counter_sibling);
         let (folder_b, _tmp_b, block_uuid_b) =
@@ -522,22 +160,16 @@ proptest! {
             "both fixtures must derive the same block_uuid from golden_vault_001",
         );
 
-        let password = fixtures::golden_vault_001_password();
-
-        let run_three_step = |folder: &std::path::Path| -> (SyncState, Vec<Record>, Vec<u8>) {
+        let run = |folder: &std::path::Path| {
             let (bundle, plan, _state_pre) = drive_sync_once_concurrent(folder);
-            let vt_bytes = std::fs::read(folder.join("vault.toml")).expect("read vault.toml");
-            let bundle_bytes = std::fs::read(folder.join("identity.bundle.enc"))
-                .expect("read identity bundle");
-            let identity = open_with_password(&vt_bytes, &bundle_bytes, &password)
-                .expect("open_with_password");
-
+            let identity = open_identity(folder);
             let draft = prepare_merge(folder, &identity, &bundle, &plan).expect("prepare_merge");
             assert!(
                 draft.vetoes.is_empty(),
                 "no_veto_fixture must produce zero vetoes (got {})",
                 draft.vetoes.len(),
             );
+            let password = fixtures::golden_vault_001_password();
             let new_state =
                 commit_with_decisions(folder, &password, draft, Vec::new(), COMMIT_NOW_MS)
                     .expect("commit_with_decisions");
@@ -547,22 +179,19 @@ proptest! {
             (new_state, records, block_bytes)
         };
 
-        let (state_a, records_a, bytes_a) = run_three_step(&folder_a);
-        let (state_b, records_b, bytes_b) = run_three_step(&folder_b);
+        let (state_a, records_a, bytes_a) = run(&folder_a);
+        let (state_b, records_b, bytes_b) = run(&folder_b);
 
-        // Pure function of inputs: SyncState matches.
         prop_assert_eq!(
             state_a,
             state_b,
             "two equivalent fixtures must yield the same post-commit SyncState",
         );
-        // Pure function of inputs: decrypted block records match.
         prop_assert_eq!(
             records_a,
             records_b,
             "two equivalent fixtures must yield the same decrypted canonical block records",
         );
-        // AEAD-nonce-per-rewrite contract: envelope bytes diverge.
         prop_assert_ne!(
             bytes_a,
             bytes_b,
@@ -584,25 +213,21 @@ proptest! {
     /// fixtures are built; one commits with decisions `[d_a, d_b]`,
     /// the other with `[d_b, d_a]`. Assert:
     ///
-    /// - Same returned [`SyncState`].
-    /// - Same decrypted canonical block records (set equality — both
-    ///   come from `prepare_merge`'s BTreeMap-into-Vec output, so they
-    ///   are already sorted by `record_uuid`; element-wise equality is
-    ///   the strict check).
+    /// - Same returned `SyncState`.
+    /// - Same decrypted canonical block records.
     ///
     /// Why this is non-trivial: `apply_decisions` iterates decisions
     /// in their input order to apply per-record `KeepLocal` restores.
     /// If the per-decision side effects were not commutative (e.g., a
     /// future refactor accidentally shared mutable state across
-    /// per-decision steps), the two orderings would diverge. The
-    /// property pins commutativity over the full decision set.
+    /// per-decision steps), the two orderings would diverge.
     ///
     /// Inputs: clock counters + two booleans (`keep_local_a`,
-    /// `keep_local_b`) that vary the decision kind per veto. This
-    /// covers the (KeepLocal, KeepLocal), (KeepLocal, AcceptTombstone),
+    /// `keep_local_b`) that vary the decision kind per veto, covering
+    /// (KeepLocal, KeepLocal), (KeepLocal, AcceptTombstone),
     /// (AcceptTombstone, KeepLocal), and
-    /// (AcceptTombstone, AcceptTombstone) decision pairings across the
-    /// 16 case budget.
+    /// (AcceptTombstone, AcceptTombstone) pairings across the 16-case
+    /// budget.
     #[test]
     fn prop_commit_associative_under_disjoint_vetoes(
         counter_canonical in 1u64..1000,
@@ -619,13 +244,9 @@ proptest! {
         let decision_a = make_decision(RECORD_A_UUID, keep_local_a);
         let decision_b = make_decision(RECORD_B_UUID, keep_local_b);
 
-        let commit = |folder: &std::path::Path, decisions: Vec<VetoDecision>| -> (SyncState, Vec<Record>) {
+        let commit = |folder: &std::path::Path, decisions: Vec<VetoDecision>| {
             let (bundle, plan, _state_pre) = drive_sync_once_concurrent(folder);
-            let vt_bytes = std::fs::read(folder.join("vault.toml")).expect("read vault.toml");
-            let bundle_bytes = std::fs::read(folder.join("identity.bundle.enc"))
-                .expect("read identity bundle");
-            let identity = open_with_password(&vt_bytes, &bundle_bytes, &password)
-                .expect("open_with_password");
+            let identity = open_identity(folder);
             let draft = prepare_merge(folder, &identity, &bundle, &plan).expect("prepare_merge");
             assert_eq!(
                 draft.vetoes.len(),
@@ -640,10 +261,8 @@ proptest! {
             (new_state, records)
         };
 
-        // Order 1: [d_a, d_b]
         let (state_ab, records_ab) =
             commit(&folder_a, vec![decision_a.clone(), decision_b.clone()]);
-        // Order 2: [d_b, d_a] — swapped
         let (state_ba, records_ba) = commit(&folder_b, vec![decision_b, decision_a]);
 
         prop_assert_eq!(
@@ -683,14 +302,11 @@ proptest! {
     /// - `include_match && strays.is_empty()` → `Ok(_)`.
     ///
     /// Strays are constructed as `[seed; 16]` from a random
-    /// `seed: u8 in (0..=0xFF except 0xAA)`. Excluding 0xAA prevents
-    /// a stray from coincidentally landing on
+    /// `seed: u8 != 0xAA`. Excluding 0xAA prevents a stray from
+    /// coincidentally landing on
     /// [`RECORD_A_UUID = [0xAA; 16]`], which would collapse into the
     /// matching decision via the bijection's set-based dedupe
     /// semantics.
-    ///
-    /// Inputs: clock counters, `include_match: bool`, `strays`: a vec
-    /// of distinct-from-0xAA seeds 0-2 entries long.
     #[test]
     fn prop_decision_bijection_enforced(
         counter_canonical in 1u64..1000,
@@ -705,12 +321,8 @@ proptest! {
             build_single_veto_fixture(counter_canonical, counter_sibling);
 
         let (bundle, plan, _state_pre) = drive_sync_once_concurrent(&folder);
+        let identity = open_identity(&folder);
         let password = fixtures::golden_vault_001_password();
-        let vt_bytes = std::fs::read(folder.join("vault.toml")).expect("read vault.toml");
-        let bundle_bytes = std::fs::read(folder.join("identity.bundle.enc"))
-            .expect("read identity bundle");
-        let identity = open_with_password(&vt_bytes, &bundle_bytes, &password)
-            .expect("open_with_password");
 
         let draft = prepare_merge(&folder, &identity, &bundle, &plan).expect("prepare_merge");
         prop_assert_eq!(
@@ -719,23 +331,22 @@ proptest! {
             "single_veto_fixture must produce exactly one veto",
         );
 
-        // Build the decisions vec. Matching decision (if requested)
-        // first, then strays — but the bijection check is set-based, so
-        // ordering inside the vec doesn't affect which error fires.
+        // Matching decision (if requested) first, then strays — but
+        // the bijection check is set-based, so ordering inside the vec
+        // doesn't affect which error fires.
         let mut decisions = Vec::with_capacity((include_match as usize) + strays.len());
         if include_match {
             decisions.push(VetoDecision::KeepLocal { record_id: RECORD_A_UUID });
         }
         for seed in &strays {
-            let stray_uuid = [*seed; 16];
-            decisions.push(VetoDecision::KeepLocal { record_id: stray_uuid });
+            decisions.push(VetoDecision::KeepLocal { record_id: [*seed; 16] });
         }
 
         let result = commit_with_decisions(&folder, &password, draft, decisions, COMMIT_NOW_MS);
 
         if !include_match {
             // Matching decision omitted → Missing fires on
-            // RECORD_A_UUID (the only veto). Strays, if any, do not
+            // RECORD_A_UUID (the only veto). Strays, if any, don't
             // matter — Missing is checked before Unknown.
             match result {
                 Err(SyncError::MissingVetoDecision { record_id }) => prop_assert_eq!(
@@ -754,8 +365,8 @@ proptest! {
             // [u8; 16] UUIDs sort lexicographically by their first
             // byte (all 16 bytes equal in our construction), so the
             // smallest stray UUID corresponds to the smallest seed.
-            let smallest_stray_seed = *strays.iter().min().expect("strays non-empty");
-            let expected_stray_uuid = [smallest_stray_seed; 16];
+            let smallest_seed = *strays.iter().min().expect("strays non-empty");
+            let expected_stray_uuid = [smallest_seed; 16];
             match result {
                 Err(SyncError::UnknownVetoDecision { record_id }) => prop_assert_eq!(
                     record_id,

--- a/core/tests/sync_merge_proptest.rs
+++ b/core/tests/sync_merge_proptest.rs
@@ -50,7 +50,8 @@ use std::collections::BTreeMap;
 use proptest::prelude::*;
 use secretary_core::crypto::secret::SecretString;
 use secretary_core::sync::{
-    commit_with_decisions, prepare_merge, sync_once, SyncOutcome, SyncState, VetoDecision,
+    commit_with_decisions, prepare_merge, sync_once, SyncError, SyncOutcome, SyncState,
+    VetoDecision,
 };
 use secretary_core::unlock::open_with_password;
 use secretary_core::vault::block::VectorClockEntry;
@@ -249,7 +250,6 @@ fn build_no_veto_fixture(
 /// targets [`RECORD_A_UUID`] (canonical LIVE at
 /// [`LOCAL_LAST_MOD_MS`], sibling TOMBSTONED at
 /// [`SIBLING_TOMBSTONE_AT_MS`]). Consumed by property 4.
-#[allow(dead_code)]
 fn build_single_veto_fixture(
     counter_canonical: u64,
     counter_sibling: u64,
@@ -656,5 +656,125 @@ proptest! {
             records_ba,
             "decision order must not affect the post-commit canonical block records",
         );
+    }
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig {
+        cases: PROPTEST_CASES,
+        .. ProptestConfig::default()
+    })]
+
+    /// Property 4 — `commit_with_decisions` enforces the strict
+    /// `draft.vetoes` ↔ `decisions` bijection by `record_id`. For a
+    /// fixture with exactly one veto on [`RECORD_A_UUID`], the test
+    /// constructs `decisions` from random `(include_match, strays)`
+    /// pairs and asserts the outcome class:
+    ///
+    /// - `!include_match` (matching decision omitted) →
+    ///   `Err(SyncError::MissingVetoDecision { record_id: RECORD_A_UUID })`,
+    ///   regardless of how many strays are present. `apply_decisions`'s
+    ///   Missing check runs before Unknown, so Missing wins on
+    ///   `(no_match, with_strays)`.
+    /// - `include_match && !strays.is_empty()` →
+    ///   `Err(SyncError::UnknownVetoDecision { record_id })` where
+    ///   `record_id == min(strays)` (BTreeSet ordering — smallest
+    ///   stray fires).
+    /// - `include_match && strays.is_empty()` → `Ok(_)`.
+    ///
+    /// Strays are constructed as `[seed; 16]` from a random
+    /// `seed: u8 in (0..=0xFF except 0xAA)`. Excluding 0xAA prevents
+    /// a stray from coincidentally landing on
+    /// [`RECORD_A_UUID = [0xAA; 16]`], which would collapse into the
+    /// matching decision via the bijection's set-based dedupe
+    /// semantics.
+    ///
+    /// Inputs: clock counters, `include_match: bool`, `strays`: a vec
+    /// of distinct-from-0xAA seeds 0-2 entries long.
+    #[test]
+    fn prop_decision_bijection_enforced(
+        counter_canonical in 1u64..1000,
+        counter_sibling in 1u64..1000,
+        include_match: bool,
+        strays in prop::collection::vec(
+            (0u8..=0xFF).prop_filter("stray must not equal RECORD_A_UUID first byte", |b| *b != 0xAA),
+            0usize..=2,
+        ),
+    ) {
+        let (folder, _tmp, _block_uuid) =
+            build_single_veto_fixture(counter_canonical, counter_sibling);
+
+        let (bundle, plan, _state_pre) = drive_sync_once_concurrent(&folder);
+        let password = fixtures::golden_vault_001_password();
+        let vt_bytes = std::fs::read(folder.join("vault.toml")).expect("read vault.toml");
+        let bundle_bytes = std::fs::read(folder.join("identity.bundle.enc"))
+            .expect("read identity bundle");
+        let identity = open_with_password(&vt_bytes, &bundle_bytes, &password)
+            .expect("open_with_password");
+
+        let draft = prepare_merge(&folder, &identity, &bundle, &plan).expect("prepare_merge");
+        prop_assert_eq!(
+            draft.vetoes.len(),
+            1,
+            "single_veto_fixture must produce exactly one veto",
+        );
+
+        // Build the decisions vec. Matching decision (if requested)
+        // first, then strays — but the bijection check is set-based, so
+        // ordering inside the vec doesn't affect which error fires.
+        let mut decisions = Vec::with_capacity((include_match as usize) + strays.len());
+        if include_match {
+            decisions.push(VetoDecision::KeepLocal { record_id: RECORD_A_UUID });
+        }
+        for seed in &strays {
+            let stray_uuid = [*seed; 16];
+            decisions.push(VetoDecision::KeepLocal { record_id: stray_uuid });
+        }
+
+        let result = commit_with_decisions(&folder, &password, draft, decisions, COMMIT_NOW_MS);
+
+        if !include_match {
+            // Matching decision omitted → Missing fires on
+            // RECORD_A_UUID (the only veto). Strays, if any, do not
+            // matter — Missing is checked before Unknown.
+            match result {
+                Err(SyncError::MissingVetoDecision { record_id }) => prop_assert_eq!(
+                    record_id,
+                    RECORD_A_UUID,
+                    "Missing must report RECORD_A_UUID (the un-adjudicated veto)",
+                ),
+                other => prop_assert!(
+                    false,
+                    "expected MissingVetoDecision, got {other:?}",
+                ),
+            }
+        } else if !strays.is_empty() {
+            // Matching present + strays → Unknown fires on the
+            // smallest stray. `strays` carries u8 seeds; the resulting
+            // [u8; 16] UUIDs sort lexicographically by their first
+            // byte (all 16 bytes equal in our construction), so the
+            // smallest stray UUID corresponds to the smallest seed.
+            let smallest_stray_seed = *strays.iter().min().expect("strays non-empty");
+            let expected_stray_uuid = [smallest_stray_seed; 16];
+            match result {
+                Err(SyncError::UnknownVetoDecision { record_id }) => prop_assert_eq!(
+                    record_id,
+                    expected_stray_uuid,
+                    "Unknown must report the smallest stray UUID",
+                ),
+                other => prop_assert!(
+                    false,
+                    "expected UnknownVetoDecision, got {other:?}",
+                ),
+            }
+        } else {
+            // Matching present + no strays → bijection holds, commit
+            // succeeds.
+            prop_assert!(
+                result.is_ok(),
+                "exact bijection must commit successfully, got {:?}",
+                result,
+            );
+        }
     }
 }

--- a/core/tests/sync_merge_proptest.rs
+++ b/core/tests/sync_merge_proptest.rs
@@ -1,0 +1,464 @@
+//! Property tests for the C.1.1b merge layer.
+//!
+//! Four properties, one per [`proptest!`] block (separate blocks so the
+//! per-property [`ProptestConfig::cases`] cap is explicit):
+//!
+//! 1. **Post-commit fixpoint** — after `commit_with_decisions` succeeds,
+//!    re-running `sync_once` with the returned [`SyncState`] yields
+//!    [`SyncOutcome::NothingToDo`]. Proves the commit's
+//!    `post_merge_clock` matches the on-disk canonical manifest's new
+//!    `vector_clock` (so the next dispatch sees `ClockRelation::Equal`).
+//! 2. **Deterministic merge** — running the three-step
+//!    `sync_once → prepare_merge → commit_with_decisions` on two
+//!    independent vaults with identical inputs produces the same
+//!    returned [`SyncState`] and the same decrypted canonical block
+//!    records. AEAD nonces differ between the two commits (drawn from
+//!    `OsRng` per rewrite), so envelope bytes diverge — the assertion
+//!    is on the decrypted manifest body + records, not the ciphertext.
+//! 3. **Decision-order independence** — given a draft with two vetoes
+//!    (disjoint `record_id`s), committing with decisions `[d1, d2]` on
+//!    one vault and `[d2, d1]` on an identically-built second vault
+//!    produces the same returned [`SyncState`] and the same decrypted
+//!    canonical block records. The two veto sets are non-overlapping by
+//!    construction (`apply_decisions` indexes by `record_id`, which is
+//!    unique per veto).
+//! 4. **Bijection enforcement** — for random `(matching, stray_count)`
+//!    inputs against a single-veto fixture, `commit_with_decisions`
+//!    returns:
+//!    - [`SyncError::MissingVetoDecision`] when the matching decision
+//!      is omitted (whether or not strays are present — Missing is
+//!      checked before Unknown in
+//!      [`apply_decisions`](secretary_core::sync::__never_imported_apply_decisions)).
+//!    - [`SyncError::UnknownVetoDecision`] when the matching decision is
+//!      present AND at least one stray decision is present.
+//!    - `Ok(_)` when the matching decision is present and no strays are
+//!      present.
+//!
+//! ## Cost model
+//!
+//! Each case runs at least one `fresh_vault_two_concurrent_blocks` build
+//! (open_vault Argon2 + two block encryptions + two manifest signs) plus
+//! at least one `commit_with_decisions` (re-encrypt + re-sign). Properties
+//! 2-3 build two fixtures per case. The per-property `cases` cap is set
+//! so each property completes in well under a minute on the project's
+//! reference hardware.
+
+#![forbid(unsafe_code)]
+
+use std::collections::BTreeMap;
+
+use proptest::prelude::*;
+use secretary_core::crypto::secret::SecretString;
+use secretary_core::sync::{commit_with_decisions, prepare_merge, sync_once, SyncOutcome, SyncState};
+use secretary_core::unlock::open_with_password;
+use secretary_core::vault::block::VectorClockEntry;
+use secretary_core::vault::{open_vault, Record, RecordField, RecordFieldValue, Unlocker};
+
+mod fixtures;
+mod sync_helpers;
+
+use fixtures::extract_vault_uuid;
+
+// === Fixed (non-randomised) fixture inputs ===
+//
+// Property cases vary the manifest clock counters and (for prop 4) the
+// stray decision UUIDs. Holding the other fixture inputs fixed avoids
+// re-deriving record bodies / device UUIDs on every iteration and keeps
+// each case's failure mode unambiguous (a flake names the same record
+// UUIDs every time).
+
+/// Record UUID for the FIRST veto-bearing record (canonical LIVE,
+/// sibling TOMBSTONED at later death-clock).
+const RECORD_A_UUID: [u8; 16] = [0xAA; 16];
+/// Record UUID for the SECOND veto-bearing record. Strictly greater
+/// than [`RECORD_A_UUID`] so `apply_decisions`'s canonical-sort error
+/// reporting is deterministic (Missing fires on the smallest
+/// un-adjudicated id). Consumed by property 3.
+#[allow(dead_code)]
+const RECORD_B_UUID: [u8; 16] = [0xBB; 16];
+/// Record UUID for the FIRST non-conflicting record on the canonical
+/// side (used in properties 1 & 2 where vetoes are not desired).
+const NONCONFLICTING_RECORD_CANONICAL_UUID: [u8; 16] = [0xAA; 16];
+/// Record UUID for the FIRST non-conflicting record on the sibling
+/// side. Distinct from
+/// [`NONCONFLICTING_RECORD_CANONICAL_UUID`] so the merge produces a
+/// clean union with no vetoes.
+const NONCONFLICTING_RECORD_SIBLING_UUID: [u8; 16] = [0xBB; 16];
+/// Canonical device clock anchor. Records' `last_modifier_device` and
+/// the canonical block's `vector_clock_summary` reference this device.
+const CANONICAL_DEVICE_UUID: [u8; 16] = [0x0A; 16];
+/// Sibling device clock anchor. Records' `last_modifier_device` and
+/// the sibling block's `vector_clock_summary` reference this device.
+const SIBLING_DEVICE_UUID: [u8; 16] = [0x0B; 16];
+/// Local device clock anchor — the persisted `SyncState`'s clock entry.
+/// Distinct from canonical / sibling so the pre-commit
+/// `ClockRelation` is `Concurrent` (sync_once precondition for the
+/// `ConcurrentDetected` arm).
+const LOCAL_DEVICE_UUID: [u8; 16] = [0x0C; 16];
+/// `last_mod_ms` on every canonical LIVE record. Constant; nothing else
+/// fixes the value.
+const LOCAL_LAST_MOD_MS: u64 = 100;
+/// `last_mod_ms` AND `tombstoned_at_ms` on every sibling TOMBSTONED
+/// record. Strictly greater than [`LOCAL_LAST_MOD_MS`] so the per-record
+/// veto pass fires (`tombstone_veto_set`'s strict-greater branch).
+/// Consumed by properties 3 and 4.
+#[allow(dead_code)]
+const SIBLING_TOMBSTONE_AT_MS: u64 = 200;
+/// `last_mod_ms` on the non-conflicting sibling record (properties 1 &
+/// 2). Same magnitude as [`SIBLING_TOMBSTONE_AT_MS`] but the record is
+/// LIVE — only the UUID disjointness matters for vetoless merges.
+const SIBLING_NONCONFLICTING_LAST_MOD_MS: u64 = 200;
+/// Commit timestamp passed to `commit_with_decisions`. Reused across
+/// every fixture's invocations so manifest `last_mod_ms` is uniform.
+const COMMIT_NOW_MS: u64 = 1_000_000;
+/// Sibling manifest filename — must start with `manifest.cbor.enc` per
+/// `enumerate_manifest_siblings`. The Syncthing-style suffix is the
+/// project convention across C.1.1a / C.1.1b tests.
+const SIBLING_MANIFEST_FILENAME: &str = "manifest.cbor.enc.sync-conflict-from-device-bb";
+/// Sibling block-file suffix — must start with a non-empty separator
+/// so the resulting filename is recognised by
+/// `enumerate_block_siblings`.
+const SIBLING_BLOCK_SUFFIX: &str = ".sync-conflict-from-device-bb";
+/// `cases` cap shared across the four properties. Each case builds one
+/// or two `fresh_vault_two_concurrent_blocks` fixtures (open_vault
+/// Argon2 + two block encryptions + two manifest signs) and runs at
+/// least one `commit_with_decisions` (re-encrypt + re-sign). 16 cases
+/// per property keeps the whole file comfortably under a minute on the
+/// project's reference hardware while still exploring two independent
+/// dimensions per property (typically the canonical + sibling clock
+/// counters).
+const PROPTEST_CASES: u32 = 16;
+
+/// Build a LIVE record with one field. `uuid` controls the
+/// `record_uuid`; `device_uuid` + `last_mod_ms` flow into the field
+/// envelope so the merge sees a coherent timestamp.
+fn live_record(uuid: [u8; 16], device_uuid: [u8; 16], last_mod_ms: u64, marker: &str) -> Record {
+    let mut fields = BTreeMap::new();
+    fields.insert(
+        "k".to_string(),
+        RecordField {
+            value: RecordFieldValue::Text(SecretString::from(marker)),
+            last_mod: last_mod_ms,
+            device_uuid,
+            unknown: BTreeMap::new(),
+        },
+    );
+    Record {
+        record_uuid: uuid,
+        record_type: "kv".to_string(),
+        fields,
+        tags: Vec::new(),
+        created_at_ms: 50,
+        last_mod_ms,
+        tombstone: false,
+        tombstoned_at_ms: 0,
+        unknown: BTreeMap::new(),
+    }
+}
+
+/// Build a TOMBSTONED record. `last_mod_ms == tombstoned_at_ms` per the
+/// §11.5 invariant that tombstoned records pin both timestamps to the
+/// death clock. Consumed by properties 3 and 4.
+#[allow(dead_code)]
+fn tombstoned_record(uuid: [u8; 16], device_uuid: [u8; 16], tombstoned_at_ms: u64) -> Record {
+    let mut fields = BTreeMap::new();
+    fields.insert(
+        "k".to_string(),
+        RecordField {
+            value: RecordFieldValue::Text(SecretString::from("ignored")),
+            last_mod: tombstoned_at_ms,
+            device_uuid,
+            unknown: BTreeMap::new(),
+        },
+    );
+    Record {
+        record_uuid: uuid,
+        record_type: "kv".to_string(),
+        fields,
+        tags: Vec::new(),
+        created_at_ms: 50,
+        last_mod_ms: tombstoned_at_ms,
+        tombstone: true,
+        tombstoned_at_ms,
+        unknown: BTreeMap::new(),
+    }
+}
+
+/// Build a per-block-divergent fixture with NO veto-producing records.
+/// The canonical block holds [`NONCONFLICTING_RECORD_CANONICAL_UUID`]
+/// LIVE; the sibling block holds
+/// [`NONCONFLICTING_RECORD_SIBLING_UUID`] LIVE. UUIDs are distinct, so
+/// the merge produces a clean union and `draft.vetoes` is empty.
+///
+/// `counter_canonical` / `counter_sibling` are the per-device counters
+/// at the canonical / sibling manifest level (the block-level
+/// vector_clock_summary uses counter `1` because the records are local
+/// edits from a single anchor; only the manifest-level clock varies).
+fn build_no_veto_fixture(
+    counter_canonical: u64,
+    counter_sibling: u64,
+) -> (std::path::PathBuf, tempfile::TempDir, [u8; 16]) {
+    let (probe_folder, _probe_tmp) = sync_helpers::fresh_vault_with_clock(Vec::new());
+    let block_uuid = sync_helpers::golden_vault_001_first_block_uuid(&probe_folder);
+
+    let canonical_block_clock = vec![VectorClockEntry {
+        device_uuid: CANONICAL_DEVICE_UUID,
+        counter: 1,
+    }];
+    let sibling_block_clock = vec![VectorClockEntry {
+        device_uuid: SIBLING_DEVICE_UUID,
+        counter: 1,
+    }];
+    let canonical_manifest_clock = vec![VectorClockEntry {
+        device_uuid: CANONICAL_DEVICE_UUID,
+        counter: counter_canonical,
+    }];
+    let sibling_manifest_clock = vec![VectorClockEntry {
+        device_uuid: SIBLING_DEVICE_UUID,
+        counter: counter_sibling,
+    }];
+
+    let (folder, tmp) = sync_helpers::fresh_vault_two_concurrent_blocks(
+        block_uuid,
+        vec![live_record(
+            NONCONFLICTING_RECORD_CANONICAL_UUID,
+            CANONICAL_DEVICE_UUID,
+            LOCAL_LAST_MOD_MS,
+            "canonical",
+        )],
+        canonical_block_clock,
+        canonical_manifest_clock,
+        vec![live_record(
+            NONCONFLICTING_RECORD_SIBLING_UUID,
+            SIBLING_DEVICE_UUID,
+            SIBLING_NONCONFLICTING_LAST_MOD_MS,
+            "sibling",
+        )],
+        sibling_block_clock,
+        sibling_manifest_clock,
+        SIBLING_MANIFEST_FILENAME,
+        SIBLING_BLOCK_SUFFIX,
+        COMMIT_NOW_MS,
+    );
+    (folder, tmp, block_uuid)
+}
+
+/// Build a per-block-divergent fixture with a SINGLE veto. The veto
+/// targets [`RECORD_A_UUID`] (canonical LIVE at
+/// [`LOCAL_LAST_MOD_MS`], sibling TOMBSTONED at
+/// [`SIBLING_TOMBSTONE_AT_MS`]). Consumed by property 4.
+#[allow(dead_code)]
+fn build_single_veto_fixture(
+    counter_canonical: u64,
+    counter_sibling: u64,
+) -> (std::path::PathBuf, tempfile::TempDir, [u8; 16]) {
+    let (probe_folder, _probe_tmp) = sync_helpers::fresh_vault_with_clock(Vec::new());
+    let block_uuid = sync_helpers::golden_vault_001_first_block_uuid(&probe_folder);
+
+    let canonical_block_clock = vec![VectorClockEntry {
+        device_uuid: CANONICAL_DEVICE_UUID,
+        counter: 1,
+    }];
+    let sibling_block_clock = vec![VectorClockEntry {
+        device_uuid: SIBLING_DEVICE_UUID,
+        counter: 1,
+    }];
+    let canonical_manifest_clock = vec![VectorClockEntry {
+        device_uuid: CANONICAL_DEVICE_UUID,
+        counter: counter_canonical,
+    }];
+    let sibling_manifest_clock = vec![VectorClockEntry {
+        device_uuid: SIBLING_DEVICE_UUID,
+        counter: counter_sibling,
+    }];
+
+    let (folder, tmp) = sync_helpers::fresh_vault_two_concurrent_blocks(
+        block_uuid,
+        vec![live_record(
+            RECORD_A_UUID,
+            CANONICAL_DEVICE_UUID,
+            LOCAL_LAST_MOD_MS,
+            "canonical",
+        )],
+        canonical_block_clock,
+        canonical_manifest_clock,
+        vec![tombstoned_record(
+            RECORD_A_UUID,
+            SIBLING_DEVICE_UUID,
+            SIBLING_TOMBSTONE_AT_MS,
+        )],
+        sibling_block_clock,
+        sibling_manifest_clock,
+        SIBLING_MANIFEST_FILENAME,
+        SIBLING_BLOCK_SUFFIX,
+        COMMIT_NOW_MS,
+    );
+    (folder, tmp, block_uuid)
+}
+
+/// Build a per-block-divergent fixture with TWO disjoint vetoes. Both
+/// records are LIVE on canonical, TOMBSTONED on sibling at the later
+/// death clock. Used by property 3 to vary decision ordering.
+#[allow(dead_code)]
+fn build_two_veto_fixture(
+    counter_canonical: u64,
+    counter_sibling: u64,
+) -> (std::path::PathBuf, tempfile::TempDir, [u8; 16]) {
+    let (probe_folder, _probe_tmp) = sync_helpers::fresh_vault_with_clock(Vec::new());
+    let block_uuid = sync_helpers::golden_vault_001_first_block_uuid(&probe_folder);
+
+    let canonical_block_clock = vec![VectorClockEntry {
+        device_uuid: CANONICAL_DEVICE_UUID,
+        counter: 1,
+    }];
+    let sibling_block_clock = vec![VectorClockEntry {
+        device_uuid: SIBLING_DEVICE_UUID,
+        counter: 1,
+    }];
+    let canonical_manifest_clock = vec![VectorClockEntry {
+        device_uuid: CANONICAL_DEVICE_UUID,
+        counter: counter_canonical,
+    }];
+    let sibling_manifest_clock = vec![VectorClockEntry {
+        device_uuid: SIBLING_DEVICE_UUID,
+        counter: counter_sibling,
+    }];
+
+    let (folder, tmp) = sync_helpers::fresh_vault_two_concurrent_blocks(
+        block_uuid,
+        vec![
+            live_record(
+                RECORD_A_UUID,
+                CANONICAL_DEVICE_UUID,
+                LOCAL_LAST_MOD_MS,
+                "canonical-a",
+            ),
+            live_record(
+                RECORD_B_UUID,
+                CANONICAL_DEVICE_UUID,
+                LOCAL_LAST_MOD_MS,
+                "canonical-b",
+            ),
+        ],
+        canonical_block_clock,
+        canonical_manifest_clock,
+        vec![
+            tombstoned_record(RECORD_A_UUID, SIBLING_DEVICE_UUID, SIBLING_TOMBSTONE_AT_MS),
+            tombstoned_record(RECORD_B_UUID, SIBLING_DEVICE_UUID, SIBLING_TOMBSTONE_AT_MS),
+        ],
+        sibling_block_clock,
+        sibling_manifest_clock,
+        SIBLING_MANIFEST_FILENAME,
+        SIBLING_BLOCK_SUFFIX,
+        COMMIT_NOW_MS,
+    );
+    (folder, tmp, block_uuid)
+}
+
+/// Drive `sync_once` against a built fixture and unwrap the
+/// `ConcurrentDetected` payload. Property cases use this once per
+/// fixture; failures fail-fast with [`prop_assert!`] in the caller.
+fn drive_sync_once_concurrent(
+    folder: &std::path::Path,
+) -> (
+    secretary_core::sync::VaultBundle,
+    secretary_core::sync::DiffPlan,
+    SyncState,
+) {
+    let password = fixtures::golden_vault_001_password();
+    let vt_bytes = std::fs::read(folder.join("vault.toml")).expect("read vault.toml");
+    let bundle_bytes =
+        std::fs::read(folder.join("identity.bundle.enc")).expect("read identity bundle");
+    let identity =
+        open_with_password(&vt_bytes, &bundle_bytes, &password).expect("open_with_password");
+
+    let vault_uuid = extract_vault_uuid(folder);
+    let local_clock = vec![VectorClockEntry {
+        device_uuid: LOCAL_DEVICE_UUID,
+        counter: 1,
+    }];
+    let state = SyncState::new(vault_uuid, local_clock).expect("SyncState::new");
+    let outcome = sync_once(folder, &identity, &state, 0u64).expect("sync_once");
+    let (bundle, plan) = match outcome {
+        SyncOutcome::ConcurrentDetected { bundle, plan, .. } => (bundle, plan),
+        other => panic!("expected ConcurrentDetected, got {other:?}"),
+    };
+    (bundle, plan, state)
+}
+
+/// Read the canonical block's decrypted records via a fresh `open_vault`
+/// so the caller's stale state doesn't contaminate the assertion.
+/// Consumed by properties 2 and 3.
+#[allow(dead_code)]
+fn read_canonical_block_records(folder: &std::path::Path, block_uuid: [u8; 16]) -> Vec<Record> {
+    let password = fixtures::golden_vault_001_password();
+    let open = open_vault(folder, Unlocker::Password(&password), None).expect("open_vault");
+    let block_path = sync_helpers::block_file_path(folder, &block_uuid);
+    let bytes = std::fs::read(&block_path).expect("read block file");
+    let plaintext = sync_helpers::decrypt_block_using_open(&open, &bytes).expect("decrypt block");
+    plaintext.records
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig {
+        cases: PROPTEST_CASES,
+        .. ProptestConfig::default()
+    })]
+
+    /// Property 1 — Post-commit, the returned [`SyncState`] is a
+    /// fixpoint with respect to the disk's canonical manifest clock:
+    /// re-running `sync_once` yields
+    /// [`SyncOutcome::NothingToDo`].
+    ///
+    /// Inputs: two unsigned counters that vary the canonical + sibling
+    /// manifest-level clocks. The fixture is per-block-divergent with
+    /// disjoint record UUIDs (no vetoes), so the commit succeeds with
+    /// an empty `decisions` vec.
+    ///
+    /// Why this is non-trivial: `commit_with_decisions` writes
+    /// `post_merge_clock` (the component-wise max of canonical +
+    /// sibling manifest clocks) into both the returned `SyncState` and
+    /// the on-disk manifest. The next `sync_once` reads only the
+    /// canonical manifest and dispatches purely on
+    /// [`secretary_core::vault::conflict::clock_relation`] between
+    /// state and disk — `Equal` triggers `NothingToDo`. The property
+    /// pins that the two writes agree, so the relation cannot land in
+    /// any other branch (Concurrent / IncomingDominates /
+    /// IncomingDominated) post-commit.
+    #[test]
+    fn prop_commit_then_sync_once_yields_nothing_to_do(
+        counter_canonical in 1u64..1000,
+        counter_sibling in 1u64..1000,
+    ) {
+        let (folder, _tmp, _block_uuid) =
+            build_no_veto_fixture(counter_canonical, counter_sibling);
+        let (bundle, plan, _state_pre) = drive_sync_once_concurrent(&folder);
+
+        let password = fixtures::golden_vault_001_password();
+        let vt_bytes = std::fs::read(folder.join("vault.toml")).expect("read vault.toml");
+        let bundle_bytes =
+            std::fs::read(folder.join("identity.bundle.enc")).expect("read identity bundle");
+        let identity =
+            open_with_password(&vt_bytes, &bundle_bytes, &password).expect("open_with_password");
+
+        let draft = prepare_merge(&folder, &identity, &bundle, &plan).expect("prepare_merge");
+        prop_assert!(
+            draft.vetoes.is_empty(),
+            "no_veto_fixture must produce zero vetoes (got {})",
+            draft.vetoes.len(),
+        );
+
+        let new_state =
+            commit_with_decisions(&folder, &password, draft, Vec::new(), COMMIT_NOW_MS)
+                .expect("commit_with_decisions");
+
+        // Re-run sync_once against the SAME identity using the returned
+        // SyncState. Equal → NothingToDo is the only acceptable outcome.
+        let outcome = sync_once(&folder, &identity, &new_state, 0u64).expect("sync_once post-commit");
+        prop_assert_eq!(
+            outcome,
+            SyncOutcome::NothingToDo,
+            "post-commit sync_once must report NothingToDo (state.clock vs disk.clock must be Equal)",
+        );
+    }
+}

--- a/core/tests/sync_merge_proptest_helpers/mod.rs
+++ b/core/tests/sync_merge_proptest_helpers/mod.rs
@@ -339,9 +339,12 @@ pub fn open_identity(folder: &std::path::Path) -> UnlockedIdentity {
 
 /// Drive `sync_once` against a built fixture and unwrap the
 /// `ConcurrentDetected` payload. Property cases use this once per
-/// fixture; failures fail-fast with `panic!` so the caller's
-/// `prop_assert!` sees the unwound error.
-pub fn drive_sync_once_concurrent(folder: &std::path::Path) -> (VaultBundle, DiffPlan, SyncState) {
+/// fixture; failures fail-fast with `panic!` (proptest catches and
+/// reports as case failure). Callers don't need the constructed
+/// `SyncState` — they pass the returned `bundle` and `plan` straight
+/// into `prepare_merge`, then build a fresh `SyncState` indirectly via
+/// `commit_with_decisions`.
+pub fn drive_sync_once_concurrent(folder: &std::path::Path) -> (VaultBundle, DiffPlan) {
     let identity = open_identity(folder);
     let vault_uuid = fixtures::extract_vault_uuid(folder);
     let local_clock = vec![VectorClockEntry {
@@ -350,11 +353,10 @@ pub fn drive_sync_once_concurrent(folder: &std::path::Path) -> (VaultBundle, Dif
     }];
     let state = SyncState::new(vault_uuid, local_clock).expect("SyncState::new");
     let outcome = sync_once(folder, &identity, &state, 0u64).expect("sync_once");
-    let (bundle, plan) = match outcome {
+    match outcome {
         SyncOutcome::ConcurrentDetected { bundle, plan, .. } => (bundle, plan),
         other => panic!("expected ConcurrentDetected, got {other:?}"),
-    };
-    (bundle, plan, state)
+    }
 }
 
 /// Read the canonical block's decrypted records via a fresh `open_vault`

--- a/core/tests/sync_merge_proptest_helpers/mod.rs
+++ b/core/tests/sync_merge_proptest_helpers/mod.rs
@@ -1,0 +1,370 @@
+//! Shared helpers for `core/tests/sync_merge_proptest.rs`.
+//!
+//! Extracted from the proptest binary to keep the proptest file under
+//! the 500-LOC project soft cap (see CLAUDE.md / repo feedback).
+//! Constants, record builders, fixture builders, and the
+//! `sync_once → ConcurrentDetected` driver all live here; the proptest
+//! file holds only the four `proptest!` blocks plus their per-property
+//! docstrings.
+//!
+//! Re-exports `crate::fixtures` + `crate::sync_helpers` symbols
+//! verbatim — those modules are declared at the proptest binary's
+//! crate root, and this helper module accesses them via `crate::`
+//! (mirroring the pattern in `core/tests/sync_helpers/mod.rs`).
+
+use std::collections::BTreeMap;
+
+use secretary_core::crypto::secret::SecretString;
+use secretary_core::sync::{
+    sync_once, DiffPlan, SyncOutcome, SyncState, VaultBundle, VetoDecision,
+};
+use secretary_core::unlock::{open_with_password, UnlockedIdentity};
+use secretary_core::vault::block::VectorClockEntry;
+use secretary_core::vault::{open_vault, Record, RecordField, RecordFieldValue, Unlocker};
+
+use crate::fixtures;
+use crate::sync_helpers;
+
+// === Fixed (non-randomised) fixture inputs ===
+//
+// Property cases vary the manifest clock counters and (for prop 4) the
+// stray decision UUIDs. Holding the other fixture inputs fixed avoids
+// re-deriving record bodies / device UUIDs on every iteration and keeps
+// each case's failure mode unambiguous (a flake names the same record
+// UUIDs every time).
+
+/// Record UUID for the FIRST veto-bearing record (canonical LIVE,
+/// sibling TOMBSTONED at later death-clock).
+pub const RECORD_A_UUID: [u8; 16] = [0xAA; 16];
+/// Record UUID for the SECOND veto-bearing record. Strictly greater
+/// than [`RECORD_A_UUID`] so `apply_decisions`'s canonical-sort error
+/// reporting is deterministic (Missing fires on the smallest
+/// un-adjudicated id). Consumed by property 3.
+pub const RECORD_B_UUID: [u8; 16] = [0xBB; 16];
+/// Record UUID for the FIRST non-conflicting record on the canonical
+/// side (used in properties 1 & 2 where vetoes are not desired).
+const NONCONFLICTING_RECORD_CANONICAL_UUID: [u8; 16] = [0xAA; 16];
+/// Record UUID for the FIRST non-conflicting record on the sibling
+/// side. Distinct from [`NONCONFLICTING_RECORD_CANONICAL_UUID`] so the
+/// merge produces a clean union with no vetoes.
+const NONCONFLICTING_RECORD_SIBLING_UUID: [u8; 16] = [0xBB; 16];
+/// Canonical device clock anchor. Records' `last_modifier_device` and
+/// the canonical block's `vector_clock_summary` reference this device.
+const CANONICAL_DEVICE_UUID: [u8; 16] = [0x0A; 16];
+/// Sibling device clock anchor. Records' `last_modifier_device` and
+/// the sibling block's `vector_clock_summary` reference this device.
+const SIBLING_DEVICE_UUID: [u8; 16] = [0x0B; 16];
+/// Local device clock anchor — the persisted `SyncState`'s clock entry.
+/// Distinct from canonical / sibling so the pre-commit `ClockRelation`
+/// is `Concurrent` (sync_once precondition for the `ConcurrentDetected`
+/// arm).
+const LOCAL_DEVICE_UUID: [u8; 16] = [0x0C; 16];
+/// `last_mod_ms` on every canonical LIVE record. Constant; nothing else
+/// fixes the value.
+const LOCAL_LAST_MOD_MS: u64 = 100;
+/// `last_mod_ms` AND `tombstoned_at_ms` on every sibling TOMBSTONED
+/// record. Strictly greater than [`LOCAL_LAST_MOD_MS`] so the per-record
+/// veto pass fires (`tombstone_veto_set`'s strict-greater branch).
+/// Consumed by properties 3 and 4.
+const SIBLING_TOMBSTONE_AT_MS: u64 = 200;
+/// `last_mod_ms` on the non-conflicting sibling record (properties 1 &
+/// 2). Same magnitude as [`SIBLING_TOMBSTONE_AT_MS`] but the record is
+/// LIVE — only the UUID disjointness matters for vetoless merges.
+const SIBLING_NONCONFLICTING_LAST_MOD_MS: u64 = 200;
+/// Commit timestamp passed to `commit_with_decisions`. Reused across
+/// every fixture's invocations so manifest `last_mod_ms` is uniform.
+pub const COMMIT_NOW_MS: u64 = 1_000_000;
+/// Sibling manifest filename — must start with `manifest.cbor.enc` per
+/// `enumerate_manifest_siblings`. The Syncthing-style suffix is the
+/// project convention across C.1.1a / C.1.1b tests.
+const SIBLING_MANIFEST_FILENAME: &str = "manifest.cbor.enc.sync-conflict-from-device-bb";
+/// Sibling block-file suffix — must start with a non-empty separator
+/// so the resulting filename is recognised by
+/// `enumerate_block_siblings`.
+const SIBLING_BLOCK_SUFFIX: &str = ".sync-conflict-from-device-bb";
+/// `cases` cap shared across the four properties. Each case builds one
+/// or two `fresh_vault_two_concurrent_blocks` fixtures (open_vault
+/// Argon2 + two block encryptions + two manifest signs) and runs at
+/// least one `commit_with_decisions` (re-encrypt + re-sign). 16 cases
+/// per property keeps the whole file comfortably under a minute on the
+/// project's reference hardware while still exploring two independent
+/// dimensions per property (typically the canonical + sibling clock
+/// counters).
+pub const PROPTEST_CASES: u32 = 16;
+
+/// Build a LIVE record with one field. `uuid` controls the
+/// `record_uuid`; `device_uuid` + `last_mod_ms` flow into the field
+/// envelope so the merge sees a coherent timestamp.
+fn live_record(uuid: [u8; 16], device_uuid: [u8; 16], last_mod_ms: u64, marker: &str) -> Record {
+    let mut fields = BTreeMap::new();
+    fields.insert(
+        "k".to_string(),
+        RecordField {
+            value: RecordFieldValue::Text(SecretString::from(marker)),
+            last_mod: last_mod_ms,
+            device_uuid,
+            unknown: BTreeMap::new(),
+        },
+    );
+    Record {
+        record_uuid: uuid,
+        record_type: "kv".to_string(),
+        fields,
+        tags: Vec::new(),
+        created_at_ms: 50,
+        last_mod_ms,
+        tombstone: false,
+        tombstoned_at_ms: 0,
+        unknown: BTreeMap::new(),
+    }
+}
+
+/// Build a TOMBSTONED record. `last_mod_ms == tombstoned_at_ms` per the
+/// §11.5 invariant that tombstoned records pin both timestamps to the
+/// death clock. Consumed by properties 3 and 4.
+fn tombstoned_record(uuid: [u8; 16], device_uuid: [u8; 16], tombstoned_at_ms: u64) -> Record {
+    let mut fields = BTreeMap::new();
+    fields.insert(
+        "k".to_string(),
+        RecordField {
+            value: RecordFieldValue::Text(SecretString::from("ignored")),
+            last_mod: tombstoned_at_ms,
+            device_uuid,
+            unknown: BTreeMap::new(),
+        },
+    );
+    Record {
+        record_uuid: uuid,
+        record_type: "kv".to_string(),
+        fields,
+        tags: Vec::new(),
+        created_at_ms: 50,
+        last_mod_ms: tombstoned_at_ms,
+        tombstone: true,
+        tombstoned_at_ms,
+        unknown: BTreeMap::new(),
+    }
+}
+
+/// Build a per-block-divergent fixture with NO veto-producing records.
+/// The canonical block holds [`NONCONFLICTING_RECORD_CANONICAL_UUID`]
+/// LIVE; the sibling block holds [`NONCONFLICTING_RECORD_SIBLING_UUID`]
+/// LIVE. UUIDs are distinct, so the merge produces a clean union and
+/// `draft.vetoes` is empty.
+///
+/// `counter_canonical` / `counter_sibling` are the per-device counters
+/// at the canonical / sibling manifest level (the block-level
+/// vector_clock_summary uses counter `1` because the records are local
+/// edits from a single anchor; only the manifest-level clock varies).
+pub fn build_no_veto_fixture(
+    counter_canonical: u64,
+    counter_sibling: u64,
+) -> (std::path::PathBuf, tempfile::TempDir, [u8; 16]) {
+    let (probe_folder, _probe_tmp) = sync_helpers::fresh_vault_with_clock(Vec::new());
+    let block_uuid = sync_helpers::golden_vault_001_first_block_uuid(&probe_folder);
+
+    let canonical_block_clock = vec![VectorClockEntry {
+        device_uuid: CANONICAL_DEVICE_UUID,
+        counter: 1,
+    }];
+    let sibling_block_clock = vec![VectorClockEntry {
+        device_uuid: SIBLING_DEVICE_UUID,
+        counter: 1,
+    }];
+    let canonical_manifest_clock = vec![VectorClockEntry {
+        device_uuid: CANONICAL_DEVICE_UUID,
+        counter: counter_canonical,
+    }];
+    let sibling_manifest_clock = vec![VectorClockEntry {
+        device_uuid: SIBLING_DEVICE_UUID,
+        counter: counter_sibling,
+    }];
+
+    let (folder, tmp) = sync_helpers::fresh_vault_two_concurrent_blocks(
+        block_uuid,
+        vec![live_record(
+            NONCONFLICTING_RECORD_CANONICAL_UUID,
+            CANONICAL_DEVICE_UUID,
+            LOCAL_LAST_MOD_MS,
+            "canonical",
+        )],
+        canonical_block_clock,
+        canonical_manifest_clock,
+        vec![live_record(
+            NONCONFLICTING_RECORD_SIBLING_UUID,
+            SIBLING_DEVICE_UUID,
+            SIBLING_NONCONFLICTING_LAST_MOD_MS,
+            "sibling",
+        )],
+        sibling_block_clock,
+        sibling_manifest_clock,
+        SIBLING_MANIFEST_FILENAME,
+        SIBLING_BLOCK_SUFFIX,
+        COMMIT_NOW_MS,
+    );
+    (folder, tmp, block_uuid)
+}
+
+/// Build a per-block-divergent fixture with a SINGLE veto. The veto
+/// targets [`RECORD_A_UUID`] (canonical LIVE at
+/// [`LOCAL_LAST_MOD_MS`], sibling TOMBSTONED at
+/// [`SIBLING_TOMBSTONE_AT_MS`]). Consumed by property 4.
+pub fn build_single_veto_fixture(
+    counter_canonical: u64,
+    counter_sibling: u64,
+) -> (std::path::PathBuf, tempfile::TempDir, [u8; 16]) {
+    let (probe_folder, _probe_tmp) = sync_helpers::fresh_vault_with_clock(Vec::new());
+    let block_uuid = sync_helpers::golden_vault_001_first_block_uuid(&probe_folder);
+
+    let canonical_block_clock = vec![VectorClockEntry {
+        device_uuid: CANONICAL_DEVICE_UUID,
+        counter: 1,
+    }];
+    let sibling_block_clock = vec![VectorClockEntry {
+        device_uuid: SIBLING_DEVICE_UUID,
+        counter: 1,
+    }];
+    let canonical_manifest_clock = vec![VectorClockEntry {
+        device_uuid: CANONICAL_DEVICE_UUID,
+        counter: counter_canonical,
+    }];
+    let sibling_manifest_clock = vec![VectorClockEntry {
+        device_uuid: SIBLING_DEVICE_UUID,
+        counter: counter_sibling,
+    }];
+
+    let (folder, tmp) = sync_helpers::fresh_vault_two_concurrent_blocks(
+        block_uuid,
+        vec![live_record(
+            RECORD_A_UUID,
+            CANONICAL_DEVICE_UUID,
+            LOCAL_LAST_MOD_MS,
+            "canonical",
+        )],
+        canonical_block_clock,
+        canonical_manifest_clock,
+        vec![tombstoned_record(
+            RECORD_A_UUID,
+            SIBLING_DEVICE_UUID,
+            SIBLING_TOMBSTONE_AT_MS,
+        )],
+        sibling_block_clock,
+        sibling_manifest_clock,
+        SIBLING_MANIFEST_FILENAME,
+        SIBLING_BLOCK_SUFFIX,
+        COMMIT_NOW_MS,
+    );
+    (folder, tmp, block_uuid)
+}
+
+/// Build a per-block-divergent fixture with TWO disjoint vetoes. Both
+/// records are LIVE on canonical, TOMBSTONED on sibling at the later
+/// death clock. Used by property 3 to vary decision ordering.
+pub fn build_two_veto_fixture(
+    counter_canonical: u64,
+    counter_sibling: u64,
+) -> (std::path::PathBuf, tempfile::TempDir, [u8; 16]) {
+    let (probe_folder, _probe_tmp) = sync_helpers::fresh_vault_with_clock(Vec::new());
+    let block_uuid = sync_helpers::golden_vault_001_first_block_uuid(&probe_folder);
+
+    let canonical_block_clock = vec![VectorClockEntry {
+        device_uuid: CANONICAL_DEVICE_UUID,
+        counter: 1,
+    }];
+    let sibling_block_clock = vec![VectorClockEntry {
+        device_uuid: SIBLING_DEVICE_UUID,
+        counter: 1,
+    }];
+    let canonical_manifest_clock = vec![VectorClockEntry {
+        device_uuid: CANONICAL_DEVICE_UUID,
+        counter: counter_canonical,
+    }];
+    let sibling_manifest_clock = vec![VectorClockEntry {
+        device_uuid: SIBLING_DEVICE_UUID,
+        counter: counter_sibling,
+    }];
+
+    let (folder, tmp) = sync_helpers::fresh_vault_two_concurrent_blocks(
+        block_uuid,
+        vec![
+            live_record(
+                RECORD_A_UUID,
+                CANONICAL_DEVICE_UUID,
+                LOCAL_LAST_MOD_MS,
+                "canonical-a",
+            ),
+            live_record(
+                RECORD_B_UUID,
+                CANONICAL_DEVICE_UUID,
+                LOCAL_LAST_MOD_MS,
+                "canonical-b",
+            ),
+        ],
+        canonical_block_clock,
+        canonical_manifest_clock,
+        vec![
+            tombstoned_record(RECORD_A_UUID, SIBLING_DEVICE_UUID, SIBLING_TOMBSTONE_AT_MS),
+            tombstoned_record(RECORD_B_UUID, SIBLING_DEVICE_UUID, SIBLING_TOMBSTONE_AT_MS),
+        ],
+        sibling_block_clock,
+        sibling_manifest_clock,
+        SIBLING_MANIFEST_FILENAME,
+        SIBLING_BLOCK_SUFFIX,
+        COMMIT_NOW_MS,
+    );
+    (folder, tmp, block_uuid)
+}
+
+/// Map a boolean choice to a [`VetoDecision`] for a given `record_id`.
+/// `true` → `KeepLocal`, `false` → `AcceptTombstone`. Used by property
+/// 3 to vary the decision kind per veto across cases.
+pub fn make_decision(record_id: [u8; 16], keep_local: bool) -> VetoDecision {
+    if keep_local {
+        VetoDecision::KeepLocal { record_id }
+    } else {
+        VetoDecision::AcceptTombstone { record_id }
+    }
+}
+
+/// Open the unlocked identity for the golden_vault_001 fixture at
+/// `folder`. Centralised so each property body doesn't repeat the
+/// password-fetch + vault.toml-read + identity-bundle-read boilerplate.
+pub fn open_identity(folder: &std::path::Path) -> UnlockedIdentity {
+    let password = fixtures::golden_vault_001_password();
+    let vt_bytes = std::fs::read(folder.join("vault.toml")).expect("read vault.toml");
+    let bundle_bytes =
+        std::fs::read(folder.join("identity.bundle.enc")).expect("read identity bundle");
+    open_with_password(&vt_bytes, &bundle_bytes, &password).expect("open_with_password")
+}
+
+/// Drive `sync_once` against a built fixture and unwrap the
+/// `ConcurrentDetected` payload. Property cases use this once per
+/// fixture; failures fail-fast with `panic!` so the caller's
+/// `prop_assert!` sees the unwound error.
+pub fn drive_sync_once_concurrent(folder: &std::path::Path) -> (VaultBundle, DiffPlan, SyncState) {
+    let identity = open_identity(folder);
+    let vault_uuid = fixtures::extract_vault_uuid(folder);
+    let local_clock = vec![VectorClockEntry {
+        device_uuid: LOCAL_DEVICE_UUID,
+        counter: 1,
+    }];
+    let state = SyncState::new(vault_uuid, local_clock).expect("SyncState::new");
+    let outcome = sync_once(folder, &identity, &state, 0u64).expect("sync_once");
+    let (bundle, plan) = match outcome {
+        SyncOutcome::ConcurrentDetected { bundle, plan, .. } => (bundle, plan),
+        other => panic!("expected ConcurrentDetected, got {other:?}"),
+    };
+    (bundle, plan, state)
+}
+
+/// Read the canonical block's decrypted records via a fresh `open_vault`
+/// so the caller's stale state doesn't contaminate the assertion.
+/// Consumed by properties 2 and 3.
+pub fn read_canonical_block_records(folder: &std::path::Path, block_uuid: [u8; 16]) -> Vec<Record> {
+    let password = fixtures::golden_vault_001_password();
+    let open = open_vault(folder, Unlocker::Password(&password), None).expect("open_vault");
+    let block_path = sync_helpers::block_file_path(folder, &block_uuid);
+    let bytes = std::fs::read(&block_path).expect("read block file");
+    let plaintext = sync_helpers::decrypt_block_using_open(&open, &bytes).expect("decrypt block");
+    plaintext.records
+}

--- a/docs/handoffs/2026-05-22-c1-1b-task-15-shipped.md
+++ b/docs/handoffs/2026-05-22-c1-1b-task-15-shipped.md
@@ -1,0 +1,211 @@
+# NEXT_SESSION.md
+
+**Session date:** 2026-05-22 (implementation session — C.1.1b Task 15 of 17 shipped; four `proptest` properties for the merge layer + helpers extraction).
+**Status:** PR to be opened. `feature/c1-1b-task-15` carries 5 commits on top of `66ca7d9` (post-Task-14 main) — 4 per-property TDD commits + 1 file-split refactor. 2 tasks remain (16-17).
+
+## (1) What we shipped this session
+
+| Commit | Task | What it adds |
+|---|---|---|
+| [`a099749`](https://github.com/hherb/secretary/commit/a099749) | 15 prop 1 | **`prop_commit_then_sync_once_yields_nothing_to_do`** — post-commit fixpoint property. Inputs: canonical + sibling manifest-clock counters via `counter_canonical in 1..1000`, `counter_sibling in 1..1000`. Fixture: per-block-divergent vault with disjoint record UUIDs (no vetoes). Asserts the next `sync_once` after `commit_with_decisions(..., decisions = [])` returns `SyncOutcome::NothingToDo`, proving the commit's `post_merge_clock` is consistent across the returned `SyncState` and the on-disk manifest (so `clock_relation` sees `Equal`). Per-property cap: 16 cases. File initially scaffolded with all four properties' fixture-builder constants + helpers in place (annotated `#[allow(dead_code)]` for items consumed by later props). |
+| [`2ae0933`](https://github.com/hherb/secretary/commit/2ae0933) | 15 prop 2 | **`prop_three_step_idempotent_on_repeated_invocation`** — deterministic-merge property. Builds two independent vaults with identical fixture parameters; runs the three-step `sync_once → prepare_merge → commit_with_decisions` on each; asserts: (a) same returned `SyncState`, (b) same decrypted canonical block records, (c) DIFFERENT envelope bytes (AEAD nonces from OsRng per rewrite). The (a)+(b) pair is the idempotence claim; (c) pins the AEAD-nonce-per-rewrite contract at the property level across a different dimension than the crash-recovery integration test's same-vault retry coverage. |
+| [`5e51607`](https://github.com/hherb/secretary/commit/5e51607) | 15 prop 3 | **`prop_commit_associative_under_disjoint_vetoes`** — decision-order independence. Builds two equivalent two-veto fixtures; one commits with decisions `[d_a, d_b]`, the other with `[d_b, d_a]`. Asserts same returned `SyncState` AND same decrypted canonical block records. Pins commutativity of `apply_decisions`'s per-decision iteration over the full decision set. Inputs: clock counters + two booleans (`keep_local_a`, `keep_local_b`) covering all four (KeepLocal, AcceptTombstone) × (KeepLocal, AcceptTombstone) pairings. |
+| [`bcbcc7b`](https://github.com/hherb/secretary/commit/bcbcc7b) | 15 prop 4 | **`prop_decision_bijection_enforced`** — Missing/Unknown/Ok branch coverage. For a single-veto fixture, constructs decisions from random `(include_match: bool, strays: Vec<u8 != 0xAA>)` and asserts: (a) `!include_match` → `MissingVetoDecision { record_id: RECORD_A_UUID }` (regardless of strays — Missing checked before Unknown); (b) `include_match && !strays.is_empty()` → `UnknownVetoDecision { record_id: [min(strays); 16] }`; (c) `include_match && strays.is_empty()` → `Ok(_)`. Strays exclude `0xAA` via `prop_filter` so they can't coincidentally collapse into the matching `RECORD_A_UUID` via the bijection's set-based dedupe. |
+| [`5749158`](https://github.com/hherb/secretary/commit/5749158) | 15 refactor | **`sync_merge_proptest_helpers/mod.rs` split.** All-four-properties file landed at 780 LOC — well over the project's 500-LOC soft cap (per `feedback_split_files_proactively`). Extracted fixture constants, record builders (`live_record`, `tombstoned_record`), fixture builders (`build_no_veto_fixture`, `build_single_veto_fixture`, `build_two_veto_fixture`), `make_decision`, `open_identity`, `drive_sync_once_concurrent`, and `read_canonical_block_records` into a sibling module. Final sizes: `sync_merge_proptest.rs` 391 LOC (four `proptest!` blocks + per-property docstrings only), `sync_merge_proptest_helpers/mod.rs` 370 LOC. Both comfortably under the cap. No behavioural change; gauntlet identical pre / post. |
+
+**Branch hygiene:** This session opened on `feature/c1-1b-task-15` (fresh branch from `66ca7d9` post-Task-14 main), leaving the prior session's `feature/c1-1b-sync-merge` branch untouched on disk (user preference at session start — see implementer-call below). Local branch carries exactly 5 new commits on top of `66ca7d9`.
+
+**Gauntlet on `feature/c1-1b-task-15` after Task 15 + refactor:**
+
+- `cargo test --release --workspace --no-fail-fast` → **795 / 0 / 10** (786 baseline at `66ca7d9` + 4 new proptests + 5 helper_tests cross-binary re-runs from the new `sync_merge_proptest` binary = 9).
+- `cargo clippy --release --workspace --tests -- -D warnings` → clean.
+- `cargo fmt --all -- --check` → clean.
+- `uv run core/tests/python/conformance.py` → PASS.
+- `uv run core/tests/python/spec_test_name_freshness.py` → PASS (96 resolved / 0 unresolved / 2 suppressed).
+
+## (2) What's next — execute Task 16
+
+### (a) First action next session: execute Task 16 (after PR for Task 15 merges)
+
+Open the plan at [`docs/superpowers/plans/2026-05-18-c1-1b-sync-merge.md`](docs/superpowers/plans/2026-05-18-c1-1b-sync-merge.md) → **Task 16 — KAT vectors**. Seven new vectors in `core/tests/data/sync_kat.json` (9 → 16) with replay-dispatch extensions in `core/tests/sync_kat.rs`:
+
+1. `concurrent_disjoint_blocks_no_vetoes_applied`
+2. `concurrent_same_block_field_lww_no_vetoes`
+3. `concurrent_one_tombstone_veto_keep_local`
+4. `concurrent_one_tombstone_veto_accept_tombstone`
+5. `concurrent_two_tombstone_vetoes_mixed_decisions`
+6. `prepare_merge_stale_hash_evidence_stale`
+7. `commit_block_fingerprint_mismatch_repair_via_reconverge`
+
+Per `feedback_stay_in_inner_loop`, keep the one-vector-one-commit cadence — seven commits.
+
+```bash
+cd /Users/hherb/src/secretary/.worktrees/c1-1b-sync-merge
+# AFTER Task 15's PR merges:
+git fetch --prune origin
+# Choose: reset the existing branch, OR (as this session did) branch a fresh
+# feature/c1-1b-task-16 from origin/main. The latter avoids the destructive
+# reset and keeps prior task branches available for backreference.
+git checkout -b feature/c1-1b-task-16 origin/main
+# THEN open the plan:
+$EDITOR docs/superpowers/plans/2026-05-18-c1-1b-sync-merge.md   # jump to "Task 16"
+```
+
+### (b) Plan structure at a glance (2 remaining of 17)
+
+| Task | What it builds | New / modified files |
+|---|---|---|
+| ~~1-10~~ | ~~Tasks 1-10 shipped~~ ✅ in PRs #84-#97 |
+| ~~11~~ | ~~`commit_with_decisions` + DraftMerge per-block + commit/ split + happy-path test~~ ✅ PR #99 |
+| ~~12~~ | ~~`EvidenceStale` integration test~~ ✅ PR #102 |
+| ~~13~~ | ~~Veto handling (KeepLocal / AcceptTombstone / Missing+Unknown bijection)~~ ✅ PR #104 |
+| ~~14~~ | ~~Crash-recovery test (partial-write reconverge — D6 proof)~~ ✅ PR #106 |
+| ~~15~~ | ~~4 property tests + helpers split~~ ✅ this session (5 commits, PR pending) |
+| **16** | **7 KAT vectors + replay extension** | `core/tests/data/sync_kat.json`, `core/tests/sync_kat.rs` |
+| 17 | README + ROADMAP + NEXT_SESSION baton + handoff snapshot + final gauntlet + open PR | `README.md`, `ROADMAP.md`, `NEXT_SESSION.md`, `docs/handoffs/*` |
+
+### (c) Acceptance criteria for the C.1.1b PR (final)
+
+- [x] `cargo test --release --workspace --no-fail-fast` → 766+ / 0 / 10 (currently 795 / 0 / 10 — well above the floor)
+- [x] `cargo clippy --release --workspace --tests -- -D warnings` → clean
+- [x] `cargo fmt --all -- --check` → clean
+- [x] `uv run core/tests/python/conformance.py` → PASS
+- [x] `uv run core/tests/python/spec_test_name_freshness.py` → PASS (no unresolved citations)
+- [x] `verify_block_fingerprints` runs eagerly in `open_vault`; corrupted-block test fires `VaultError::BlockFingerprintMismatch` ✅ Task 5
+- [x] `DraftMerge` / `RecordTombstoneVeto` / `VetoDecision` defined with zeroize discipline + module tests ✅ Task 6
+- [x] `tombstone_veto_set` pure helper with 7 table tests ✅ Task 7
+- [x] `prepare_merge` orchestrator wires decap + iterative fold + veto detection + post_merge_clock ✅ Task 8
+- [x] `rewrite_block_with_records_and_update_manifest` helper exists; post-rewrite vault opens cleanly under D6 ✅ Task 9
+- [x] `apply_decisions` pure helper enforces `vetoes ↔ decisions` bijection ✅ Task 10
+- [x] `commit_with_decisions` re-opens vault, freshness-checks manifest hash, applies decisions, re-encrypts diverging blocks, atomic block-first manifest-last write ✅ Task 11
+- [x] `EvidenceStale` integration test fires on stale manifest_hash + asserts NO disk writes ✅ Task 12
+- [x] **Bijection: `MissingVetoDecision` + `UnknownVetoDecision` typed errors fire on every non-bijective `(vetoes, decisions)` pair — disk-side proof** ✅ Tasks 13.3 + 13.4
+- [x] **`KeepLocal` and `AcceptTombstone` decisions persist correctly to disk** ✅ Tasks 13.1 + 13.2
+- [x] **Crash-recovery test (Task 14) proves CRDT-idempotent reconvergence after partial commit** ✅ Task 14
+- [x] **All four merge-layer proptests pass (post-commit fixpoint, deterministic merge, decision-order independence, bijection enforcement)** ✅ Task 15
+- [x] **All four CRDT proptests (commutativity, associativity, idempotence, well-formedness) still pass — must not weaken.** Task 15 did not touch `core/src/vault/conflict.rs`. ✅
+- [ ] **Before merging Task 17:** grep every `#[allow(dead_code)]` introduced in Tasks 1-10 and confirm each has at least one real consumer in Tasks 11-16. `BLOCK_NONCE_G` + `fresh_vault_four_concurrent_manifests` remain `#[allow(dead_code)]` — neither consumed by Task 15. Task 16 KAT vectors may consume them; if not, file them as cleanup follow-ups.
+
+## (3) Open decisions and risks
+
+### Implementer-call decisions from this session
+
+- **Fresh branch vs reset.** Per `feedback_worktree_location`, the user prefers project-local `.worktrees/` and worktree-per-feature. The prior session's `feature/c1-1b-sync-merge` carried 2 local commits (Task 14 work) that were squash-merged into main as PR #106 — the natural reset is `git reset --hard origin/main`. User chose "fresh branch instead" (auto-mode classifier blocked the `--hard` reset; user authorised the new-branch path). Result: `feature/c1-1b-task-15` is a fresh branch from `66ca7d9`. The prior `feature/c1-1b-sync-merge` branch remains on disk pointing at the (now-squash-merged) Task 14 commits — harmless but worth pruning at the end of C.1.1b if no longer needed.
+- **Helpers split into a sibling module.** The four-properties-in-one-file approach landed at 780 LOC. Per `feedback_split_files_proactively`, that's well over the 500-LOC soft cap. The refactor commit moves fixture/driver helpers into `core/tests/sync_merge_proptest_helpers/mod.rs` (a sibling test-module, mirroring the `core/tests/sync_helpers/` pattern). Reviewer: confirm the split shape — fixture builders + drivers in helpers; the proptest file holds only the four `proptest!` blocks + per-property docstrings.
+- **Property 4's stray-UUID exclusion.** Random stray UUIDs are built as `[seed; 16]` from `u8` seeds. To prevent a stray from coincidentally landing on `RECORD_A_UUID = [0xAA; 16]` (which would collapse into the matching decision via the bijection's set-based dedupe), the `prop_filter` excludes `seed == 0xAA`. This is the natural way to keep the property's distinction between "matching" and "stray" decisions unambiguous; an alternative (allow the collision and special-case the outcome) would muddle the assertion logic.
+- **Cap of 16 cases per property.** Each case opens a vault (Argon2) + encrypts 2 blocks + signs 2 manifests + runs at least one commit (re-encrypt + re-sign). 16 cases keeps the whole file under ~6 seconds. Props 2 + 3 build TWO fixtures per case but still come in well under the budget. Higher cap would not surface much additional coverage — the meaningful dimensions (clock counters, decision kinds, stray seeds) are well-explored at 16.
+
+### Carry-over from earlier PRs (still live)
+
+- **PR #99 in-PR refactor (`1193072`)** — `MANIFEST_FILENAME` consolidation already merged.
+- **PRs #102, #104, #106** — already merged.
+- **Implementer-call decisions from Task 12/13/14 batons still live:**
+  - #1 `commit_with_decisions` identity argument: stays `&SecretBytes`, re-opens internally.
+  - #2 `DraftMerge.per_block_clocks` + `per_block_records` shape: frozen, no change this session.
+  - #3 `extract_vault_uuid` helper duplication: closed in PR #104 (`63b32a7`).
+  - #4 `sync_helpers/mod.rs` file size: still 1174 LOC, unchanged this session. Track via [#95](https://github.com/hherb/secretary/issues/95).
+  - #5 `commit/` directory split (PR #99): no change this session — Task 15 is tests-only, didn't touch `commit/write.rs`.
+  - #6 `prepare.rs` file size (~890 LOC post-Task-13): unchanged this session.
+  - #7 `sync_merge_vetoes.rs` is a new test binary (Task 13): no change this session.
+  - #8 `sync_merge_crash.rs` is a new test binary (Task 14): no change this session.
+
+### Implementer's-call decisions (live for Task 16)
+
+1. **`commit_with_decisions` identity argument.** Unchanged.
+2. **`DraftMerge` shape.** Unchanged.
+3. **Veto-pass iteration source.** Unchanged from Task 13.1.
+4. **`sync_helpers/mod.rs` file size.** 1174 LOC. Past the 800 trigger but [#95](https://github.com/hherb/secretary/issues/95) stays the umbrella for the split refactor.
+5. **`commit/` directory split.** Unchanged.
+6. **`prepare.rs` file size.** ~890 LOC. Still in the "tracking issue at C.1.1b close" bucket.
+7. **New test binaries per concern.** Pattern continues — Task 14 = `sync_merge_crash.rs`, Task 15 = `sync_merge_proptest.rs` (+ `sync_merge_proptest_helpers/`). Task 16 (KAT) extends existing `sync_kat.rs` per the plan.
+8. **Property file LOC ceiling.** Reviewer's call: confirm `sync_merge_proptest_helpers/` split as the right shape, or consolidate the helpers into the existing `sync_helpers/` module instead. This baton's choice prefers the per-binary helpers (matches the pattern of `conformance_kat_helpers/` next to `conformance_kat.rs`) because the proptest fixture builders carry proptest-specific defaults that wouldn't generalise to the integration tests.
+
+### Risks (from the design doc, restated for plan execution)
+
+- **`DraftMerge` zeroize discipline** — unchanged this session (no production code touched).
+- **AEAD nonce per rewrite** — Property 2 now covers this contract at the proptest level across two-independent-vault dimension. The integration test in `sync_merge_crash.rs` covers the same contract across two-commits-on-same-vault dimension. Both still pass; deterministic-nonce regression would fire on either.
+- **`tempfile` exact pin** (`=3.27.0`) — unchanged this session.
+- **CRDT proptests must not weaken** — Task 15's tests do NOT touch `core/src/vault/conflict.rs`. Confirmed via gauntlet: 4 conflict proptests still pass.
+- **`SyncOutcome::ConcurrentDetected` is large** — unchanged.
+- **Exhaustive `VaultError` matchers in `secretary-ffi-bridge`** — no new core variants this session.
+- **File size of `core/src/sync/commit/write.rs`** — 389 LOC (unchanged). Task 15 is tests-only.
+- **File size of `core/src/sync/prepare.rs`** — ~890 LOC (unchanged this session).
+- **File size of `core/tests/sync_helpers/mod.rs`** — 1174 LOC. See [#95](https://github.com/hherb/secretary/issues/95).
+- **File size of `core/tests/sync_merge_vetoes.rs`** — 499 LOC (unchanged this session).
+- **File size of `core/tests/sync_merge_crash.rs`** — 327 LOC (unchanged this session).
+- **File size of `core/tests/sync_merge_proptest.rs`** — 391 LOC (new this session, post-split). Comfortable margin.
+- **File size of `core/tests/sync_merge_proptest_helpers/mod.rs`** — 370 LOC (new this session). Comfortable margin.
+- **File size of `core/src/vault/orchestrators.rs`** — ~2180 LOC (unchanged). Pre-existing.
+
+### Issues currently open
+
+- **[#37](https://github.com/hherb/secretary/issues/37)** — Sub-project C design discipline umbrella. C.1.1b closes the merge-layer portion.
+- **[#38](https://github.com/hherb/secretary/issues/38)** — `save_block` proptest case-count budget.
+- **[#45](https://github.com/hherb/secretary/issues/45)** — three `pub(crate) #[allow(dead_code)]` accessors on `OpenVaultManifest`.
+- **[#75](https://github.com/hherb/secretary/issues/75)** — replace `#[doc(hidden)] pub __test_dispatch` with `pub(crate)` + lib-internal tests.
+- **[#76](https://github.com/hherb/secretary/issues/76)** — Python clean-room replay of `sync_kat.json`. Task 16's seven new vectors will join when #76 lands.
+- **[#78](https://github.com/hherb/secretary/issues/78)** — C.1.1a integration-test gaps.
+- **[#79](https://github.com/hherb/secretary/issues/79)** — sync_kat.json ingestion vectors.
+- **[#81](https://github.com/hherb/secretary/issues/81)** — `MAX_BLOCK_FILE_SIZE` undocumented vs format-max recipient table.
+- **[#87](https://github.com/hherb/secretary/issues/87)** — dedup `golden_vault_001_password` reader.
+- **[#88](https://github.com/hherb/secretary/issues/88)** — `VaultError::Io` does not carry the failing block UUID on fingerprint-check I/O failures.
+- **[#90](https://github.com/hherb/secretary/issues/90)** — consolidate four `copy_dir_recursive` test-helper copies.
+- **[#95](https://github.com/hherb/secretary/issues/95)** — split `core/tests/sync_helpers/mod.rs`.
+- **[#98](https://github.com/hherb/secretary/issues/98)** — `apply_decisions` duplicate-decision tightening.
+- **[#103](https://github.com/hherb/secretary/issues/103)** — Task 12 follow-on: EvidenceStale abort beats step 5's per-block rewrites on a divergence-bearing fixture. Could roll into Task 16's KATs.
+
+### Open PRs at close
+
+**To be opened at end of this session** — `feature/c1-1b-task-15` carries 5 commits on top of `66ca7d9`. PR body will reference this baton.
+
+## (4) Exact commands to resume
+
+```bash
+cd /Users/hherb/src/secretary
+git fetch --prune origin
+git status --short                                              # expect: clean
+git worktree list                                               # expect: main + .worktrees/c1-1b-sync-merge
+
+cd .worktrees/c1-1b-sync-merge
+pwd                                                             # confirm worktree
+git branch --show-current                                       # → feature/c1-1b-task-15 (this session's branch)
+git log --oneline -8                                            # last 8: baton + 5 task commits + main HEAD
+
+# Baseline gauntlet (expect 795 / 0 / 10 on this branch BEFORE Task 16 starts):
+cargo test --release --workspace --no-fail-fast 2>&1 | grep -E "^test result:" | awk '{passed+=$4; failed+=$6; ignored+=$8} END {print "PASSED:", passed, "FAILED:", failed, "IGNORED:", ignored}'
+cargo clippy --release --workspace --tests -- -D warnings 2>&1 | tail -3
+cargo fmt --all -- --check
+uv run core/tests/python/conformance.py 2>&1 | tail -3
+uv run core/tests/python/spec_test_name_freshness.py 2>&1 | tail -3
+
+# AFTER Task 15's PR merges, switch to a fresh task branch + open the plan for Task 16:
+git fetch --prune origin
+git checkout -b feature/c1-1b-task-16 origin/main
+$EDITOR docs/superpowers/plans/2026-05-18-c1-1b-sync-merge.md   # jump to "Task 16"
+```
+
+## Closing inventory
+
+- **Branch state on close:** `main` at `66ca7d9` (PR #106 squash-merged Task 14). `feature/c1-1b-task-15` carries 5 new commits on top of `66ca7d9` (4 prop commits + 1 refactor commit) + this baton commit.
+- **Workspace tests on `feature/c1-1b-task-15`:** 795 passed + 10 ignored. Clippy + fmt + Python conformance + spec-citation freshness all clean.
+- **README.md:** unchanged this session. Per plan Task 17, updates land at end of C.1.1b.
+- **ROADMAP.md:** unchanged this session. Per plan Task 17, updates land at end of C.1.1b.
+- **CLAUDE.md:** unchanged this session.
+- **Open issues:** [#37](https://github.com/hherb/secretary/issues/37) / [#38](https://github.com/hherb/secretary/issues/38) / [#45](https://github.com/hherb/secretary/issues/45) / [#75](https://github.com/hherb/secretary/issues/75) / [#76](https://github.com/hherb/secretary/issues/76) / [#78](https://github.com/hherb/secretary/issues/78) / [#79](https://github.com/hherb/secretary/issues/79) / [#81](https://github.com/hherb/secretary/issues/81) / [#87](https://github.com/hherb/secretary/issues/87) / [#88](https://github.com/hherb/secretary/issues/88) / [#90](https://github.com/hherb/secretary/issues/90) / [#95](https://github.com/hherb/secretary/issues/95) / [#98](https://github.com/hherb/secretary/issues/98) / [#103](https://github.com/hherb/secretary/issues/103).
+- **Open PRs:** one to be opened at end of this session covering Task 15.
+- **Worktrees on disk:** `main` + `.worktrees/c1-1b-sync-merge` (this session's branch lives in the same worktree directory — branch name decoupled from path).
+- **Frozen baton snapshots:**
+  - [`docs/handoffs/2026-05-19-c1-1b-tasks-1-3-shipped.md`](docs/handoffs/2026-05-19-c1-1b-tasks-1-3-shipped.md) — Tasks 1-3 close.
+  - [`docs/handoffs/2026-05-19-c1-1b-pr-84-review-fixes.md`](docs/handoffs/2026-05-19-c1-1b-pr-84-review-fixes.md) — PR #84 review-fix cycle.
+  - [`docs/handoffs/2026-05-19-c1-1b-task-4-shipped.md`](docs/handoffs/2026-05-19-c1-1b-task-4-shipped.md) — Task 4 close.
+  - [`docs/handoffs/2026-05-19-c1-1b-task-5-shipped.md`](docs/handoffs/2026-05-19-c1-1b-task-5-shipped.md) — Task 5 close.
+  - [`docs/handoffs/2026-05-19-c1-1b-task-6-shipped.md`](docs/handoffs/2026-05-19-c1-1b-task-6-shipped.md) — Task 6 close.
+  - [`docs/handoffs/2026-05-19-c1-1b-task-7-shipped.md`](docs/handoffs/2026-05-19-c1-1b-task-7-shipped.md) — Task 7 close.
+  - [`docs/handoffs/2026-05-19-c1-1b-task-8-shipped.md`](docs/handoffs/2026-05-19-c1-1b-task-8-shipped.md) — Task 8 close.
+  - [`docs/handoffs/2026-05-19-c1-1b-task-9-shipped.md`](docs/handoffs/2026-05-19-c1-1b-task-9-shipped.md) — Task 9 close.
+  - [`docs/handoffs/2026-05-19-c1-1b-task-10-shipped.md`](docs/handoffs/2026-05-19-c1-1b-task-10-shipped.md) — Task 10 close.
+  - [`docs/handoffs/2026-05-20-c1-1b-task-11-shipped.md`](docs/handoffs/2026-05-20-c1-1b-task-11-shipped.md) — Task 11 close.
+  - [`docs/handoffs/2026-05-20-c1-1b-task-12-shipped.md`](docs/handoffs/2026-05-20-c1-1b-task-12-shipped.md) — Task 12 close.
+  - [`docs/handoffs/2026-05-21-c1-1b-task-13-shipped.md`](docs/handoffs/2026-05-21-c1-1b-task-13-shipped.md) — Task 13 close.
+  - [`docs/handoffs/2026-05-22-c1-1b-task-14-shipped.md`](docs/handoffs/2026-05-22-c1-1b-task-14-shipped.md) — Task 14 close.
+  - [`docs/handoffs/2026-05-22-c1-1b-task-15-shipped.md`](docs/handoffs/2026-05-22-c1-1b-task-15-shipped.md) — Task 15 close (this session).


### PR DESCRIPTION
## Summary

Closes Task 15 of the C.1.1b sync-merge plan: four `proptest` properties covering the merge layer's public API.

- **prop_commit_then_sync_once_yields_nothing_to_do** — post-commit fixpoint: re-running `sync_once` with the returned `SyncState` yields `NothingToDo`.
- **prop_three_step_idempotent_on_repeated_invocation** — deterministic merge: two independent vaults with identical inputs produce the same `SyncState` and decrypted records, but DIFFERENT envelope bytes (AEAD-nonce-per-rewrite contract).
- **prop_commit_associative_under_disjoint_vetoes** — decision-order independence: `commit_with_decisions(draft, [d_a, d_b])` and `commit_with_decisions(draft, [d_b, d_a])` produce the same observable state.
- **prop_decision_bijection_enforced** — Missing/Unknown/Ok branch coverage for the `(vetoes, decisions)` bijection, with `prop_filter`-excluded stray UUIDs to keep the set-based dedupe distinct from collisions.

16 cases per property; full proptest binary completes in ~6 sec.

The initial draft landed at 780 LOC (one file). Per `feedback_split_files_proactively`, refactored helpers into `core/tests/sync_merge_proptest_helpers/mod.rs` — final shape is 391 LOC (properties only) + 370 LOC (helpers).

## Test plan

- [x] `cargo test --release --workspace --no-fail-fast` → **795 / 0 / 10** (786 baseline + 4 proptests + 5 helper_tests cross-binary re-runs)
- [x] `cargo clippy --release --workspace --tests -- -D warnings` → clean
- [x] `cargo fmt --all -- --check` → clean
- [x] `uv run core/tests/python/conformance.py` → PASS
- [x] `uv run core/tests/python/spec_test_name_freshness.py` → PASS (96 resolved / 0 unresolved / 2 suppressed)

## Spec & plan

- Design: [`docs/superpowers/specs/2026-05-18-c1-1b-sync-merge-design.md`](docs/superpowers/specs/2026-05-18-c1-1b-sync-merge-design.md)
- Plan: [`docs/superpowers/plans/2026-05-18-c1-1b-sync-merge.md`](docs/superpowers/plans/2026-05-18-c1-1b-sync-merge.md) — Task 15
- Baton: [`docs/handoffs/2026-05-22-c1-1b-task-15-shipped.md`](docs/handoffs/2026-05-22-c1-1b-task-15-shipped.md)

## Branch shape

Five commits on top of `66ca7d9` (post-Task-14 main) + one baton commit:

- `a099749` — prop 1 (post-commit fixpoint)
- `2ae0933` — prop 2 (deterministic merge)
- `5e51607` — prop 3 (decision-order independence)
- `bcbcc7b` — prop 4 (bijection enforcement)
- `5749158` — refactor: helpers split into `sync_merge_proptest_helpers/`
- `af8857b` — docs: NEXT_SESSION baton + symlink retarget

🤖 Generated with [Claude Code](https://claude.com/claude-code)