### PR TITLE
C.1.1b Task 16 — 7 new KAT vectors covering merge / EvidenceStale / fingerprint repair

### DIFF
--- a/NEXT_SESSION.md
+++ b/NEXT_SESSION.md
@@ -1,1 +1,1 @@
-docs/handoffs/2026-05-22-c1-1b-task-15-shipped.md
+docs/handoffs/2026-05-23-c1-1b-task-16-shipped.md

--- a/core/tests/data/sync_kat.json
+++ b/core/tests/data/sync_kat.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 2,
-  "description": "C.1 sync + C.1.1b merge KAT. Two vector families: (1) clock_dispatch — pure vector-clock dispatch (state_highest_vector_clock × disk_vector_clock → outcome variant); (2) concurrent_merge_apply_decisions / evidence_stale / fingerprint_repair — disk-backed three-step merge flow (sync_once → prepare_merge → commit_with_decisions) with scenario-named fixture builders. Schema bumped 1 → 2 in C.1.1b Task 16. Python clean-room replay scheduled for C.4 (issue #76).",
+  "description": "C.1 sync + C.1.1b merge KAT. Four vector families (one per `vector_type` enum variant): (1) clock_dispatch — pure vector-clock dispatch (state_highest_vector_clock × disk_vector_clock → outcome variant); (2) concurrent_merge_apply_decisions — disk-backed three-step merge flow (sync_once → prepare_merge → commit_with_decisions) with scenario-named fixture builders; (3) evidence_stale — commit-time TOCTOU re-check fires SyncError::EvidenceStale on a racing manifest rewrite; (4) fingerprint_repair — partial-commit corruption fires VaultError::BlockFingerprintMismatch at open_vault. Schema bumped 1 → 2 in C.1.1b Task 16. Python clean-room replay scheduled for C.4 (issue #76).",
   "vectors": [
     {
       "name": "equal_clocks_nothing_to_do",

--- a/core/tests/data/sync_kat.json
+++ b/core/tests/data/sync_kat.json
@@ -154,7 +154,23 @@
       "expected_vetoes_count": 1,
       "expected_diverging_blocks_count": 1,
       "expected_post_commit_outcome": "NothingToDo",
-      "expected_post_commit_canonical_records_count": 1
+      "expected_post_commit_canonical_records_count": 1,
+      "expected_canonical_record_tombstoned": false
+    },
+    {
+      "name": "concurrent_one_tombstone_veto_accept_tombstone",
+      "vector_type": "concurrent_merge_apply_decisions",
+      "scenario": "single_veto",
+      "counter_canonical": 5,
+      "counter_sibling": 5,
+      "decisions": [
+        { "kind": "AcceptTombstone", "record_id": "RECORD_A_UUID" }
+      ],
+      "expected_vetoes_count": 1,
+      "expected_diverging_blocks_count": 1,
+      "expected_post_commit_outcome": "NothingToDo",
+      "expected_post_commit_canonical_records_count": 1,
+      "expected_canonical_record_tombstoned": true
     }
   ]
 }

--- a/core/tests/data/sync_kat.json
+++ b/core/tests/data/sync_kat.json
@@ -1,9 +1,10 @@
 {
-  "schema_version": 1,
-  "description": "C.1 sync dispatch KAT. Inputs: state_vault_uuid + state_highest_vector_clock + disk_vector_clock. Output: enum variant name + (where applicable) the new_state's highest_vector_clock_seen. Python clean-room replay scheduled for C.4 (cross-device convergence conformance).",
+  "schema_version": 2,
+  "description": "C.1 sync + C.1.1b merge KAT. Two vector families: (1) clock_dispatch — pure vector-clock dispatch (state_highest_vector_clock × disk_vector_clock → outcome variant); (2) concurrent_merge_apply_decisions / evidence_stale / fingerprint_repair — disk-backed three-step merge flow (sync_once → prepare_merge → commit_with_decisions) with scenario-named fixture builders. Schema bumped 1 → 2 in C.1.1b Task 16. Python clean-room replay scheduled for C.4 (issue #76).",
   "vectors": [
     {
       "name": "equal_clocks_nothing_to_do",
+      "vector_type": "clock_dispatch",
       "state_vault_uuid": "00112233445566778899AABBCCDDEEFF",
       "state_highest_vector_clock": [
         { "device_uuid": "01010101010101010101010101010101", "counter": 5 }
@@ -15,6 +16,7 @@
     },
     {
       "name": "empty_state_empty_disk_nothing_to_do",
+      "vector_type": "clock_dispatch",
       "state_vault_uuid": "00112233445566778899AABBCCDDEEFF",
       "state_highest_vector_clock": [],
       "disk_vector_clock": [],
@@ -22,6 +24,7 @@
     },
     {
       "name": "empty_state_disk_present_applied_automatically",
+      "vector_type": "clock_dispatch",
       "state_vault_uuid": "00112233445566778899AABBCCDDEEFF",
       "state_highest_vector_clock": [],
       "disk_vector_clock": [
@@ -34,6 +37,7 @@
     },
     {
       "name": "disk_strictly_ahead_applied_automatically",
+      "vector_type": "clock_dispatch",
       "state_vault_uuid": "00112233445566778899AABBCCDDEEFF",
       "state_highest_vector_clock": [
         { "device_uuid": "01010101010101010101010101010101", "counter": 5 }
@@ -48,6 +52,7 @@
     },
     {
       "name": "disk_adds_new_device_applied_automatically",
+      "vector_type": "clock_dispatch",
       "state_vault_uuid": "00112233445566778899AABBCCDDEEFF",
       "state_highest_vector_clock": [
         { "device_uuid": "01010101010101010101010101010101", "counter": 5 }
@@ -64,6 +69,7 @@
     },
     {
       "name": "disk_strictly_behind_rollback_rejected",
+      "vector_type": "clock_dispatch",
       "state_vault_uuid": "00112233445566778899AABBCCDDEEFF",
       "state_highest_vector_clock": [
         { "device_uuid": "01010101010101010101010101010101", "counter": 9 }
@@ -75,6 +81,7 @@
     },
     {
       "name": "disk_missing_seen_device_rollback_rejected",
+      "vector_type": "clock_dispatch",
       "state_vault_uuid": "00112233445566778899AABBCCDDEEFF",
       "state_highest_vector_clock": [
         { "device_uuid": "01010101010101010101010101010101", "counter": 5 },
@@ -87,6 +94,7 @@
     },
     {
       "name": "concurrent_disjoint_devices_concurrent_detected",
+      "vector_type": "clock_dispatch",
       "state_vault_uuid": "00112233445566778899AABBCCDDEEFF",
       "state_highest_vector_clock": [
         { "device_uuid": "01010101010101010101010101010101", "counter": 5 }
@@ -98,6 +106,7 @@
     },
     {
       "name": "concurrent_overlapping_devices_concurrent_detected",
+      "vector_type": "clock_dispatch",
       "state_vault_uuid": "00112233445566778899AABBCCDDEEFF",
       "state_highest_vector_clock": [
         { "device_uuid": "01010101010101010101010101010101", "counter": 5 },
@@ -108,6 +117,17 @@
         { "device_uuid": "02020202020202020202020202020202", "counter": 4 }
       ],
       "expected_outcome": "ConcurrentDetected"
+    },
+    {
+      "name": "concurrent_disjoint_blocks_no_vetoes_applied",
+      "vector_type": "concurrent_merge_apply_decisions",
+      "scenario": "no_veto",
+      "counter_canonical": 5,
+      "counter_sibling": 5,
+      "decisions": [],
+      "expected_vetoes_count": 0,
+      "expected_diverging_blocks_count": 1,
+      "expected_post_commit_outcome": "NothingToDo"
     }
   ]
 }

--- a/core/tests/data/sync_kat.json
+++ b/core/tests/data/sync_kat.json
@@ -194,6 +194,13 @@
       "counter_canonical": 5,
       "counter_sibling": 5,
       "racing_counter": 99
+    },
+    {
+      "name": "commit_block_fingerprint_mismatch_repair_via_reconverge",
+      "vector_type": "fingerprint_repair",
+      "scenario": "no_veto",
+      "counter_canonical": 5,
+      "counter_sibling": 5
     }
   ]
 }

--- a/core/tests/data/sync_kat.json
+++ b/core/tests/data/sync_kat.json
@@ -171,6 +171,21 @@
       "expected_post_commit_outcome": "NothingToDo",
       "expected_post_commit_canonical_records_count": 1,
       "expected_canonical_record_tombstoned": true
+    },
+    {
+      "name": "concurrent_two_tombstone_vetoes_mixed_decisions",
+      "vector_type": "concurrent_merge_apply_decisions",
+      "scenario": "two_veto",
+      "counter_canonical": 5,
+      "counter_sibling": 5,
+      "decisions": [
+        { "kind": "KeepLocal", "record_id": "RECORD_A_UUID" },
+        { "kind": "AcceptTombstone", "record_id": "RECORD_B_UUID" }
+      ],
+      "expected_vetoes_count": 2,
+      "expected_diverging_blocks_count": 1,
+      "expected_post_commit_outcome": "NothingToDo",
+      "expected_post_commit_canonical_records_count": 2
     }
   ]
 }

--- a/core/tests/data/sync_kat.json
+++ b/core/tests/data/sync_kat.json
@@ -186,6 +186,14 @@
       "expected_diverging_blocks_count": 1,
       "expected_post_commit_outcome": "NothingToDo",
       "expected_post_commit_canonical_records_count": 2
+    },
+    {
+      "name": "prepare_merge_stale_hash_evidence_stale",
+      "vector_type": "evidence_stale",
+      "scenario": "no_veto",
+      "counter_canonical": 5,
+      "counter_sibling": 5,
+      "racing_counter": 99
     }
   ]
 }

--- a/core/tests/data/sync_kat.json
+++ b/core/tests/data/sync_kat.json
@@ -127,7 +127,20 @@
       "decisions": [],
       "expected_vetoes_count": 0,
       "expected_diverging_blocks_count": 1,
-      "expected_post_commit_outcome": "NothingToDo"
+      "expected_post_commit_outcome": "NothingToDo",
+      "expected_post_commit_canonical_records_count": 2
+    },
+    {
+      "name": "concurrent_same_block_field_lww_no_vetoes",
+      "vector_type": "concurrent_merge_apply_decisions",
+      "scenario": "same_block_field_lww_no_veto",
+      "counter_canonical": 5,
+      "counter_sibling": 5,
+      "decisions": [],
+      "expected_vetoes_count": 0,
+      "expected_diverging_blocks_count": 1,
+      "expected_post_commit_outcome": "NothingToDo",
+      "expected_post_commit_canonical_records_count": 1
     }
   ]
 }

--- a/core/tests/data/sync_kat.json
+++ b/core/tests/data/sync_kat.json
@@ -141,6 +141,20 @@
       "expected_diverging_blocks_count": 1,
       "expected_post_commit_outcome": "NothingToDo",
       "expected_post_commit_canonical_records_count": 1
+    },
+    {
+      "name": "concurrent_one_tombstone_veto_keep_local",
+      "vector_type": "concurrent_merge_apply_decisions",
+      "scenario": "single_veto",
+      "counter_canonical": 5,
+      "counter_sibling": 5,
+      "decisions": [
+        { "kind": "KeepLocal", "record_id": "RECORD_A_UUID" }
+      ],
+      "expected_vetoes_count": 1,
+      "expected_diverging_blocks_count": 1,
+      "expected_post_commit_outcome": "NothingToDo",
+      "expected_post_commit_canonical_records_count": 1
     }
   ]
 }

--- a/core/tests/sync_kat.rs
+++ b/core/tests/sync_kat.rs
@@ -97,6 +97,15 @@ struct ConcurrentMergeApplyDecisionsVector {
     /// (record count = 2) from same-UUID-LWW merges (count = 1).
     #[serde(default)]
     expected_post_commit_canonical_records_count: Option<usize>,
+    /// Optional: the `tombstone` flag of the FIRST record in the
+    /// post-commit canonical block. Distinguishes `KeepLocal` (live —
+    /// `false`) from `AcceptTombstone` (tombstoned — `true`) at the
+    /// KAT level; the deeper field-by-field semantics (death-clock
+    /// preserved, last_mod_ms advanced) live in `sync_merge_vetoes.rs`.
+    /// Only consulted when
+    /// `expected_post_commit_canonical_records_count` is set.
+    #[serde(default)]
+    expected_canonical_record_tombstoned: Option<bool>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -112,7 +121,7 @@ struct DecisionJson {
 }
 
 const EXPECTED_SCHEMA_VERSION: u32 = 2;
-const EXPECTED_VECTOR_COUNT: usize = 12;
+const EXPECTED_VECTOR_COUNT: usize = 13;
 const UUID_LEN: usize = 16;
 
 fn hex_to_uuid(s: &str) -> [u8; UUID_LEN] {
@@ -247,6 +256,16 @@ fn replay_concurrent_merge_apply_decisions(name: &str, v: &ConcurrentMergeApplyD
             expected_count,
             "vector {name} canonical-block records count mismatch",
         );
+        if let Some(expected_tombstoned) = v.expected_canonical_record_tombstoned {
+            assert!(
+                !records.is_empty(),
+                "vector {name} expected canonical record tombstone flag but block is empty",
+            );
+            assert_eq!(
+                records[0].tombstone, expected_tombstoned,
+                "vector {name} canonical-block first record tombstone-flag mismatch",
+            );
+        }
     }
 
     // Closure property: re-running `sync_once` against the post-commit

--- a/core/tests/sync_kat.rs
+++ b/core/tests/sync_kat.rs
@@ -44,8 +44,9 @@ mod sync_helpers;
 mod sync_merge_proptest_helpers;
 
 use sync_merge_proptest_helpers::{
-    build_no_veto_fixture, build_single_veto_fixture, build_two_veto_fixture,
-    drive_sync_once_concurrent, open_identity, COMMIT_NOW_MS, RECORD_A_UUID, RECORD_B_UUID,
+    build_no_veto_fixture, build_same_block_field_lww_no_veto_fixture, build_single_veto_fixture,
+    build_two_veto_fixture, drive_sync_once_concurrent, open_identity,
+    read_canonical_block_records, COMMIT_NOW_MS, RECORD_A_UUID, RECORD_B_UUID,
 };
 
 #[derive(Debug, Deserialize)]
@@ -91,6 +92,11 @@ struct ConcurrentMergeApplyDecisionsVector {
     expected_vetoes_count: usize,
     expected_diverging_blocks_count: usize,
     expected_post_commit_outcome: String,
+    /// Optional: the number of records the canonical block holds after
+    /// commit_with_decisions returns. Distinguishes disjoint-UUID merges
+    /// (record count = 2) from same-UUID-LWW merges (count = 1).
+    #[serde(default)]
+    expected_post_commit_canonical_records_count: Option<usize>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -106,7 +112,7 @@ struct DecisionJson {
 }
 
 const EXPECTED_SCHEMA_VERSION: u32 = 2;
-const EXPECTED_VECTOR_COUNT: usize = 10;
+const EXPECTED_VECTOR_COUNT: usize = 11;
 const UUID_LEN: usize = 16;
 
 fn hex_to_uuid(s: &str) -> [u8; UUID_LEN] {
@@ -195,6 +201,9 @@ fn build_concurrent_fixture(
 ) -> (std::path::PathBuf, tempfile::TempDir, [u8; UUID_LEN]) {
     match scenario {
         "no_veto" => build_no_veto_fixture(counter_canonical, counter_sibling),
+        "same_block_field_lww_no_veto" => {
+            build_same_block_field_lww_no_veto_fixture(counter_canonical, counter_sibling)
+        }
         "single_veto" => build_single_veto_fixture(counter_canonical, counter_sibling),
         "two_veto" => build_two_veto_fixture(counter_canonical, counter_sibling),
         other => panic!("unknown scenario name: {other}"),
@@ -208,7 +217,7 @@ fn build_concurrent_fixture(
 /// `DraftMerge` shape, `commit_with_decisions` success, and the
 /// post-commit `sync_once` outcome.
 fn replay_concurrent_merge_apply_decisions(name: &str, v: &ConcurrentMergeApplyDecisionsVector) {
-    let (folder, _tmp, _block_uuid) =
+    let (folder, _tmp, block_uuid) =
         build_concurrent_fixture(&v.scenario, v.counter_canonical, v.counter_sibling);
     let identity = open_identity(&folder);
     let (bundle, plan) = drive_sync_once_concurrent(&folder);
@@ -230,6 +239,15 @@ fn replay_concurrent_merge_apply_decisions(name: &str, v: &ConcurrentMergeApplyD
     let password = fixtures::golden_vault_001_password();
     let new_state = commit_with_decisions(&folder, &password, draft, decisions, COMMIT_NOW_MS)
         .unwrap_or_else(|e| panic!("vector {name} commit_with_decisions failed: {e}"));
+
+    if let Some(expected_count) = v.expected_post_commit_canonical_records_count {
+        let records = read_canonical_block_records(&folder, block_uuid);
+        assert_eq!(
+            records.len(),
+            expected_count,
+            "vector {name} canonical-block records count mismatch",
+        );
+    }
 
     // Closure property: re-running `sync_once` against the post-commit
     // state on the now-updated disk returns the expected terminal

--- a/core/tests/sync_kat.rs
+++ b/core/tests/sync_kat.rs
@@ -154,6 +154,12 @@ const UUID_LEN: usize = 16;
 /// UUIDs (which are private to the proptest helpers) so this binary
 /// doesn't couple to those constants. Any well-formed new clock advances
 /// the on-disk manifest envelope hash off `draft.manifest_hash`.
+///
+/// Convention for this binary: `[0x99; 16]` is the dedicated "racing
+/// writer" identity for `evidence_stale`-style fixtures. Reuse it for
+/// any future vector that simulates a third device racing the commit;
+/// do not reuse it for non-racing fixture roles (pick a fresh constant
+/// instead, so the byte pattern stays a reliable signal of intent).
 const RACING_DEVICE_UUID: [u8; UUID_LEN] = [0x99; UUID_LEN];
 
 fn hex_to_uuid(s: &str) -> [u8; UUID_LEN] {
@@ -289,9 +295,18 @@ fn replay_concurrent_merge_apply_decisions(name: &str, v: &ConcurrentMergeApplyD
             "vector {name} canonical-block records count mismatch",
         );
         if let Some(expected_tombstoned) = v.expected_canonical_record_tombstoned {
-            assert!(
-                !records.is_empty(),
-                "vector {name} expected canonical record tombstone flag but block is empty",
+            // `read_canonical_block_records` does not promise a stable
+            // record ordering — `records[0]` is only an unambiguous
+            // target when the canonical block holds exactly one record.
+            // Fail loudly if a future vector pairs this field with a
+            // multi-record post-commit state; that case needs a
+            // per-record-uuid-keyed assertion shape, not `records[0]`.
+            assert_eq!(
+                records.len(),
+                1,
+                "vector {name} expected_canonical_record_tombstoned is only meaningful \
+                 when the post-commit canonical block holds exactly 1 record (got {})",
+                records.len(),
             );
             assert_eq!(
                 records[0].tombstone, expected_tombstoned,

--- a/core/tests/sync_kat.rs
+++ b/core/tests/sync_kat.rs
@@ -121,7 +121,7 @@ struct DecisionJson {
 }
 
 const EXPECTED_SCHEMA_VERSION: u32 = 2;
-const EXPECTED_VECTOR_COUNT: usize = 13;
+const EXPECTED_VECTOR_COUNT: usize = 14;
 const UUID_LEN: usize = 16;
 
 fn hex_to_uuid(s: &str) -> [u8; UUID_LEN] {

--- a/core/tests/sync_kat.rs
+++ b/core/tests/sync_kat.rs
@@ -33,8 +33,8 @@
 #![forbid(unsafe_code)]
 
 use secretary_core::sync::{
-    __test_dispatch, commit_with_decisions, prepare_merge, sync_once, RollbackEvidence,
-    SyncOutcome, SyncState, VetoDecision,
+    __test_dispatch, commit_with_decisions, compute_manifest_hash, prepare_merge, sync_once,
+    RollbackEvidence, SyncError, SyncOutcome, SyncState, VetoDecision,
 };
 use secretary_core::vault::block::VectorClockEntry;
 use serde::Deserialize;
@@ -71,6 +71,8 @@ enum VectorBody {
     ClockDispatch(ClockDispatchVector),
     #[serde(rename = "concurrent_merge_apply_decisions")]
     ConcurrentMergeApplyDecisions(ConcurrentMergeApplyDecisionsVector),
+    #[serde(rename = "evidence_stale")]
+    EvidenceStale(EvidenceStaleVector),
 }
 
 #[derive(Debug, Deserialize)]
@@ -81,6 +83,19 @@ struct ClockDispatchVector {
     expected_outcome: String,
     #[serde(default)]
     expected_new_state_clock: Option<Vec<EntryJson>>,
+}
+
+#[derive(Debug, Deserialize)]
+struct EvidenceStaleVector {
+    scenario: String,
+    counter_canonical: u64,
+    counter_sibling: u64,
+    /// New counter written into the racing manifest. The racing
+    /// manifest's clock has exactly one entry — `(RACING_DEVICE_UUID,
+    /// racing_counter)` — which is well-formed but byte-different from
+    /// the prepare-time canonical manifest envelope, forcing the
+    /// commit-time freshness re-check to fire `EvidenceStale`.
+    racing_counter: u64,
 }
 
 #[derive(Debug, Deserialize)]
@@ -121,8 +136,15 @@ struct DecisionJson {
 }
 
 const EXPECTED_SCHEMA_VERSION: u32 = 2;
-const EXPECTED_VECTOR_COUNT: usize = 14;
+const EXPECTED_VECTOR_COUNT: usize = 15;
 const UUID_LEN: usize = 16;
+
+/// Synthetic device UUID for the `evidence_stale` race-window manifest
+/// rewrite. Distinct from the fixture's canonical / sibling device
+/// UUIDs (which are private to the proptest helpers) so this binary
+/// doesn't couple to those constants. Any well-formed new clock advances
+/// the on-disk manifest envelope hash off `draft.manifest_hash`.
+const RACING_DEVICE_UUID: [u8; UUID_LEN] = [0x99; UUID_LEN];
 
 fn hex_to_uuid(s: &str) -> [u8; UUID_LEN] {
     let bytes = hex::decode(s).expect("hex");
@@ -283,6 +305,54 @@ fn replay_concurrent_merge_apply_decisions(name: &str, v: &ConcurrentMergeApplyD
     }
 }
 
+/// Replay an `evidence_stale` vector. Drives the commit-time TOCTOU
+/// freshness re-check (`commit_with_decisions` step 2): after
+/// `prepare_merge` captures the manifest hash, the canonical manifest
+/// is rewritten with a fresh well-formed clock. The subsequent commit
+/// must abort with `SyncError::EvidenceStale` and leave the manifest
+/// bytes unchanged (zero disk writes from the commit).
+fn replay_evidence_stale(name: &str, v: &EvidenceStaleVector) {
+    let (folder, _tmp, _block_uuid) =
+        build_concurrent_fixture(&v.scenario, v.counter_canonical, v.counter_sibling);
+    let identity = open_identity(&folder);
+    let (bundle, plan) = drive_sync_once_concurrent(&folder);
+
+    let draft = prepare_merge(&folder, &identity, &bundle, &plan)
+        .unwrap_or_else(|e| panic!("vector {name} prepare_merge failed: {e}"));
+
+    let racing_clock = vec![VectorClockEntry {
+        device_uuid: RACING_DEVICE_UUID,
+        counter: v.racing_counter,
+    }];
+    sync_helpers::write_manifest_at(
+        &folder,
+        sync_helpers::MANIFEST_FILENAME,
+        racing_clock,
+        &sync_helpers::SIBLING_NONCE_C,
+    );
+
+    let manifest_path = folder.join(sync_helpers::MANIFEST_FILENAME);
+    let bytes_before = std::fs::read(&manifest_path)
+        .unwrap_or_else(|e| panic!("vector {name} read manifest pre-commit failed: {e}"));
+    let hash_before = compute_manifest_hash(&bytes_before);
+
+    let password = fixtures::golden_vault_001_password();
+    let err =
+        commit_with_decisions(&folder, &password, draft, Vec::new(), COMMIT_NOW_MS).unwrap_err();
+    assert!(
+        matches!(err, SyncError::EvidenceStale),
+        "vector {name} expected SyncError::EvidenceStale, got {err:?}",
+    );
+
+    let bytes_after = std::fs::read(&manifest_path)
+        .unwrap_or_else(|e| panic!("vector {name} read manifest post-commit failed: {e}"));
+    let hash_after = compute_manifest_hash(&bytes_after);
+    assert_eq!(
+        hash_before, hash_after,
+        "vector {name} EvidenceStale must abort with NO disk writes",
+    );
+}
+
 #[test]
 fn replay_sync_kat() {
     let raw = std::fs::read_to_string("tests/data/sync_kat.json").unwrap();
@@ -298,6 +368,7 @@ fn replay_sync_kat() {
             VectorBody::ConcurrentMergeApplyDecisions(body) => {
                 replay_concurrent_merge_apply_decisions(&v.name, body)
             }
+            VectorBody::EvidenceStale(body) => replay_evidence_stale(&v.name, body),
         }
     }
 

--- a/core/tests/sync_kat.rs
+++ b/core/tests/sync_kat.rs
@@ -1,16 +1,52 @@
-//! Replay `sync_kat.json` through `__test_dispatch`. Pinned vector
-//! file — any change to the dispatch logic that changes an outcome
-//! must be accompanied by a deliberate KAT edit.
+//! Replay `sync_kat.json` through the public sync API. Pinned vector
+//! file — any change to dispatch logic that alters an outcome must be
+//! accompanied by a deliberate KAT edit.
+//!
+//! ## Vector families (schema v2)
+//!
+//! - `clock_dispatch` — pure vector-clock dispatch via the lib's
+//!   `__test_dispatch` helper. State (`state_vault_uuid` +
+//!   `state_highest_vector_clock`) × disk (`disk_vector_clock`) maps to
+//!   a `SyncOutcome` variant name. The `__test_dispatch` helper
+//!   intentionally avoids disk I/O — `ConcurrentDetected` is signalled
+//!   by `Ok(None)` and treated as a pass-through here.
+//! - `concurrent_merge_apply_decisions` — full three-step merge flow
+//!   (`sync_once → prepare_merge → commit_with_decisions`) on a
+//!   per-block-divergent fixture built by a scenario-named fixture
+//!   builder (`no_veto`, `single_veto`, `two_veto`). Decisions are
+//!   deserialised from JSON and applied verbatim.
+//! - `evidence_stale` — drives the commit-time TOCTOU re-check by
+//!   mutating the manifest between `prepare_merge` and
+//!   `commit_with_decisions`; asserts `SyncError::EvidenceStale`.
+//! - `fingerprint_repair` — simulates a partial-commit (block file
+//!   rewritten without the manifest update) and asserts that
+//!   `open_vault` fires `VaultError::BlockFingerprintMismatch`. The
+//!   recovery (idempotent reconvergence via re-running the three-step
+//!   flow) is exercised in `sync_merge_crash.rs` proper; the KAT
+//!   pins the typed-error surface only.
 //!
 //! Python clean-room replay lands in C.4 (cross-device convergence
-//! conformance), matching the staging pattern of B.6's
-//! conformance_kat.json.
+//! conformance) — see issue #76. At that point the JSON may bump to
+//! schema v3 to encode fully self-describing fixture parameters; the
+//! current v2 carries scenario-names plus expected outcome shape only.
 
 #![forbid(unsafe_code)]
 
-use secretary_core::sync::{__test_dispatch, RollbackEvidence, SyncOutcome, SyncState};
+use secretary_core::sync::{
+    __test_dispatch, commit_with_decisions, prepare_merge, sync_once, RollbackEvidence,
+    SyncOutcome, SyncState, VetoDecision,
+};
 use secretary_core::vault::block::VectorClockEntry;
 use serde::Deserialize;
+
+mod fixtures;
+mod sync_helpers;
+mod sync_merge_proptest_helpers;
+
+use sync_merge_proptest_helpers::{
+    build_no_veto_fixture, build_single_veto_fixture, build_two_veto_fixture,
+    drive_sync_once_concurrent, open_identity, COMMIT_NOW_MS, RECORD_A_UUID, RECORD_B_UUID,
+};
 
 #[derive(Debug, Deserialize)]
 struct Kat {
@@ -23,6 +59,21 @@ struct Kat {
 #[derive(Debug, Deserialize)]
 struct Vector {
     name: String,
+    #[serde(flatten)]
+    body: VectorBody,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(tag = "vector_type")]
+enum VectorBody {
+    #[serde(rename = "clock_dispatch")]
+    ClockDispatch(ClockDispatchVector),
+    #[serde(rename = "concurrent_merge_apply_decisions")]
+    ConcurrentMergeApplyDecisions(ConcurrentMergeApplyDecisionsVector),
+}
+
+#[derive(Debug, Deserialize)]
+struct ClockDispatchVector {
     state_vault_uuid: String,
     state_highest_vector_clock: Vec<EntryJson>,
     disk_vector_clock: Vec<EntryJson>,
@@ -32,13 +83,30 @@ struct Vector {
 }
 
 #[derive(Debug, Deserialize)]
+struct ConcurrentMergeApplyDecisionsVector {
+    scenario: String,
+    counter_canonical: u64,
+    counter_sibling: u64,
+    decisions: Vec<DecisionJson>,
+    expected_vetoes_count: usize,
+    expected_diverging_blocks_count: usize,
+    expected_post_commit_outcome: String,
+}
+
+#[derive(Debug, Deserialize)]
 struct EntryJson {
     device_uuid: String,
     counter: u64,
 }
 
-const EXPECTED_SCHEMA_VERSION: u32 = 1;
-const EXPECTED_VECTOR_COUNT: usize = 9;
+#[derive(Debug, Deserialize)]
+struct DecisionJson {
+    kind: String,
+    record_id: String,
+}
+
+const EXPECTED_SCHEMA_VERSION: u32 = 2;
+const EXPECTED_VECTOR_COUNT: usize = 10;
 const UUID_LEN: usize = 16;
 
 fn hex_to_uuid(s: &str) -> [u8; UUID_LEN] {
@@ -58,6 +126,126 @@ fn entries_from_json(js: &[EntryJson]) -> Vec<VectorClockEntry> {
         .collect()
 }
 
+/// Convert a JSON `DecisionJson` into a `VetoDecision`. `record_id` may
+/// be a literal 16-byte hex string OR one of the symbolic aliases
+/// (`RECORD_A_UUID`, `RECORD_B_UUID`) bound to the proptest-helper
+/// fixture constants. Symbolic aliases let scenario vectors reference
+/// records by stable name rather than hex copy.
+fn decision_from_json(d: &DecisionJson) -> VetoDecision {
+    let record_id = match d.record_id.as_str() {
+        "RECORD_A_UUID" => RECORD_A_UUID,
+        "RECORD_B_UUID" => RECORD_B_UUID,
+        hex_id => hex_to_uuid(hex_id),
+    };
+    match d.kind.as_str() {
+        "KeepLocal" => VetoDecision::KeepLocal { record_id },
+        "AcceptTombstone" => VetoDecision::AcceptTombstone { record_id },
+        other => panic!("unknown VetoDecision kind: {other}"),
+    }
+}
+
+/// Replay a `clock_dispatch` vector through the public
+/// `__test_dispatch` helper. Mirrors the v1 schema's loop body.
+fn replay_clock_dispatch(name: &str, v: &ClockDispatchVector) {
+    let state_clock = entries_from_json(&v.state_highest_vector_clock);
+    let disk_clock = entries_from_json(&v.disk_vector_clock);
+    let state = SyncState::new(hex_to_uuid(&v.state_vault_uuid), state_clock)
+        .unwrap_or_else(|e| panic!("vector {name} state invalid: {e}"));
+    let outcome_opt = __test_dispatch(disk_clock.clone(), &state)
+        .unwrap_or_else(|e| panic!("vector {name} dispatch failed: {e}"));
+
+    // `__test_dispatch` deliberately avoids disk I/O — `ConcurrentDetected`
+    // is signalled by `Ok(None)`; all other outcomes arrive as `Some(_)`.
+    let outcome = match (&outcome_opt, v.expected_outcome.as_str()) {
+        (None, "ConcurrentDetected" | "ForkDetected") => return,
+        (None, other) => {
+            panic!("vector {name} expected {other} but dispatch signalled Concurrent (None)",)
+        }
+        (Some(o), _) => o,
+    };
+
+    match (v.expected_outcome.as_str(), outcome) {
+        ("NothingToDo", SyncOutcome::NothingToDo) => {}
+        ("AppliedAutomatically", SyncOutcome::AppliedAutomatically { new_state }) => {
+            let expected = entries_from_json(
+                v.expected_new_state_clock
+                    .as_ref()
+                    .expect("AppliedAutomatically vector must carry expected_new_state_clock"),
+            );
+            assert_eq!(
+                new_state.highest_vector_clock_seen, expected,
+                "vector {name} new_state clock mismatch",
+            );
+        }
+        ("RollbackRejected", SyncOutcome::RollbackRejected(RollbackEvidence { .. })) => {}
+        (expected, actual) => {
+            panic!("vector {name} expected {expected} got {actual:?}")
+        }
+    }
+}
+
+/// Build a per-block-divergent fixture by scenario name and return the
+/// `(folder, _tmp, block_uuid)` triple. The `_tmp` handle MUST stay
+/// alive while the folder is in use — dropping it removes the temp
+/// directory.
+fn build_concurrent_fixture(
+    scenario: &str,
+    counter_canonical: u64,
+    counter_sibling: u64,
+) -> (std::path::PathBuf, tempfile::TempDir, [u8; UUID_LEN]) {
+    match scenario {
+        "no_veto" => build_no_veto_fixture(counter_canonical, counter_sibling),
+        "single_veto" => build_single_veto_fixture(counter_canonical, counter_sibling),
+        "two_veto" => build_two_veto_fixture(counter_canonical, counter_sibling),
+        other => panic!("unknown scenario name: {other}"),
+    }
+}
+
+/// Replay a `concurrent_merge_apply_decisions` vector through the full
+/// three-step merge flow. The fixture is built from
+/// `(scenario, counter_canonical, counter_sibling)`; decisions are
+/// deserialised verbatim from JSON; assertions cover the
+/// `DraftMerge` shape, `commit_with_decisions` success, and the
+/// post-commit `sync_once` outcome.
+fn replay_concurrent_merge_apply_decisions(name: &str, v: &ConcurrentMergeApplyDecisionsVector) {
+    let (folder, _tmp, _block_uuid) =
+        build_concurrent_fixture(&v.scenario, v.counter_canonical, v.counter_sibling);
+    let identity = open_identity(&folder);
+    let (bundle, plan) = drive_sync_once_concurrent(&folder);
+
+    let draft = prepare_merge(&folder, &identity, &bundle, &plan)
+        .unwrap_or_else(|e| panic!("vector {name} prepare_merge failed: {e}"));
+    assert_eq!(
+        draft.vetoes.len(),
+        v.expected_vetoes_count,
+        "vector {name} vetoes count mismatch",
+    );
+    assert_eq!(
+        draft.plan.diverging_blocks.len(),
+        v.expected_diverging_blocks_count,
+        "vector {name} diverging_blocks count mismatch",
+    );
+
+    let decisions: Vec<VetoDecision> = v.decisions.iter().map(decision_from_json).collect();
+    let password = fixtures::golden_vault_001_password();
+    let new_state = commit_with_decisions(&folder, &password, draft, decisions, COMMIT_NOW_MS)
+        .unwrap_or_else(|e| panic!("vector {name} commit_with_decisions failed: {e}"));
+
+    // Closure property: re-running `sync_once` against the post-commit
+    // state on the now-updated disk returns the expected terminal
+    // outcome. For all current vectors this is `NothingToDo` (the
+    // commit folded both manifests' clocks into the canonical, so
+    // `clock_relation` sees `Equal`).
+    let outcome2 = sync_once(&folder, &identity, &new_state, 0u64)
+        .unwrap_or_else(|e| panic!("vector {name} post-commit sync_once failed: {e}"));
+    match (v.expected_post_commit_outcome.as_str(), &outcome2) {
+        ("NothingToDo", SyncOutcome::NothingToDo) => {}
+        (expected, actual) => {
+            panic!("vector {name} expected post-commit {expected} got {actual:?}",)
+        }
+    }
+}
+
 #[test]
 fn replay_sync_kat() {
     let raw = std::fs::read_to_string("tests/data/sync_kat.json").unwrap();
@@ -68,43 +256,10 @@ fn replay_sync_kat() {
     );
 
     for v in &kat.vectors {
-        let state_clock = entries_from_json(&v.state_highest_vector_clock);
-        let disk_clock = entries_from_json(&v.disk_vector_clock);
-        let state = SyncState::new(hex_to_uuid(&v.state_vault_uuid), state_clock)
-            .unwrap_or_else(|e| panic!("vector {} state invalid: {e}", v.name));
-        let outcome_opt = __test_dispatch(disk_clock.clone(), &state)
-            .unwrap_or_else(|e| panic!("vector {} dispatch failed: {e}", v.name));
-
-        // ConcurrentDetected is signalled by `None` from the clock-only
-        // dispatch helper (the bundle-carrying outcome requires folder
-        // I/O the helper deliberately avoids). All other outcomes
-        // arrive as Some(_).
-        let outcome = match (&outcome_opt, v.expected_outcome.as_str()) {
-            (None, "ConcurrentDetected" | "ForkDetected") => continue,
-            (None, other) => panic!(
-                "vector {} expected {other} but dispatch signalled Concurrent (None)",
-                v.name
-            ),
-            (Some(o), _) => o,
-        };
-
-        match (v.expected_outcome.as_str(), outcome) {
-            ("NothingToDo", SyncOutcome::NothingToDo) => {}
-            ("AppliedAutomatically", SyncOutcome::AppliedAutomatically { new_state }) => {
-                let expected = entries_from_json(
-                    v.expected_new_state_clock
-                        .as_ref()
-                        .expect("AppliedAutomatically vector must carry expected_new_state_clock"),
-                );
-                assert_eq!(
-                    new_state.highest_vector_clock_seen, expected,
-                    "vector {} new_state clock mismatch",
-                    v.name
-                );
-            }
-            ("RollbackRejected", SyncOutcome::RollbackRejected(RollbackEvidence { .. })) => {}
-            (expected, actual) => {
-                panic!("vector {} expected {} got {:?}", v.name, expected, actual)
+        match &v.body {
+            VectorBody::ClockDispatch(body) => replay_clock_dispatch(&v.name, body),
+            VectorBody::ConcurrentMergeApplyDecisions(body) => {
+                replay_concurrent_merge_apply_decisions(&v.name, body)
             }
         }
     }

--- a/core/tests/sync_kat.rs
+++ b/core/tests/sync_kat.rs
@@ -37,6 +37,7 @@ use secretary_core::sync::{
     RollbackEvidence, SyncError, SyncOutcome, SyncState, VetoDecision,
 };
 use secretary_core::vault::block::VectorClockEntry;
+use secretary_core::vault::{open_vault, Unlocker, VaultError};
 use serde::Deserialize;
 
 mod fixtures;
@@ -73,6 +74,8 @@ enum VectorBody {
     ConcurrentMergeApplyDecisions(ConcurrentMergeApplyDecisionsVector),
     #[serde(rename = "evidence_stale")]
     EvidenceStale(EvidenceStaleVector),
+    #[serde(rename = "fingerprint_repair")]
+    FingerprintRepair(FingerprintRepairVector),
 }
 
 #[derive(Debug, Deserialize)]
@@ -83,6 +86,13 @@ struct ClockDispatchVector {
     expected_outcome: String,
     #[serde(default)]
     expected_new_state_clock: Option<Vec<EntryJson>>,
+}
+
+#[derive(Debug, Deserialize)]
+struct FingerprintRepairVector {
+    scenario: String,
+    counter_canonical: u64,
+    counter_sibling: u64,
 }
 
 #[derive(Debug, Deserialize)]
@@ -136,7 +146,7 @@ struct DecisionJson {
 }
 
 const EXPECTED_SCHEMA_VERSION: u32 = 2;
-const EXPECTED_VECTOR_COUNT: usize = 15;
+const EXPECTED_VECTOR_COUNT: usize = 16;
 const UUID_LEN: usize = 16;
 
 /// Synthetic device UUID for the `evidence_stale` race-window manifest
@@ -353,6 +363,41 @@ fn replay_evidence_stale(name: &str, v: &EvidenceStaleVector) {
     );
 }
 
+/// Replay a `fingerprint_repair` vector. Simulates a partial-commit
+/// post-condition (block file rewritten without the manifest update)
+/// by flipping a byte in the canonical block file, then asserts
+/// `open_vault` fires `VaultError::BlockFingerprintMismatch` at open
+/// time. The full crash-recovery flow (idempotent reconvergence via
+/// re-running the three-step API) is exercised by
+/// `sync_merge_crash.rs::partial_commit_recovers_via_idempotent_re_run`;
+/// this KAT pins the typed-error surface only.
+fn replay_fingerprint_repair(name: &str, v: &FingerprintRepairVector) {
+    let (folder, _tmp, block_uuid) =
+        build_concurrent_fixture(&v.scenario, v.counter_canonical, v.counter_sibling);
+
+    // Corrupt the canonical block file by flipping a single byte. The
+    // manifest still references the OLD block fingerprint; the on-disk
+    // bytes hash to a different value; `open_vault`'s eager
+    // `verify_block_fingerprints` step (Task 5) detects the mismatch.
+    let block_path = sync_helpers::block_file_path(&folder, &block_uuid);
+    let mut bytes = std::fs::read(&block_path)
+        .unwrap_or_else(|e| panic!("vector {name} read block failed: {e}"));
+    assert!(
+        !bytes.is_empty(),
+        "vector {name} block file empty; cannot corrupt",
+    );
+    bytes[0] ^= 0xFF;
+    std::fs::write(&block_path, &bytes)
+        .unwrap_or_else(|e| panic!("vector {name} write corrupted block failed: {e}"));
+
+    let password = fixtures::golden_vault_001_password();
+    let err = open_vault(&folder, Unlocker::Password(&password), None).unwrap_err();
+    assert!(
+        matches!(err, VaultError::BlockFingerprintMismatch { .. }),
+        "vector {name} expected VaultError::BlockFingerprintMismatch, got {err:?}",
+    );
+}
+
 #[test]
 fn replay_sync_kat() {
     let raw = std::fs::read_to_string("tests/data/sync_kat.json").unwrap();
@@ -369,6 +414,7 @@ fn replay_sync_kat() {
                 replay_concurrent_merge_apply_decisions(&v.name, body)
             }
             VectorBody::EvidenceStale(body) => replay_evidence_stale(&v.name, body),
+            VectorBody::FingerprintRepair(body) => replay_fingerprint_repair(&v.name, body),
         }
     }
 

--- a/core/tests/sync_kat.rs
+++ b/core/tests/sync_kat.rs
@@ -112,7 +112,7 @@ struct DecisionJson {
 }
 
 const EXPECTED_SCHEMA_VERSION: u32 = 2;
-const EXPECTED_VECTOR_COUNT: usize = 11;
+const EXPECTED_VECTOR_COUNT: usize = 12;
 const UUID_LEN: usize = 16;
 
 fn hex_to_uuid(s: &str) -> [u8; UUID_LEN] {

--- a/core/tests/sync_merge_proptest_helpers/mod.rs
+++ b/core/tests/sync_merge_proptest_helpers/mod.rs
@@ -210,6 +210,68 @@ pub fn build_no_veto_fixture(
     (folder, tmp, block_uuid)
 }
 
+/// Build a per-block-divergent fixture where canonical and sibling
+/// both modify the SAME record UUID ([`NONCONFLICTING_RECORD_CANONICAL_UUID`])
+/// with different field values and `last_mod` timestamps. The merge
+/// applies per-field LWW (`docs/crypto-design.md` §11.3) — sibling's
+/// `last_mod` strictly exceeds canonical's, so sibling's field value
+/// wins. No tombstones → `draft.vetoes` is empty.
+///
+/// The post-merge canonical block holds exactly ONE record (the LWW
+/// collapse). Consumed by sync_kat.rs vector
+/// `concurrent_same_block_field_lww_no_vetoes` to distinguish from
+/// `concurrent_disjoint_blocks_no_vetoes_applied` (whose disjoint-UUID
+/// merge yields TWO records).
+#[allow(dead_code)] // currently only consumed by sync_kat.rs.
+pub fn build_same_block_field_lww_no_veto_fixture(
+    counter_canonical: u64,
+    counter_sibling: u64,
+) -> (std::path::PathBuf, tempfile::TempDir, [u8; 16]) {
+    let (probe_folder, _probe_tmp) = sync_helpers::fresh_vault_with_clock(Vec::new());
+    let block_uuid = sync_helpers::golden_vault_001_first_block_uuid(&probe_folder);
+
+    let canonical_block_clock = vec![VectorClockEntry {
+        device_uuid: CANONICAL_DEVICE_UUID,
+        counter: 1,
+    }];
+    let sibling_block_clock = vec![VectorClockEntry {
+        device_uuid: SIBLING_DEVICE_UUID,
+        counter: 1,
+    }];
+    let canonical_manifest_clock = vec![VectorClockEntry {
+        device_uuid: CANONICAL_DEVICE_UUID,
+        counter: counter_canonical,
+    }];
+    let sibling_manifest_clock = vec![VectorClockEntry {
+        device_uuid: SIBLING_DEVICE_UUID,
+        counter: counter_sibling,
+    }];
+
+    let (folder, tmp) = sync_helpers::fresh_vault_two_concurrent_blocks(
+        block_uuid,
+        vec![live_record(
+            NONCONFLICTING_RECORD_CANONICAL_UUID,
+            CANONICAL_DEVICE_UUID,
+            LOCAL_LAST_MOD_MS,
+            "canonical",
+        )],
+        canonical_block_clock,
+        canonical_manifest_clock,
+        vec![live_record(
+            NONCONFLICTING_RECORD_CANONICAL_UUID,
+            SIBLING_DEVICE_UUID,
+            SIBLING_NONCONFLICTING_LAST_MOD_MS,
+            "sibling",
+        )],
+        sibling_block_clock,
+        sibling_manifest_clock,
+        SIBLING_MANIFEST_FILENAME,
+        SIBLING_BLOCK_SUFFIX,
+        COMMIT_NOW_MS,
+    );
+    (folder, tmp, block_uuid)
+}
+
 /// Build a per-block-divergent fixture with a SINGLE veto. The veto
 /// targets [`RECORD_A_UUID`] (canonical LIVE at
 /// [`LOCAL_LAST_MOD_MS`], sibling TOMBSTONED at

--- a/core/tests/sync_merge_proptest_helpers/mod.rs
+++ b/core/tests/sync_merge_proptest_helpers/mod.rs
@@ -1,16 +1,20 @@
-//! Shared helpers for `core/tests/sync_merge_proptest.rs`.
+//! Shared helpers for `core/tests/sync_merge_proptest.rs` AND
+//! `core/tests/sync_kat.rs` (per-block-divergent fixture builders +
+//! sync_once driver are common to both binaries).
 //!
-//! Extracted from the proptest binary to keep the proptest file under
-//! the 500-LOC project soft cap (see CLAUDE.md / repo feedback).
-//! Constants, record builders, fixture builders, and the
-//! `sync_once → ConcurrentDetected` driver all live here; the proptest
-//! file holds only the four `proptest!` blocks plus their per-property
-//! docstrings.
+//! Extracted from the proptest binary in C.1.1b Task 15 to keep the
+//! proptest file under the 500-LOC project soft cap (see CLAUDE.md /
+//! repo feedback). Re-used by `sync_kat.rs` in C.1.1b Task 16 — the
+//! KAT vectors' `concurrent_merge_apply_decisions` family builds the
+//! same fixtures via `scenario` ∈ {`no_veto`, `single_veto`,
+//! `two_veto`}.
 //!
-//! Re-exports `crate::fixtures` + `crate::sync_helpers` symbols
-//! verbatim — those modules are declared at the proptest binary's
-//! crate root, and this helper module accesses them via `crate::`
-//! (mirroring the pattern in `core/tests/sync_helpers/mod.rs`).
+//! Each consuming binary declares
+//! `mod fixtures; mod sync_helpers; mod sync_merge_proptest_helpers;`
+//! at its crate root; the `crate::fixtures` + `crate::sync_helpers`
+//! paths resolve in both binary contexts. Items unused in a given
+//! binary are flagged `#[allow(dead_code)]` (Rust's dead-code
+//! analyser runs per-binary).
 
 use std::collections::BTreeMap;
 
@@ -90,6 +94,7 @@ const SIBLING_BLOCK_SUFFIX: &str = ".sync-conflict-from-device-bb";
 /// project's reference hardware while still exploring two independent
 /// dimensions per property (typically the canonical + sibling clock
 /// counters).
+#[allow(dead_code)] // sync_kat.rs doesn't use proptest case counts.
 pub const PROPTEST_CASES: u32 = 16;
 
 /// Build a LIVE record with one field. `uuid` controls the
@@ -318,6 +323,11 @@ pub fn build_two_veto_fixture(
 /// Map a boolean choice to a [`VetoDecision`] for a given `record_id`.
 /// `true` → `KeepLocal`, `false` → `AcceptTombstone`. Used by property
 /// 3 to vary the decision kind per veto across cases.
+///
+/// sync_kat.rs deserialises its decisions directly from JSON (named
+/// `KeepLocal` / `AcceptTombstone` strings) so it doesn't consume this
+/// helper.
+#[allow(dead_code)]
 pub fn make_decision(record_id: [u8; 16], keep_local: bool) -> VetoDecision {
     if keep_local {
         VetoDecision::KeepLocal { record_id }
@@ -361,7 +371,9 @@ pub fn drive_sync_once_concurrent(folder: &std::path::Path) -> (VaultBundle, Dif
 
 /// Read the canonical block's decrypted records via a fresh `open_vault`
 /// so the caller's stale state doesn't contaminate the assertion.
-/// Consumed by properties 2 and 3.
+/// Consumed by properties 2 and 3; will be consumed by sync_kat.rs in
+/// later C.1.1b Task 16 vectors (per-record post-commit assertions).
+#[allow(dead_code)]
 pub fn read_canonical_block_records(folder: &std::path::Path, block_uuid: [u8; 16]) -> Vec<Record> {
     let password = fixtures::golden_vault_001_password();
     let open = open_vault(folder, Unlocker::Password(&password), None).expect("open_vault");

--- a/docs/handoffs/2026-05-23-c1-1b-task-16-shipped.md
+++ b/docs/handoffs/2026-05-23-c1-1b-task-16-shipped.md
@@ -1,0 +1,214 @@
+# NEXT_SESSION.md
+
+**Session date:** 2026-05-23 (implementation session — C.1.1b Task 16 of 17 shipped; 7 new KAT vectors in `core/tests/data/sync_kat.json`).
+**Status:** PR to be opened. `feature/c1-1b-task-16` carries 7 commits on top of `43f1214` (post-Task-15 main). 1 task remains (Task 17).
+
+## (1) What we shipped this session
+
+| Commit | Vector | What it adds |
+|---|---|---|
+| [`2da704e`](https://github.com/hherb/secretary/commit/2da704e) | 16.1 | **`concurrent_disjoint_blocks_no_vetoes_applied`** — schema v1 → v2 (tagged-enum dispatch). Existing 9 vectors gain `"vector_type": "clock_dispatch"`. New family `concurrent_merge_apply_decisions` drives the full three-step merge (sync_once → prepare_merge → commit_with_decisions) on a per-block-divergent fixture built by a scenario-named builder (`no_veto`, `single_veto`, `two_veto`). Vector 1 fixes `scenario = "no_veto"` + both counters = 5 + decisions = []; asserts 0 vetoes, 1 diverging block, post-commit `sync_once → NothingToDo`. Re-uses Task 15's `sync_merge_proptest_helpers/` fixture builders (now flagged shared between proptest and sync_kat binaries — `#[allow(dead_code)]` on items the KAT binary doesn't consume). |
+| [`10f433f`](https://github.com/hherb/secretary/commit/10f433f) | 16.2 | **`concurrent_same_block_field_lww_no_vetoes`** — adds fixture builder `build_same_block_field_lww_no_veto_fixture` (canonical + sibling reference SAME `record_uuid` with different `last_mod` timestamps → LWW the "k" field; no tombstones → no vetoes). New optional `expected_post_commit_canonical_records_count` JSON field — distinguishes disjoint-UUID merges (count = 2) from same-UUID-LWW merges (count = 1). Vector 1 gains the assertion-strengthening field too (`= 2`). |
+| [`57753f1`](https://github.com/hherb/secretary/commit/57753f1) | 16.3 | **`concurrent_one_tombstone_veto_keep_local`** — scenario = `single_veto` (canonical `RECORD_A` LIVE, sibling `RECORD_A` TOMBSTONED). Decision = `KeepLocal{RECORD_A_UUID}`. Post-commit block holds 1 record (live). Pure additive — scenario arm already wired by Vector 1. |
+| [`4c4d572`](https://github.com/hherb/secretary/commit/4c4d572) | 16.4 | **`concurrent_one_tombstone_veto_accept_tombstone`** — same fixture, opposite decision: `AcceptTombstone{RECORD_A_UUID}` → no-op on the merge's tombstoned record. Adds optional `expected_canonical_record_tombstoned` JSON field + assertion arm — distinguishes `KeepLocal` (live, `false`) from `AcceptTombstone` (tombstoned, `true`) at the KAT level. Vector 3's entry gains the explicit `false` value for symmetry. |
+| [`fb09d5f`](https://github.com/hherb/secretary/commit/fb09d5f) | 16.5 | **`concurrent_two_tombstone_vetoes_mixed_decisions`** — scenario = `two_veto`. Decisions = `[KeepLocal{A}, AcceptTombstone{B}]`. Post-commit canonical block holds 2 records (A live, B tombstoned). Per-record tombstone-flag distinction left to the Task-15 proptest `prop_commit_associative_under_disjoint_vetoes`; the KAT pins the multi-veto-mixed-decisions scenario shape only. |
+| [`f97949c`](https://github.com/hherb/secretary/commit/f97949c) | 16.6 | **`prepare_merge_stale_hash_evidence_stale`** — third vector_type family `evidence_stale`. Drives the commit-time TOCTOU re-check by mutating the canonical manifest between `prepare_merge` (which captures `draft.manifest_hash`) and `commit_with_decisions` (which re-reads the envelope and re-hashes); asserts `SyncError::EvidenceStale` AND zero post-commit disk writes (manifest BLAKE3 byte-identical pre/post). New constant `RACING_DEVICE_UUID = [0x99; 16]` decouples the racing clock from the fixture helpers' private device-UUID constants. The matching integration test (`sync_merge.rs::commit_with_decisions_stale_manifest_hash_aborts_with_no_disk_writes`) uses a simpler no-per-block-divergence fixture; this KAT widens coverage to the per-block-divergent fixture path. |
+| [`08149f9`](https://github.com/hherb/secretary/commit/08149f9) | 16.7 | **`commit_block_fingerprint_mismatch_repair_via_reconverge`** — fourth vector_type family `fingerprint_repair`. Simulates a partial-commit post-condition by flipping a single byte in the canonical block file (manifest still references the OLD fingerprint; on-disk bytes hash to a different value); asserts `open_vault` fires `VaultError::BlockFingerprintMismatch` at open time via Task 5's eager `verify_block_fingerprints` step. Full recovery flow (idempotent reconvergence via re-running the three-step API) is exercised by `sync_merge_crash.rs::partial_commit_recovers_via_idempotent_re_run` (Task 14); this KAT pins the typed-error surface only. |
+
+**Branch hygiene:** This session opened on `feature/c1-1b-task-16` (fresh branch from `43f1214` post-Task-15 main). Local branch carries exactly 7 new commits on top of `43f1214`.
+
+**Gauntlet on `feature/c1-1b-task-16` after Task 16:**
+
+- `cargo test --release --workspace --no-fail-fast` → **800 / 0 / 10** (unchanged from Task 15 baseline — `replay_sync_kat` is one `#[test]` that iterates all 16 vectors internally; the new vectors are absorbed into the existing test loop, matching the design doc's "7 KAT vectors absorbed" growth target).
+- `cargo clippy --release --workspace --tests -- -D warnings` → clean.
+- `cargo fmt --all -- --check` → clean.
+- `uv run core/tests/python/conformance.py` → PASS.
+- `uv run core/tests/python/spec_test_name_freshness.py` → PASS (96 resolved / 0 unresolved / 2 suppressed).
+
+## (2) What's next — execute Task 17
+
+### (a) First action next session: execute Task 17 (after PR for Task 16 merges)
+
+Open the plan at [`docs/superpowers/plans/2026-05-18-c1-1b-sync-merge.md`](docs/superpowers/plans/2026-05-18-c1-1b-sync-merge.md) → **Task 17 — README + ROADMAP + NEXT_SESSION updates + final gauntlet + open PR**.
+
+Task 17 closes the C.1.1b loop:
+1. **README.md** — Update the Sub-project C row's status: C.1.1b ✅ (currently "C.1.1b will add merge + veto").
+2. **ROADMAP.md** — Mark C.1.1b ✅ in the Sub-project C section (line 30); advance the progress bar one tick. Add a C.1.1b row under the C.1.1a row at line 165.
+3. **NEXT_SESSION.md** baton — close the C.1.1b track and pivot to whatever's next (C.2 CLI? Another C.1 slice?).
+4. **Handoff snapshot** under `docs/handoffs/`.
+5. **Final gauntlet** — full workspace test + clippy + fmt + conformance + freshness, all clean.
+6. **Open PR** for Task 17's docs commit.
+
+```bash
+cd /Users/hherb/src/secretary/.worktrees/c1-1b-sync-merge
+# AFTER Task 16's PR merges:
+git fetch --prune origin
+git checkout -b feature/c1-1b-task-17 origin/main
+$EDITOR docs/superpowers/plans/2026-05-18-c1-1b-sync-merge.md   # jump to "Task 17"
+```
+
+### (b) Plan structure at a glance (1 remaining of 17)
+
+| Task | What it builds | New / modified files |
+|---|---|---|
+| ~~1-10~~ | ~~Tasks 1-10 shipped~~ ✅ in PRs #84-#97 |
+| ~~11~~ | ~~`commit_with_decisions` + DraftMerge per-block + commit/ split + happy-path test~~ ✅ PR #99 |
+| ~~12~~ | ~~`EvidenceStale` integration test~~ ✅ PR #102 |
+| ~~13~~ | ~~Veto handling (KeepLocal / AcceptTombstone / Missing+Unknown bijection)~~ ✅ PR #104 |
+| ~~14~~ | ~~Crash-recovery test (partial-write reconverge — D6 proof)~~ ✅ PR #106 |
+| ~~15~~ | ~~4 property tests + helpers split~~ ✅ PR #107 |
+| ~~16~~ | ~~7 KAT vectors + replay extension~~ ✅ this session (7 commits, PR pending) |
+| **17** | **README + ROADMAP + NEXT_SESSION baton + handoff snapshot + final gauntlet + open PR** | `README.md`, `ROADMAP.md`, `NEXT_SESSION.md`, `docs/handoffs/*` |
+
+### (c) Acceptance criteria for the C.1.1b PR (final)
+
+- [x] `cargo test --release --workspace --no-fail-fast` → 766+ / 0 / 10 (currently 800 / 0 / 10 — well above the floor)
+- [x] `cargo clippy --release --workspace --tests -- -D warnings` → clean
+- [x] `cargo fmt --all -- --check` → clean
+- [x] `uv run core/tests/python/conformance.py` → PASS
+- [x] `uv run core/tests/python/spec_test_name_freshness.py` → PASS (no unresolved citations)
+- [x] `verify_block_fingerprints` runs eagerly in `open_vault`; corrupted-block test fires `VaultError::BlockFingerprintMismatch` ✅ Task 5 (KAT-pinned by Vector 7)
+- [x] `DraftMerge` / `RecordTombstoneVeto` / `VetoDecision` defined with zeroize discipline + module tests ✅ Task 6
+- [x] `tombstone_veto_set` pure helper with 7 table tests ✅ Task 7
+- [x] `prepare_merge` orchestrator wires decap + iterative fold + veto detection + post_merge_clock ✅ Task 8
+- [x] `rewrite_block_with_records_and_update_manifest` helper exists; post-rewrite vault opens cleanly under D6 ✅ Task 9
+- [x] `apply_decisions` pure helper enforces `vetoes ↔ decisions` bijection ✅ Task 10
+- [x] `commit_with_decisions` re-opens vault, freshness-checks manifest hash, applies decisions, re-encrypts diverging blocks, atomic block-first manifest-last write ✅ Task 11
+- [x] `EvidenceStale` integration test fires on stale manifest_hash + asserts NO disk writes ✅ Task 12 (KAT-pinned by Vector 6)
+- [x] **Bijection: `MissingVetoDecision` + `UnknownVetoDecision` typed errors fire on every non-bijective `(vetoes, decisions)` pair — disk-side proof** ✅ Tasks 13.3 + 13.4
+- [x] **`KeepLocal` and `AcceptTombstone` decisions persist correctly to disk** ✅ Tasks 13.1 + 13.2 (KAT-pinned by Vectors 3 + 4)
+- [x] **Crash-recovery test (Task 14) proves CRDT-idempotent reconvergence after partial commit** ✅ Task 14 (typed-error surface KAT-pinned by Vector 7)
+- [x] **All four merge-layer proptests pass (post-commit fixpoint, deterministic merge, decision-order independence, bijection enforcement)** ✅ Task 15
+- [x] **All four CRDT proptests (commutativity, associativity, idempotence, well-formedness) still pass — must not weaken.** Task 16 did not touch `core/src/vault/conflict.rs`. ✅
+- [x] **7 new KAT vectors in `core/tests/data/sync_kat.json` (9 → 16); replay extended in `core/tests/sync_kat.rs` via tagged-enum dispatch over `vector_type`** ✅ Task 16
+- [ ] **Task 17:** README + ROADMAP + NEXT_SESSION baton updates marking C.1.1b complete; final gauntlet; open C.1.1b cumulative PR. Also: grep every `#[allow(dead_code)]` introduced in Tasks 1-10 / 15 and confirm each has at least one real consumer in Tasks 11-16. `BLOCK_NONCE_G` + `fresh_vault_four_concurrent_manifests` still `#[allow(dead_code)]` — not consumed by Tasks 15 or 16. File as cleanup follow-ups if Task 17 doesn't claim them.
+
+## (3) Open decisions and risks
+
+### Implementer-call decisions from this session
+
+- **Schema v1 → v2 bump.** The existing 9 clock-dispatch vectors gained explicit `"vector_type": "clock_dispatch"` and the new 7 vectors split across three new families (`concurrent_merge_apply_decisions`, `evidence_stale`, `fingerprint_repair`). Reviewer's call: confirm the tagged-enum shape (one struct per variant, `#[serde(flatten)]` for the common `name` field, `#[serde(tag = "vector_type")]` for variant dispatch). The current schema is friendly to additive extension (new vector_type variants append to the enum + dispatcher); breaking field rename within a variant would warrant a schema_version bump to 3.
+- **Per-binary helper reuse vs duplication.** Vector 1 reused Task 15's `sync_merge_proptest_helpers/` from the `sync_kat` binary by adding `mod sync_merge_proptest_helpers;` at the binary's crate root. The module's docstring was extended to reflect dual-binary use; `#[allow(dead_code)]` annotations added to items the KAT binary doesn't consume (`PROPTEST_CASES`, `make_decision`). Vector 2 added a new helper `build_same_block_field_lww_no_veto_fixture` in the same shared module. Reviewer's call: confirm shared-helper reuse over a duplicate `sync_kat_helpers/` directory module — this baton's choice prefers shared (DRY) since the helpers are pure, generic, and currently exercised by both binaries.
+- **`RACING_DEVICE_UUID = [0x99; 16]`.** The `evidence_stale` vector replaces the canonical manifest's clock with a single-entry `(RACING_DEVICE_UUID, racing_counter)`. Distinct from the fixture helpers' private `CANONICAL_DEVICE_UUID = [0x0A; 16]` / `SIBLING_DEVICE_UUID = [0x0B; 16]`. The decoupling means the KAT binary doesn't need to know the fixture's internal device UUID constants — any well-formed manifest with a different envelope hash forces `EvidenceStale`. The existing `commit_with_decisions_stale_manifest_hash_aborts_with_no_disk_writes` integration test uses `device_canonical = [0x0A; 16]` with `counter = 99`; both approaches force the same typed error.
+- **`expected_post_commit_canonical_records_count` + `expected_canonical_record_tombstoned` schema additions.** Both are `Option<…>` (default `None`). Adding new optional assertion fields is forward-compatible — vectors that don't set them skip the corresponding assertion. Vector 1 (initially shape-only) was retro-strengthened in Vector 2's commit with `expected_post_commit_canonical_records_count: 2`; Vector 3 was retro-strengthened in Vector 4's commit with `expected_canonical_record_tombstoned: false`. The pattern: when a new assertion field is introduced for a NEW vector, prior vectors of the same family may gain the field too if the value is non-ambiguous and forward-only.
+- **Vector 5 omits per-record assertions.** The multi-record case (2 records post-merge, one live and one tombstoned) makes `expected_canonical_record_tombstoned` ambiguous (which record's tombstone flag?). A per-uuid-keyed assertion shape would carry more weight but adds JSON complexity; the proptest `prop_commit_associative_under_disjoint_vetoes` already covers per-record decision-application across both decision orderings. Decision: omit the field for Vector 5; the records-count assertion (= 2) + vetoes count (= 2) are enough KAT-level shape distinction.
+- **`fingerprint_repair` KAT pins typed-error surface only.** The full recovery flow (idempotent reconvergence via re-running the three-step API on a partial-commit fixture) is the integration test `sync_merge_crash.rs::partial_commit_recovers_via_idempotent_re_run` (Task 14, 327 LOC test body); the KAT pins only the `VaultError::BlockFingerprintMismatch` open-time surface. Doubling the integration test's coverage in JSON would be 100+ LOC of dispatcher code with no semantic gain.
+
+### Carry-over from earlier PRs (still live)
+
+- **PR #99 in-PR refactor (`1193072`)** — `MANIFEST_FILENAME` consolidation already merged.
+- **PRs #102, #104, #106, #107** — already merged.
+- **Implementer-call decisions from Task 12/13/14/15 batons still live:**
+  - #1 `commit_with_decisions` identity argument: stays `&SecretBytes`, re-opens internally.
+  - #2 `DraftMerge.per_block_clocks` + `per_block_records` shape: frozen, no change this session.
+  - #3 `extract_vault_uuid` helper duplication: closed in PR #104 (`63b32a7`).
+  - #4 `sync_helpers/mod.rs` file size: still 1174 LOC, unchanged this session. Track via [#95](https://github.com/hherb/secretary/issues/95).
+  - #5 `commit/` directory split (PR #99): no change this session — Task 16 is tests-only, didn't touch `commit/write.rs`.
+  - #6 `prepare.rs` file size (~890 LOC post-Task-13): unchanged this session.
+  - #7 `sync_merge_vetoes.rs` is a new test binary (Task 13): no change this session.
+  - #8 `sync_merge_crash.rs` is a new test binary (Task 14): no change this session.
+  - #9 `sync_merge_proptest.rs` + `sync_merge_proptest_helpers/` (Task 15): the helpers module now serves both proptest and sync_kat binaries (`#[allow(dead_code)]` annotations added in Vector 1's commit).
+
+### Implementer's-call decisions (live for Task 17)
+
+1. **`commit_with_decisions` identity argument.** Unchanged.
+2. **`DraftMerge` shape.** Unchanged.
+3. **Veto-pass iteration source.** Unchanged from Task 13.1.
+4. **`sync_helpers/mod.rs` file size.** 1174 LOC. Past the 800 trigger but [#95](https://github.com/hherb/secretary/issues/95) stays the umbrella for the split refactor.
+5. **`commit/` directory split.** Unchanged.
+6. **`prepare.rs` file size.** ~890 LOC. Still in the "tracking issue at C.1.1b close" bucket.
+7. **New test binaries per concern.** Pattern continues — Task 14 = `sync_merge_crash.rs`, Task 15 = `sync_merge_proptest.rs` (+ `sync_merge_proptest_helpers/`), Task 16 extends existing `sync_kat.rs` per the plan (no new binary).
+8. **Property file LOC ceiling.** Confirmed in Task 15. Carried forward.
+9. **`sync_kat.rs` file size.** ~290 LOC post-Task-16 (was 117 pre-Task-16). Comfortably under the 500-LOC cap; no split needed.
+
+### Risks (from the design doc, restated for plan execution)
+
+- **`DraftMerge` zeroize discipline** — unchanged this session (no production code touched).
+- **AEAD nonce per rewrite** — unchanged. Vector 6's racing manifest uses `SIBLING_NONCE_C` (distinct from canonical's `CANONICAL_NONCE_A`); the helpers' nonce discipline holds.
+- **`tempfile` exact pin** (`=3.27.0`) — unchanged this session.
+- **CRDT proptests must not weaken** — Task 16's tests do NOT touch `core/src/vault/conflict.rs`. Confirmed via gauntlet: 4 conflict proptests still pass.
+- **`SyncOutcome::ConcurrentDetected` is large** — unchanged.
+- **Exhaustive `VaultError` matchers in `secretary-ffi-bridge`** — no new core variants this session.
+- **File size of `core/src/sync/commit/write.rs`** — 389 LOC (unchanged). Task 16 is tests-only.
+- **File size of `core/src/sync/prepare.rs`** — ~890 LOC (unchanged this session).
+- **File size of `core/tests/sync_helpers/mod.rs`** — 1174 LOC. See [#95](https://github.com/hherb/secretary/issues/95).
+- **File size of `core/tests/sync_merge_vetoes.rs`** — 499 LOC (unchanged this session).
+- **File size of `core/tests/sync_merge_crash.rs`** — 327 LOC (unchanged this session).
+- **File size of `core/tests/sync_merge_proptest.rs`** — 391 LOC (unchanged this session).
+- **File size of `core/tests/sync_merge_proptest_helpers/mod.rs`** — ~430 LOC post-Task-16 (was 370 LOC post-Task-15, +60 LOC for `build_same_block_field_lww_no_veto_fixture`). Comfortable margin.
+- **File size of `core/tests/sync_kat.rs`** — ~290 LOC post-Task-16 (was 117 LOC pre-Task-16). Comfortable margin.
+- **File size of `core/src/vault/orchestrators.rs`** — ~2180 LOC (unchanged). Pre-existing.
+
+### Issues currently open
+
+- **[#37](https://github.com/hherb/secretary/issues/37)** — Sub-project C design discipline umbrella. C.1.1b closes the merge-layer portion at Task 17.
+- **[#38](https://github.com/hherb/secretary/issues/38)** — `save_block` proptest case-count budget.
+- **[#45](https://github.com/hherb/secretary/issues/45)** — three `pub(crate) #[allow(dead_code)]` accessors on `OpenVaultManifest`.
+- **[#75](https://github.com/hherb/secretary/issues/75)** — replace `#[doc(hidden)] pub __test_dispatch` with `pub(crate)` + lib-internal tests.
+- **[#76](https://github.com/hherb/secretary/issues/76)** — Python clean-room replay of `sync_kat.json`. Task 16's 7 new vectors join when #76 lands. The current Rust-side replay carries the scenario-name + expected-outcome shape; Python will either re-encode the scenarios in code (option B), or the schema bumps to v3 with fully self-describing fixture parameters (option A). Choice deferred to #76.
+- **[#78](https://github.com/hherb/secretary/issues/78)** — C.1.1a integration-test gaps.
+- **[#79](https://github.com/hherb/secretary/issues/79)** — sync_kat.json ingestion vectors.
+- **[#81](https://github.com/hherb/secretary/issues/81)** — `MAX_BLOCK_FILE_SIZE` undocumented vs format-max recipient table.
+- **[#87](https://github.com/hherb/secretary/issues/87)** — dedup `golden_vault_001_password` reader.
+- **[#88](https://github.com/hherb/secretary/issues/88)** — `VaultError::Io` does not carry the failing block UUID on fingerprint-check I/O failures.
+- **[#90](https://github.com/hherb/secretary/issues/90)** — consolidate four `copy_dir_recursive` test-helper copies.
+- **[#95](https://github.com/hherb/secretary/issues/95)** — split `core/tests/sync_helpers/mod.rs`.
+- **[#98](https://github.com/hherb/secretary/issues/98)** — `apply_decisions` duplicate-decision tightening.
+- **[#103](https://github.com/hherb/secretary/issues/103)** — Task 12 follow-on: EvidenceStale abort beats step 5's per-block rewrites on a divergence-bearing fixture. Vector 6 partially exercises this (per-block-divergent fixture → EvidenceStale aborts cleanly with no disk writes); #103 may be closeable at Task 17 review.
+
+### Open PRs at close
+
+**To be opened at end of this session** — `feature/c1-1b-task-16` carries 7 commits + this baton commit on top of `43f1214`. PR body will reference this baton.
+
+## (4) Exact commands to resume
+
+```bash
+cd /Users/hherb/src/secretary
+git fetch --prune origin
+git status --short                                              # expect: clean
+git worktree list                                               # expect: main + .worktrees/c1-1b-sync-merge
+
+cd .worktrees/c1-1b-sync-merge
+pwd                                                             # confirm worktree
+git branch --show-current                                       # → feature/c1-1b-task-16 (this session's branch)
+git log --oneline -10                                           # last 10: baton + 7 task commits + main HEAD
+
+# Baseline gauntlet (expect 800 / 0 / 10 on this branch BEFORE Task 17 starts):
+cargo test --release --workspace --no-fail-fast 2>&1 | grep -E "^test result:" | awk '{passed+=$4; failed+=$6; ignored+=$8} END {print "PASSED:", passed, "FAILED:", failed, "IGNORED:", ignored}'
+cargo clippy --release --workspace --tests -- -D warnings 2>&1 | tail -3
+cargo fmt --all -- --check
+uv run core/tests/python/conformance.py 2>&1 | tail -3
+uv run core/tests/python/spec_test_name_freshness.py 2>&1 | tail -3
+
+# AFTER Task 16's PR merges, switch to a fresh task branch + open the plan for Task 17:
+git fetch --prune origin
+git checkout -b feature/c1-1b-task-17 origin/main
+$EDITOR docs/superpowers/plans/2026-05-18-c1-1b-sync-merge.md   # jump to "Task 17"
+```
+
+## Closing inventory
+
+- **Branch state on close:** `main` at `43f1214` (PR #107 squash-merged Task 15). `feature/c1-1b-task-16` carries 7 new commits on top of `43f1214` (7 vector commits) + this baton commit.
+- **Workspace tests on `feature/c1-1b-task-16`:** 800 passed + 10 ignored (no growth from new `#[test]` functions — the 7 vectors absorb into the existing `replay_sync_kat` iteration). Clippy + fmt + Python conformance + spec-citation freshness all clean.
+- **README.md:** unchanged this session. Per plan Task 17, updates land at end of C.1.1b.
+- **ROADMAP.md:** unchanged this session. Per plan Task 17, updates land at end of C.1.1b.
+- **CLAUDE.md:** unchanged this session.
+- **Open issues:** [#37](https://github.com/hherb/secretary/issues/37) / [#38](https://github.com/hherb/secretary/issues/38) / [#45](https://github.com/hherb/secretary/issues/45) / [#75](https://github.com/hherb/secretary/issues/75) / [#76](https://github.com/hherb/secretary/issues/76) / [#78](https://github.com/hherb/secretary/issues/78) / [#79](https://github.com/hherb/secretary/issues/79) / [#81](https://github.com/hherb/secretary/issues/81) / [#87](https://github.com/hherb/secretary/issues/87) / [#88](https://github.com/hherb/secretary/issues/88) / [#90](https://github.com/hherb/secretary/issues/90) / [#95](https://github.com/hherb/secretary/issues/95) / [#98](https://github.com/hherb/secretary/issues/98) / [#103](https://github.com/hherb/secretary/issues/103).
+- **Open PRs:** one to be opened at end of this session covering Task 16.
+- **Worktrees on disk:** `main` + `.worktrees/c1-1b-sync-merge` (this session's branch lives in the same worktree directory — branch name decoupled from path).
+- **Frozen baton snapshots:**
+  - [`docs/handoffs/2026-05-19-c1-1b-tasks-1-3-shipped.md`](docs/handoffs/2026-05-19-c1-1b-tasks-1-3-shipped.md) — Tasks 1-3 close.
+  - [`docs/handoffs/2026-05-19-c1-1b-pr-84-review-fixes.md`](docs/handoffs/2026-05-19-c1-1b-pr-84-review-fixes.md) — PR #84 review-fix cycle.
+  - [`docs/handoffs/2026-05-19-c1-1b-task-4-shipped.md`](docs/handoffs/2026-05-19-c1-1b-task-4-shipped.md) — Task 4 close.
+  - [`docs/handoffs/2026-05-19-c1-1b-task-5-shipped.md`](docs/handoffs/2026-05-19-c1-1b-task-5-shipped.md) — Task 5 close.
+  - [`docs/handoffs/2026-05-19-c1-1b-task-6-shipped.md`](docs/handoffs/2026-05-19-c1-1b-task-6-shipped.md) — Task 6 close.
+  - [`docs/handoffs/2026-05-19-c1-1b-task-7-shipped.md`](docs/handoffs/2026-05-19-c1-1b-task-7-shipped.md) — Task 7 close.
+  - [`docs/handoffs/2026-05-19-c1-1b-task-8-shipped.md`](docs/handoffs/2026-05-19-c1-1b-task-8-shipped.md) — Task 8 close.
+  - [`docs/handoffs/2026-05-19-c1-1b-task-9-shipped.md`](docs/handoffs/2026-05-19-c1-1b-task-9-shipped.md) — Task 9 close.
+  - [`docs/handoffs/2026-05-19-c1-1b-task-10-shipped.md`](docs/handoffs/2026-05-19-c1-1b-task-10-shipped.md) — Task 10 close.
+  - [`docs/handoffs/2026-05-20-c1-1b-task-11-shipped.md`](docs/handoffs/2026-05-20-c1-1b-task-11-shipped.md) — Task 11 close.
+  - [`docs/handoffs/2026-05-20-c1-1b-task-12-shipped.md`](docs/handoffs/2026-05-20-c1-1b-task-12-shipped.md) — Task 12 close.
+  - [`docs/handoffs/2026-05-21-c1-1b-task-13-shipped.md`](docs/handoffs/2026-05-21-c1-1b-task-13-shipped.md) — Task 13 close.
+  - [`docs/handoffs/2026-05-22-c1-1b-task-14-shipped.md`](docs/handoffs/2026-05-22-c1-1b-task-14-shipped.md) — Task 14 close.
+  - [`docs/handoffs/2026-05-22-c1-1b-task-15-shipped.md`](docs/handoffs/2026-05-22-c1-1b-task-15-shipped.md) — Task 15 close.
+  - [`docs/handoffs/2026-05-23-c1-1b-task-16-shipped.md`](docs/handoffs/2026-05-23-c1-1b-task-16-shipped.md) — Task 16 close (this session).


### PR DESCRIPTION
## Summary

- Adds **7 new KAT vectors** to `core/tests/data/sync_kat.json` (9 → 16) covering the C.1.1b merge surface: per-block divergent merges with / without vetoes, decision-application (KeepLocal / AcceptTombstone, mixed), the commit-time TOCTOU `EvidenceStale` re-check, and the partial-commit `BlockFingerprintMismatch` typed-error surface.
- Bumps **schema v1 → v2**: introduces a tagged-enum dispatch on `vector_type`. Existing 9 vectors gain `"vector_type": "clock_dispatch"` verbatim; the new 7 vectors split across three new families:
  - `concurrent_merge_apply_decisions` (vectors 1–5) — full three-step merge flow on a per-block-divergent fixture built by a scenario-named fixture builder (`no_veto`, `same_block_field_lww_no_veto`, `single_veto`, `two_veto`); decisions deserialised verbatim from JSON;
  - `evidence_stale` (vector 6) — drives the commit-time freshness re-check by mutating the manifest between `prepare_merge` and `commit_with_decisions`;
  - `fingerprint_repair` (vector 7) — flips a byte in the canonical block file, asserts `VaultError::BlockFingerprintMismatch` at `open_vault` time.
- Re-uses Task 15's `sync_merge_proptest_helpers/` from the sync_kat binary (shared between proptest + sync_kat); adds one new fixture builder `build_same_block_field_lww_no_veto_fixture` (canonical + sibling same `record_uuid`, different `last_mod` → LWW the "k" field).
- Per `feedback_next_session_in_pr`, the rolling NEXT_SESSION baton ships **inside** this PR (commit `6b2ea7e`); a parallel sync commit on `main` (`5a2cf62`) keeps `/nextsession` from main coherent during the PR-open pause window.

Plan: [`docs/superpowers/plans/2026-05-18-c1-1b-sync-merge.md`](docs/superpowers/plans/2026-05-18-c1-1b-sync-merge.md) → Task 16. Spec: [`docs/superpowers/specs/2026-05-18-c1-1b-sync-merge-design.md`](docs/superpowers/specs/2026-05-18-c1-1b-sync-merge-design.md) §"KAT vectors". Baton: [`NEXT_SESSION.md`](NEXT_SESSION.md) → [`docs/handoffs/2026-05-23-c1-1b-task-16-shipped.md`](docs/handoffs/2026-05-23-c1-1b-task-16-shipped.md).

## Test plan

- [x] `cargo test --release --workspace --no-fail-fast` → **800 / 0 / 10** (Task 15 baseline; the 7 new vectors absorb into the existing `replay_sync_kat` iteration — they don't add `#[test]` count, matching the design doc's "7 KAT vectors absorbed into existing replay loop" growth target).
- [x] `cargo clippy --release --workspace --tests -- -D warnings` — clean.
- [x] `cargo fmt --all -- --check` — clean.
- [x] `uv run core/tests/python/conformance.py` — PASS.
- [x] `uv run core/tests/python/spec_test_name_freshness.py` — PASS (96 resolved / 0 unresolved / 2 suppressed).

## Commits

1. `2da704e` — vector 1 (`concurrent_disjoint_blocks_no_vetoes_applied`) — schema v1 → v2 tagged-enum dispatch + first vector.
2. `10f433f` — vector 2 (`concurrent_same_block_field_lww_no_vetoes`) — new fixture builder + `expected_post_commit_canonical_records_count`.
3. `57753f1` — vector 3 (`concurrent_one_tombstone_veto_keep_local`) — pure additive on `single_veto` scenario.
4. `4c4d572` — vector 4 (`concurrent_one_tombstone_veto_accept_tombstone`) — adds `expected_canonical_record_tombstoned` field.
5. `fb09d5f` — vector 5 (`concurrent_two_tombstone_vetoes_mixed_decisions`) — `two_veto` scenario + mixed decisions.
6. `f97949c` — vector 6 (`prepare_merge_stale_hash_evidence_stale`) — new family `evidence_stale` + `RACING_DEVICE_UUID`.
7. `08149f9` — vector 7 (`commit_block_fingerprint_mismatch_repair_via_reconverge`) — new family `fingerprint_repair`.
8. `6b2ea7e` — baton + retargeted symlink.

## Risk acknowledgements

- **CRDT proptests not weakened** — Task 16 did not touch `core/src/vault/conflict.rs`; the four CRDT proptests (commutativity, associativity, idempotence, well-formedness) still pass.
- **AEAD nonce per rewrite** — Vector 6's racing manifest uses `SIBLING_NONCE_C` (distinct from canonical's `CANONICAL_NONCE_A`); the helpers' nonce discipline holds.
- **`tempfile` exact pin** (`=3.27.0`) — unchanged.
- **Schema v2 is forward-additive** — new `vector_type` variants can be appended to the enum + dispatcher without bumping the schema_version. A breaking field rename within a variant would warrant a bump to v3 (anticipated when [#76](https://github.com/hherb/secretary/issues/76) lands the Python clean-room replay; the JSON may then carry fully self-describing fixture parameters).