### PR TITLE
C.2 Task 1 — scaffold cli/ workspace member + exit codes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -734,13 +734,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "fs2"
-version = "0.4.3"
+name = "fs4"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
+checksum = "7e72ed92b67c146290f88e9c89d60ca163ea417a446f61ffd7b72df3e7f1dfd5"
 dependencies = [
- "libc",
- "winapi",
+ "rustix",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1616,7 +1616,7 @@ dependencies = [
  "assert_cmd",
  "clap",
  "dirs",
- "fs2",
+ "fs4",
  "notify",
  "predicates",
  "rpassword",
@@ -2407,22 +2407,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "winapi"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
-dependencies = [
- "winapi-i686-pc-windows-gnu",
- "winapi-x86_64-pc-windows-gnu",
-]
-
-[[package]]
-name = "winapi-i686-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
-
-[[package]]
 name = "winapi-util"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2430,12 +2414,6 @@ checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
  "windows-sys 0.61.2",
 ]
-
-[[package]]
-name = "winapi-x86_64-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-link"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,10 +13,63 @@ dependencies = [
 ]
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "anstream"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
 name = "anstyle"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
+
+[[package]]
+name = "anstyle-parse"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "anyhow"
@@ -91,6 +144,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "assert_cmd"
+version = "2.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2aa3a22042e45de04255c7bf3626e239f450200fd0493c1e382263544b20aea6"
+dependencies = [
+ "anstyle",
+ "bstr",
+ "libc",
+ "predicates",
+ "predicates-core",
+ "predicates-tree",
+ "wait-timeout",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -155,6 +223,12 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
 version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
@@ -201,6 +275,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "bstr"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab"
+dependencies = [
+ "memchr",
+ "regex-automata",
+ "serde",
+]
+
+[[package]]
 name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -235,7 +320,7 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -332,6 +417,7 @@ version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
 dependencies = [
+ "anstream",
  "anstyle",
  "clap_lex",
  "strsim",
@@ -360,6 +446,12 @@ name = "cmov"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f88a43d011fc4a6876cb7344703e297c71dda42494fee094d5f7c76bf13f746"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "const-oid"
@@ -396,6 +488,21 @@ checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crunchy"
@@ -480,6 +587,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "difflib"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -498,6 +611,27 @@ checksum = "4850db49bf08e663084f7fb5c87d202ef91a3907271aff24a94eb97ff039153c"
 dependencies = [
  "block-buffer 0.12.0",
  "crypto-common 0.2.1",
+]
+
+[[package]]
+name = "dirs"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -538,7 +672,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -554,10 +688,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
+name = "filetime"
+version = "0.2.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c287a33c7f0a620c38e641e7f60827713987b3c0f26e8ddc9462cc69cf75759"
+dependencies = [
+ "cfg-if",
+ "libc",
+]
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "float-cmp"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b09cf3155332e944990140d967ff5eceb70df778b34f77d8075db46e4704e6d8"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "fnv"
@@ -578,6 +731,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "88a41f105fe1d5b6b34b2055e3dc59bb79b46b48b2040b9e6c7b4b5de097aa41"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "fs2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
+name = "fsevent-sys"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76ee7a02da4d231650c7cea31349b889be2f45ddb3ef3032d2ec8185f6313fd2"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -746,6 +918,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "inotify"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8069d3ec154eb856955c1c0fbffefbf5f3c40a104ec912d4797314c1801abff"
+dependencies = [
+ "bitflags 1.3.2",
+ "inotify-sys",
+ "libc",
+]
+
+[[package]]
+name = "inotify-sys"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "inout"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -753,6 +945,12 @@ checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
 dependencies = [
  "generic-array",
 ]
+
+[[package]]
+name = "is_terminal_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "itoa"
@@ -790,6 +988,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "kqueue"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eac30106d7dce88daf4a3fcb4879ea939476d5074a9b7ddd0fb97fa4bed5596a"
+dependencies = [
+ "kqueue-sys",
+ "libc",
+]
+
+[[package]]
+name = "kqueue-sys"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07293a4e297ac234359b510362495713f75ea345d5307140414f20c69ffeb087"
+dependencies = [
+ "bitflags 2.11.1",
+ "libc",
+]
+
+[[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
 name = "leb128fmt"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -800,6 +1024,15 @@ name = "libc"
 version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+
+[[package]]
+name = "libredox"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "linux-raw-sys"
@@ -814,6 +1047,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -824,6 +1066,18 @@ name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
+name = "mio"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
+dependencies = [
+ "libc",
+ "log",
+ "wasi",
+ "windows-sys 0.48.0",
+]
 
 [[package]]
 name = "ml-dsa"
@@ -874,6 +1128,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "normalize-line-endings"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
+
+[[package]]
+name = "notify"
+version = "6.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6205bd8bb1e454ad2e27422015fb5e4f2bcc7e08fa8f27058670d208324a4d2d"
+dependencies = [
+ "bitflags 2.11.1",
+ "crossbeam-channel",
+ "filetime",
+ "fsevent-sys",
+ "inotify",
+ "kqueue",
+ "libc",
+ "log",
+ "mio",
+ "walkdir",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -889,10 +1177,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
+name = "once_cell_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
 name = "opaque-debug"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
+
+[[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "password-hash"
@@ -970,6 +1270,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "predicates"
+version = "3.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ada8f2932f28a27ee7b70dd6c1c39ea0675c55a36879ab92f3a715eaa1e63cfe"
+dependencies = [
+ "anstyle",
+ "difflib",
+ "float-cmp",
+ "normalize-line-endings",
+ "predicates-core",
+ "regex",
+]
+
+[[package]]
+name = "predicates-core"
+version = "1.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cad38746f3166b4031b1a0d39ad9f954dd291e7854fcc0eed52ee41a0b50d144"
+
+[[package]]
+name = "predicates-tree"
+version = "1.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0de1b847b39c8131db0467e9df1ff60e6d0562ab8e9a16e568ad0fdb372e2f2"
+dependencies = [
+ "predicates-core",
+ "termtree",
+]
+
+[[package]]
 name = "prettyplease"
 version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -996,7 +1326,7 @@ checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
 dependencies = [
  "bit-set",
  "bit-vec",
- "bitflags",
+ "bitflags 2.11.1",
  "num-traits",
  "rand",
  "rand_chacha 0.9.0",
@@ -1150,10 +1480,65 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_users"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
+dependencies = [
+ "getrandom 0.2.17",
+ "libredox",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "regex"
+version = "1.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
 name = "regex-syntax"
 version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+
+[[package]]
+name = "rpassword"
+version = "7.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "835a57a69104632d64deb0df2e09a69945cd7a6eab4070fc9b1d7e50cf6c3edc"
+dependencies = [
+ "libc",
+ "rtoolbox",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rtoolbox"
+version = "0.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50a0e551c1e27e1731aba276dbeaeac73f53c7cd34d1bda485d02bd1e0f36844"
+dependencies = [
+ "libc",
+ "windows-sys 0.59.0",
+]
 
 [[package]]
 name = "rustc-hash"
@@ -1176,11 +1561,11 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1193,6 +1578,15 @@ dependencies = [
  "quick-error",
  "tempfile",
  "wait-timeout",
+]
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
 ]
 
 [[package]]
@@ -1213,6 +1607,26 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "secretary-cli"
+version = "0.1.0"
+dependencies = [
+ "assert_cmd",
+ "clap",
+ "dirs",
+ "fs2",
+ "notify",
+ "predicates",
+ "rpassword",
+ "secretary-core",
+ "serde_json",
+ "signal-hook",
+ "tempfile",
+ "thiserror 2.0.18",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -1240,7 +1654,7 @@ dependencies = [
  "sha3 0.10.9",
  "subtle",
  "tempfile",
- "thiserror",
+ "thiserror 2.0.18",
  "toml",
  "tracing",
  "unicode-normalization",
@@ -1259,7 +1673,7 @@ dependencies = [
  "secretary-core",
  "serde_json",
  "tempfile",
- "thiserror",
+ "thiserror 2.0.18",
  "zeroize",
 ]
 
@@ -1280,7 +1694,7 @@ dependencies = [
  "rand_chacha 0.3.1",
  "secretary-core",
  "secretary-ffi-bridge",
- "thiserror",
+ "thiserror 2.0.18",
  "uniffi",
  "zeroize",
 ]
@@ -1380,10 +1794,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "signal-hook"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
+dependencies = [
+ "errno",
+ "libc",
+]
 
 [[package]]
 name = "signature"
@@ -1408,6 +1851,12 @@ name = "siphasher"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
+
+[[package]]
+name = "smallvec"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "smawk"
@@ -1480,8 +1929,14 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "termtree"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "textwrap"
@@ -1494,11 +1949,31 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
 version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 2.0.18",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1510,6 +1985,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "thread_local"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -1597,6 +2081,49 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-serde"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "704b1aeb7be0d0a84fc9828cae51dab5970fee5088f83d1dd7ee6f6246fc6ff1"
+dependencies = [
+ "serde",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex-automata",
+ "serde",
+ "serde_json",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+ "tracing-serde",
 ]
 
 [[package]]
@@ -1776,6 +2303,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
 name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1788,6 +2327,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
 ]
 
 [[package]]
@@ -1842,7 +2391,7 @@ version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
@@ -1858,10 +2407,59 @@ dependencies = [
 ]
 
 [[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+dependencies = [
+ "windows-targets 0.52.6",
+]
 
 [[package]]
 name = "windows-sys"
@@ -1871,6 +2469,127 @@ checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
 ]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
@@ -1945,7 +2664,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
- "bitflags",
+ "bitflags 2.11.1",
  "indexmap",
  "log",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 resolver = "2"
 members = [
     "core",
+    "cli",
     "ffi/secretary-ffi-py",
     "ffi/secretary-ffi-uniffi",
     "ffi/secretary-ffi-bridge",

--- a/NEXT_SESSION.md
+++ b/NEXT_SESSION.md
@@ -1,1 +1,1 @@
-docs/handoffs/2026-05-23-c2-design-shipped.md
+docs/handoffs/2026-05-23-c2-task-1-scaffold-shipped.md

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,0 +1,36 @@
+[package]
+name = "secretary-cli"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+
+[[bin]]
+name = "secretary-sync"
+path = "src/main.rs"
+
+[dependencies]
+secretary-core = { path = "../core" }
+clap = { version = "4", features = ["derive"] }
+notify = "6"
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt", "json"] }
+dirs = "5"
+# `tempfile` exact-pinned to match `core/Cargo.toml`. The CLI's state file
+# (per docs/superpowers/specs/2026-05-23-c2-headless-sync-cli-design.md §"State persistence")
+# uses NamedTempFile::persist for atomic rename, same discipline as the
+# vault format. A regression in persist semantics would silently corrupt
+# the SyncState file. Same exact-pin rule as `core` — bump only via
+# deliberate changelog review (CLAUDE.md "exact pins on security-critical paths").
+tempfile = "=3.27.0"
+rpassword = "7"
+serde_json = "1"
+fs2 = "0.4"
+signal-hook = "0.3"
+thiserror = "2"
+
+[dev-dependencies]
+assert_cmd = "2"
+predicates = "3"
+tempfile = "=3.27.0"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -34,3 +34,6 @@ thiserror = "2"
 assert_cmd = "2"
 predicates = "3"
 tempfile = "=3.27.0"
+
+[lints]
+workspace = true

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -26,7 +26,10 @@ dirs = "5"
 tempfile = "=3.27.0"
 rpassword = "7"
 serde_json = "1"
-fs2 = "0.4"
+# `fs4` is a maintained fork of the unmaintained `fs2` crate (fs2's last
+# release was 2019). API for sync `FileExt::try_lock_exclusive` is
+# drop-in compatible. Used by Task 2's host-local lockfile.
+fs4 = "1"
 signal-hook = "0.3"
 thiserror = "2"
 

--- a/cli/src/args.rs
+++ b/cli/src/args.rs
@@ -1,0 +1,172 @@
+//! `clap` derive types for `secretary-sync` arg parsing.
+//!
+//! See [`docs/superpowers/specs/2026-05-23-c2-headless-sync-cli-design.md`](../../../docs/superpowers/specs/2026-05-23-c2-headless-sync-cli-design.md)
+//! §"Public surface" for the flag table and defaults.
+
+use std::path::PathBuf;
+
+use clap::{Parser, Subcommand};
+
+#[derive(Parser, Debug)]
+#[command(
+    name = "secretary-sync",
+    about = "Headless sync orchestration for a Secretary vault folder",
+    version
+)]
+pub struct Cli {
+    #[command(subcommand)]
+    pub command: Command,
+}
+
+#[derive(Subcommand, Debug)]
+pub enum Command {
+    /// Single sync attempt then exit.
+    Once {
+        #[command(flatten)]
+        common: CommonArgs,
+        /// Vault folder to sync.
+        vault_folder: PathBuf,
+    },
+    /// Long-running daemon (notify-based file watcher + debounce + optional poll).
+    Run {
+        #[command(flatten)]
+        common: CommonArgs,
+        #[command(flatten)]
+        run_args: RunArgs,
+        /// Vault folder to watch + sync.
+        vault_folder: PathBuf,
+    },
+}
+
+#[derive(clap::Args, Debug)]
+pub struct CommonArgs {
+    /// Read password from stdin until EOF.
+    #[arg(long)]
+    pub password_stdin: bool,
+
+    /// No TTY prompts; require --password-stdin; auto-KeepLocal on vetoes.
+    #[arg(long)]
+    pub non_interactive: bool,
+
+    /// Where to persist <vault_uuid_hex>.state.cbor + .lock. Defaults to OS data dir.
+    #[arg(long)]
+    pub state_dir: Option<PathBuf>,
+
+    /// Log output format.
+    #[arg(long, default_value = "human")]
+    pub log_format: LogFormat,
+
+    /// Verbosity. -v → debug; -vv → core debug.
+    #[arg(short, long, action = clap::ArgAction::Count)]
+    pub verbose: u8,
+}
+
+#[derive(clap::Args, Debug)]
+pub struct RunArgs {
+    /// Debounce window for notify event bursts (ms).
+    #[arg(long, default_value_t = 500)]
+    pub debounce_ms: u64,
+
+    /// Periodic safety-net poll (secs). 0 = off.
+    #[arg(long, default_value_t = 0)]
+    pub poll_interval_secs: u64,
+
+    /// Size-stability window for partial-download detection (ms).
+    #[arg(long, default_value_t = 2000)]
+    pub ready_window_ms: u64,
+}
+
+#[derive(clap::ValueEnum, Clone, Copy, Debug, PartialEq, Eq)]
+pub enum LogFormat {
+    Human,
+    Json,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// `secretary-sync once <folder>` with no flags parses to default CommonArgs.
+    #[test]
+    fn parse_once_with_defaults() {
+        let cli =
+            Cli::try_parse_from(["secretary-sync", "once", "/tmp/vault"]).expect("parse failed");
+        match cli.command {
+            Command::Once {
+                common,
+                vault_folder,
+            } => {
+                assert_eq!(vault_folder, PathBuf::from("/tmp/vault"));
+                assert!(!common.password_stdin);
+                assert!(!common.non_interactive);
+                assert!(common.state_dir.is_none());
+                assert_eq!(common.log_format, LogFormat::Human);
+                assert_eq!(common.verbose, 0);
+            }
+            _ => panic!("expected Once subcommand"),
+        }
+    }
+
+    /// `secretary-sync run` with all flags parses each correctly.
+    #[test]
+    fn parse_run_with_all_flags() {
+        let cli = Cli::try_parse_from([
+            "secretary-sync",
+            "run",
+            "--password-stdin",
+            "--non-interactive",
+            "--state-dir",
+            "/etc/secretary",
+            "--log-format",
+            "json",
+            "-vv",
+            "--debounce-ms",
+            "750",
+            "--poll-interval-secs",
+            "60",
+            "--ready-window-ms",
+            "3000",
+            "/srv/vault",
+        ])
+        .expect("parse failed");
+        match cli.command {
+            Command::Run {
+                common,
+                run_args,
+                vault_folder,
+            } => {
+                assert_eq!(vault_folder, PathBuf::from("/srv/vault"));
+                assert!(common.password_stdin);
+                assert!(common.non_interactive);
+                assert_eq!(common.state_dir, Some(PathBuf::from("/etc/secretary")));
+                assert_eq!(common.log_format, LogFormat::Json);
+                assert_eq!(common.verbose, 2);
+                assert_eq!(run_args.debounce_ms, 750);
+                assert_eq!(run_args.poll_interval_secs, 60);
+                assert_eq!(run_args.ready_window_ms, 3000);
+            }
+            _ => panic!("expected Run subcommand"),
+        }
+    }
+
+    /// Missing required positional vault_folder argument → parse error.
+    #[test]
+    fn parse_once_missing_folder_fails() {
+        let result = Cli::try_parse_from(["secretary-sync", "once"]);
+        assert!(result.is_err());
+    }
+
+    /// `--ready-window-ms` defaults to 2000 (spec §"Public surface" D6 mobile-aware default).
+    #[test]
+    fn run_args_default_ready_window_is_2000() {
+        let cli = Cli::try_parse_from(["secretary-sync", "run", "/tmp/vault"]).expect("parse");
+        if let Command::Run { run_args, .. } = cli.command {
+            assert_eq!(
+                run_args.ready_window_ms, 2000,
+                "spec freezes default at 2000 ms"
+            );
+        } else {
+            panic!("expected Run");
+        }
+    }
+}

--- a/cli/src/exit.rs
+++ b/cli/src/exit.rs
@@ -22,6 +22,8 @@ use secretary_core::sync::SyncError;
 // only the skeleton; the unit tests below exercise every variant so
 // the discriminant table is locked in. The allow lifts once Task 5
 // references the rest of the surface.
+// TODO(#113): remove this `#[allow(dead_code)]` when Task 5 wires the
+// dispatch layer that consumes every variant.
 #[allow(dead_code)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(i32)]
@@ -40,6 +42,8 @@ impl ExitCode {
     /// Map a `SyncError` to the documented exit code. Variants without a
     /// dedicated code map to `GenericError`.
     #[must_use]
+    // TODO(#113): remove this `#[allow(dead_code)]` when Task 5 wires
+    // the dispatch layer that calls `from_sync_error`.
     #[allow(dead_code)]
     pub fn from_sync_error(err: &SyncError) -> Self {
         match err {

--- a/cli/src/exit.rs
+++ b/cli/src/exit.rs
@@ -1,0 +1,104 @@
+//! Exit code mapping. See spec §"Public surface" exit-code table.
+
+use secretary_core::sync::SyncError;
+
+/// Documented exit codes for `secretary-sync`. The discriminant is the
+/// numeric exit code surfaced to the operator.
+///
+/// Per spec §"Public surface":
+///
+/// | Code | Meaning |
+/// |---|---|
+/// | 0  | Success (any non-Rollback outcome; clean shutdown). |
+/// | 1  | Generic error (vault format, IO, unlock, state-file). |
+/// | 2  | Usage error. |
+/// | 10 | RollbackRejected. |
+/// | 11 | Reserved — non-interactive veto-policy refusal (currently unreachable). |
+/// | 12 | EvidenceStale after retry budget exhausted. |
+/// | 13 | BlockFingerprintMismatch on commit. |
+/// | 14 | Lockfile held — another secretary-sync process is running on this vault. |
+// The non-`GenericError` variants and `from_sync_error` are consumed by
+// the pipeline + dispatch wiring landed in Task 5 onward. Task 1 ships
+// only the skeleton; the unit tests below exercise every variant so
+// the discriminant table is locked in. The allow lifts once Task 5
+// references the rest of the surface.
+#[allow(dead_code)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(i32)]
+pub enum ExitCode {
+    Success = 0,
+    GenericError = 1,
+    UsageError = 2,
+    RollbackRejected = 10,
+    VetoPolicyRefused = 11,
+    EvidenceStale = 12,
+    BlockFingerprintMismatch = 13,
+    LockfileHeld = 14,
+}
+
+impl ExitCode {
+    /// Map a `SyncError` to the documented exit code. Variants without a
+    /// dedicated code map to `GenericError`.
+    #[must_use]
+    #[allow(dead_code)]
+    pub fn from_sync_error(err: &SyncError) -> Self {
+        match err {
+            SyncError::EvidenceStale => Self::EvidenceStale,
+            SyncError::Vault(secretary_core::vault::VaultError::BlockFingerprintMismatch {
+                ..
+            }) => Self::BlockFingerprintMismatch,
+            _ => Self::GenericError,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn success_is_zero() {
+        assert_eq!(ExitCode::Success as i32, 0);
+    }
+
+    #[test]
+    fn generic_error_is_one() {
+        assert_eq!(ExitCode::GenericError as i32, 1);
+    }
+
+    #[test]
+    fn usage_error_is_two() {
+        assert_eq!(ExitCode::UsageError as i32, 2);
+    }
+
+    #[test]
+    fn rollback_rejected_is_ten() {
+        assert_eq!(ExitCode::RollbackRejected as i32, 10);
+    }
+
+    #[test]
+    fn veto_policy_refused_is_eleven() {
+        assert_eq!(ExitCode::VetoPolicyRefused as i32, 11);
+    }
+
+    #[test]
+    fn evidence_stale_is_twelve() {
+        assert_eq!(ExitCode::EvidenceStale as i32, 12);
+    }
+
+    #[test]
+    fn block_fingerprint_mismatch_is_thirteen() {
+        assert_eq!(ExitCode::BlockFingerprintMismatch as i32, 13);
+    }
+
+    #[test]
+    fn lockfile_held_is_fourteen() {
+        assert_eq!(ExitCode::LockfileHeld as i32, 14);
+    }
+
+    #[test]
+    fn evidence_stale_error_maps() {
+        let mapped = ExitCode::from_sync_error(&SyncError::EvidenceStale);
+        assert_eq!(mapped, ExitCode::EvidenceStale);
+    }
+}

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1,0 +1,22 @@
+//! `secretary-sync` entry point. See
+//! [`docs/superpowers/specs/2026-05-23-c2-headless-sync-cli-design.md`](../../docs/superpowers/specs/2026-05-23-c2-headless-sync-cli-design.md).
+
+use clap::Parser;
+
+mod args;
+mod exit;
+
+fn main() {
+    let cli = args::Cli::parse();
+    let code = match cli.command {
+        args::Command::Once { .. } => {
+            eprintln!("secretary-sync once: not yet implemented");
+            exit::ExitCode::GenericError
+        }
+        args::Command::Run { .. } => {
+            eprintln!("secretary-sync run: not yet implemented");
+            exit::ExitCode::GenericError
+        }
+    };
+    std::process::exit(code as i32);
+}

--- a/docs/handoffs/2026-05-23-c2-task-1-scaffold-shipped.md
+++ b/docs/handoffs/2026-05-23-c2-task-1-scaffold-shipped.md
@@ -1,0 +1,131 @@
+# NEXT_SESSION.md — C.2 Task 1 (cli/ scaffold + exit codes) shipped
+
+**Session date:** 2026-05-23 (C.2 Task 1 — scaffold `cli/` workspace member + `ExitCode` enum).
+**Status:** C.2 Task 1 ✅ on branch `feature/c2-task-1`; PR pending. Tasks 2-10 queued.
+
+## (1) What we shipped this session
+
+A single PR on `feature/c2-task-1` carrying the first code slice of C.2 — the new `cli/` workspace member that subsequent tasks extend.
+
+| Artifact | Path | Notes |
+|---|---|---|
+| Workspace manifest | [`Cargo.toml`](../../Cargo.toml) | `cli` added to `[workspace] members` (slot 2 between `core` and the `ffi/*` crates). |
+| Crate manifest | [`cli/Cargo.toml`](../../cli/Cargo.toml) | 11 runtime deps (clap, notify, tracing, tracing-subscriber, dirs, tempfile=3.27.0 exact-pinned, rpassword, serde_json, fs2, signal-hook, thiserror) + 2 dev deps (assert_cmd, predicates). |
+| Binary entry point | [`cli/src/main.rs`](../../cli/src/main.rs) | Skeleton `clap::Parser::parse()` → match subcommand → eprintln + `ExitCode::GenericError`. |
+| Arg parser | [`cli/src/args.rs`](../../cli/src/args.rs) | `Cli` / `Command::{Once,Run}` / `CommonArgs` / `RunArgs` / `LogFormat`. 4 unit tests, including the spec-frozen 2000 ms `--ready-window-ms` default. |
+| Exit codes | [`cli/src/exit.rs`](../../cli/src/exit.rs) | `ExitCode` enum (0/1/2/10/11/12/13/14) + `from_sync_error` mapper. 9 unit tests pin every discriminant + the `EvidenceStale` mapping. `#[allow(dead_code)]` on the not-yet-used surface; Task 5 wires the rest. |
+
+### Plan ↔ reality reconciliation
+
+| Plan note | Reality | Resolution |
+|---|---|---|
+| "12 new cli tests" / "PASSED: 812" | Actual: **13 cli tests** (4 args + 9 exit) / **PASSED: 813** | Plan was off by one (arithmetic typo). Acceptance criterion in Task 1 of the plan updated implicitly to 813 by ship reality; no plan amendment needed since Task 2's baseline is now "813". |
+| Plan code listed `from_sync_error` as nested `match v { ... }` | `clippy::collapsible_match` rejected the nested form | Collapsed to a single-arm nested pattern (`SyncError::Vault(VaultError::BlockFingerprintMismatch { .. }) => …`) preserving identical semantics. Tests unchanged. |
+| Plan listed `pub enum ExitCode` without `#[allow(dead_code)]` | Unused variants and the `from_sync_error` method warned (this is a binary crate, no external consumers) | Added `#[allow(dead_code)]` to the enum + impl with an inline comment noting "Task 5 wires the rest". Will lift in Task 5. |
+
+### Gauntlet snapshot at session close
+
+```
+PASSED: 813 FAILED: 0 IGNORED: 10
+clippy --release --workspace --tests -- -D warnings   clean
+fmt --all -- --check                                  clean
+uv run core/tests/python/conformance.py               PASS
+uv run core/tests/python/spec_test_name_freshness.py  PASS (96 resolved / 0 unresolved / 2 suppressed)
+secretary-sync --help / once --help / run --help     all print correctly
+```
+
+## (2) What's next — start C.2 Task 2
+
+After this PR merges, the next slice is **C.2 Task 2: state persistence + host-local lockfile** ([`docs/superpowers/plans/2026-05-23-c2-headless-sync-cli.md`](../superpowers/plans/2026-05-23-c2-headless-sync-cli.md) §"Task 2").
+
+### Acceptance criteria for Task 2
+
+- [ ] New `cli/src/state.rs` (~280 LOC) with the following surface:
+  - `canonical_hex(vault_uuid: [u8; 16]) -> String` (pure, 32-char lowercase hex).
+  - `state_file_path(state_dir, vault_uuid) -> PathBuf` / `lock_file_path(...)` (pure).
+  - `default_state_dir() -> Option<PathBuf>` via the `dirs` crate.
+  - `load(state_dir, vault_uuid) -> Result<SyncState, StateError>` — empty-on-missing, vault-UUID-mismatch returns typed error.
+  - `save(state_dir, &SyncState) -> Result<(), StateError>` — atomic via `tempfile::NamedTempFile::persist`.
+  - `LockfileGuard::acquire(state_dir, vault_uuid)` — `fs2::try_lock_exclusive`; collision returns `StateError::LockfileHeld`; kernel auto-release on drop.
+- [ ] `cli/src/main.rs` gains `mod state;`.
+- [ ] 9 new unit tests cover: canonical_hex format, state/lock file-path layout, load-missing-returns-empty, save→load roundtrip, vault-UUID-mismatch typed error, lockfile collision returns held, lockfile releases on drop, different-vaults-don't-collide, default_state_dir ends in `secretary/sync`.
+- [ ] Gauntlet target: **PASSED: 822 FAILED: 0 IGNORED: 10** (813 base + 9 new). Plan said 821 but the base is now 813, so the absolute number floats up by one.
+- [ ] Clippy, fmt, conformance, spec freshness all clean.
+
+### Plan handoff
+
+Full step-by-step in [`docs/superpowers/plans/2026-05-23-c2-headless-sync-cli.md`](../superpowers/plans/2026-05-23-c2-headless-sync-cli.md) §"Task 2", which still applies verbatim (no observable Task 1 deviations affect Task 2's surface).
+
+## (3) Open decisions and risks
+
+### Decisions settled during this session
+
+- The `from_sync_error` mapper currently surfaces `EvidenceStale → ExitCode::EvidenceStale` and `Vault(BlockFingerprintMismatch{..}) → ExitCode::BlockFingerprintMismatch`. **Every other `SyncError` variant folds to `GenericError`.** This matches the spec's exit-code table — variants without a dedicated code map to `1`. The `UnknownVetoDecision` / `MissingVetoDecision` / `EmptyDraftWithVetoes` bijection-failure variants do NOT get distinct exit codes (they indicate a CLI bug, not an operator-recoverable condition).
+
+### Decisions carried forward (unchanged from C.2 design close)
+
+- D1-D10 from the spec are still settled.
+- `--veto-policy=fail`, `--decisions-file`, `--exit-on-error`, `status`, `init` subcommands all deferred to future C.2.x slices.
+- Windows is best-effort per D10 (no CI runner planned for C.2 implementation).
+- Clean-room conformance harness for `cli/` deferred to C.4 or a future C.2.x slice.
+
+### Risks carried into Task 2
+
+- **`tempfile = "=3.27.0"` exact pin** is now duplicated in `cli/Cargo.toml`. Same discipline as `core` — bump only via deliberate changelog review. Documented in-file via comment cross-referencing CLAUDE.md.
+- **`#![forbid(unsafe_code)]`** workspace-wide. `cli/` already pure-safe — Task 2's `fs2::FileExt::try_lock_exclusive` is fully safe Rust (the lower-level `flock(2)` lives inside `fs2`).
+- **`#[allow(dead_code)]` on `ExitCode` / `from_sync_error`** lifts when Task 5 (pipeline) consumes them. If Task 5 ships without removing the allow, the lint hides a regression. Reviewer for the Task 5 PR should grep for `allow(dead_code)` in `cli/src/exit.rs` and require it removed.
+
+### Issues currently open (unchanged from C.2 design close)
+
+- #37 — Sub-project C umbrella. C.2 Task 1 ✅ in this PR.
+- #38, #45, #75, #76, #78, #79, #81, #87, #88, #90, #95, #98 — none block C.2 Task 2.
+
+### Housekeeping note (stale worktrees on disk)
+
+Three worktrees on disk locally after Task 1:
+- `/Users/hherb/src/secretary` — `main` (clean).
+- `/Users/hherb/src/secretary/.worktrees/c1-1b-sync-merge` — branch `feature/c1-1b-task-17`, remote gone (carried over from C.1.1b session). Safe to remove via `git worktree remove .worktrees/c1-1b-sync-merge && git branch -D feature/c1-1b-task-17`.
+- `/Users/hherb/src/secretary/.worktrees/c2-task-1-spec` — branch `feature/c2-task-1-spec`, also remote-gone after PR #111 merged. Safe to remove.
+- `/Users/hherb/src/secretary/.worktrees/c2-task-1` — **this session's work**; keep until PR merges, then remove.
+
+Cleanup is one-line each and does NOT block Task 2.
+
+## (4) Exact commands to resume
+
+```bash
+# After this C.2 Task 1 PR (feature/c2-task-1) merges:
+cd /Users/hherb/src/secretary
+git fetch --prune origin
+git status --short                       # expect: clean (modulo NEXT_SESSION.md sync, see below)
+git checkout main
+git pull --ff-only origin main
+
+# Verify gauntlet on fresh main (expect 813 / 0 / 10 — same as session close):
+cargo test --release --workspace --no-fail-fast 2>&1 | grep -E "^test result:" | awk '{passed+=$4; failed+=$6; ignored+=$8} END {print "PASSED:", passed, "FAILED:", failed, "IGNORED:", ignored}'
+cargo clippy --release --workspace --tests -- -D warnings 2>&1 | tail -3
+cargo fmt --all -- --check
+uv run core/tests/python/conformance.py 2>&1 | tail -3
+uv run core/tests/python/spec_test_name_freshness.py 2>&1 | tail -3
+
+# Start Task 2:
+git worktree add .worktrees/c2-task-2 -b feature/c2-task-2 main
+cd .worktrees/c2-task-2
+
+# Open the plan and follow Task 2 line-by-line:
+#   docs/superpowers/plans/2026-05-23-c2-headless-sync-cli.md §"Task 2"
+# Steps 1-5 cover the full scaffold + commit + PR.
+```
+
+## Closing inventory
+
+- **Branch state on close:** `main` at `6863523` (PR #111 squash-merged). `feature/c2-task-1` carries 1 commit on top.
+- **Workspace tests on `feature/c2-task-1`:** 813 passed + 10 ignored (800 base + 13 new cli unit tests — 4 in `args.rs`, 9 in `exit.rs`). Clippy + fmt + Python conformance + spec freshness all clean.
+- **README.md:** unchanged this session — Task 1 ships a scaffold, no user-visible behavior. Plan defers README update to Task 10.
+- **ROADMAP.md:** unchanged this session — same reason; ROADMAP already calls C.2 "queued" since the C.2 design PR.
+- **CLAUDE.md:** unchanged this session — the dependency-pin discipline noted in `cli/Cargo.toml` is a cross-reference, not a new convention.
+- **NEXT_SESSION.md:** symlink retargeted to this file.
+- **Open issues:** see §(3) — none block Task 2.
+- **Open PRs:** one to be opened at end of this session (C.2 Task 1).
+- **Worktrees on disk:** see §(3) housekeeping.
+- **Frozen baton snapshots:** all 18 prior C.1.1b + C.2-design handoffs at [`docs/handoffs/`](.) — preserved unchanged.
+- **This file:** the live baton for C.2 Task 1 close.

--- a/docs/handoffs/2026-05-23-c2-task-1-scaffold-shipped.md
+++ b/docs/handoffs/2026-05-23-c2-task-1-scaffold-shipped.md
@@ -10,7 +10,7 @@ A single PR on `feature/c2-task-1` carrying the first code slice of C.2 — the 
 | Artifact | Path | Notes |
 |---|---|---|
 | Workspace manifest | [`Cargo.toml`](../../Cargo.toml) | `cli` added to `[workspace] members` (slot 2 between `core` and the `ffi/*` crates). |
-| Crate manifest | [`cli/Cargo.toml`](../../cli/Cargo.toml) | 11 runtime deps (clap, notify, tracing, tracing-subscriber, dirs, tempfile=3.27.0 exact-pinned, rpassword, serde_json, fs2, signal-hook, thiserror) + 2 dev deps (assert_cmd, predicates). |
+| Crate manifest | [`cli/Cargo.toml`](../../cli/Cargo.toml) | 11 runtime deps (clap, notify, tracing, tracing-subscriber, dirs, tempfile=3.27.0 exact-pinned, rpassword, serde_json, fs4, signal-hook, thiserror) + 2 dev deps (assert_cmd, predicates) + `[lints] workspace = true`. |
 | Binary entry point | [`cli/src/main.rs`](../../cli/src/main.rs) | Skeleton `clap::Parser::parse()` → match subcommand → eprintln + `ExitCode::GenericError`. |
 | Arg parser | [`cli/src/args.rs`](../../cli/src/args.rs) | `Cli` / `Command::{Once,Run}` / `CommonArgs` / `RunArgs` / `LogFormat`. 4 unit tests, including the spec-frozen 2000 ms `--ready-window-ms` default. |
 | Exit codes | [`cli/src/exit.rs`](../../cli/src/exit.rs) | `ExitCode` enum (0/1/2/10/11/12/13/14) + `from_sync_error` mapper. 9 unit tests pin every discriminant + the `EvidenceStale` mapping. `#[allow(dead_code)]` on the not-yet-used surface; Task 5 wires the rest. |
@@ -46,7 +46,7 @@ After this PR merges, the next slice is **C.2 Task 2: state persistence + host-l
   - `default_state_dir() -> Option<PathBuf>` via the `dirs` crate.
   - `load(state_dir, vault_uuid) -> Result<SyncState, StateError>` — empty-on-missing, vault-UUID-mismatch returns typed error.
   - `save(state_dir, &SyncState) -> Result<(), StateError>` — atomic via `tempfile::NamedTempFile::persist`.
-  - `LockfileGuard::acquire(state_dir, vault_uuid)` — `fs2::try_lock_exclusive`; collision returns `StateError::LockfileHeld`; kernel auto-release on drop.
+  - `LockfileGuard::acquire(state_dir, vault_uuid)` — `fs4::fs_std::FileExt::try_lock_exclusive`; collision returns `StateError::LockfileHeld`; kernel auto-release on drop.
 - [ ] `cli/src/main.rs` gains `mod state;`.
 - [ ] 9 new unit tests cover: canonical_hex format, state/lock file-path layout, load-missing-returns-empty, save→load roundtrip, vault-UUID-mismatch typed error, lockfile collision returns held, lockfile releases on drop, different-vaults-don't-collide, default_state_dir ends in `secretary/sync`.
 - [ ] Gauntlet target: **PASSED: 822 FAILED: 0 IGNORED: 10** (813 base + 9 new). Plan said 821 but the base is now 813, so the absolute number floats up by one.
@@ -72,12 +72,14 @@ Full step-by-step in [`docs/superpowers/plans/2026-05-23-c2-headless-sync-cli.md
 ### Risks carried into Task 2
 
 - **`tempfile = "=3.27.0"` exact pin** is now duplicated in `cli/Cargo.toml`. Same discipline as `core` — bump only via deliberate changelog review. Documented in-file via comment cross-referencing CLAUDE.md.
-- **`#![forbid(unsafe_code)]`** workspace-wide. `cli/` already pure-safe — Task 2's `fs2::FileExt::try_lock_exclusive` is fully safe Rust (the lower-level `flock(2)` lives inside `fs2`).
-- **`#[allow(dead_code)]` on `ExitCode` / `from_sync_error`** lifts when Task 5 (pipeline) consumes them. If Task 5 ships without removing the allow, the lint hides a regression. Reviewer for the Task 5 PR should grep for `allow(dead_code)` in `cli/src/exit.rs` and require it removed.
+- **`#![forbid(unsafe_code)]`** is now enforced on `cli/` via `[lints] workspace = true` in `cli/Cargo.toml` (added during PR review cleanup — Task 1 originally omitted the opt-in). `cli/` is pure-safe; Task 2's `fs4::fs_std::FileExt::try_lock_exclusive` is fully safe Rust (the lower-level `flock(2)` lives inside `fs4`).
+- **`fs4 = "1"`** replaces the original `fs2 = "0.4"` (fs2 last released 2019 and is effectively unmaintained). Drop-in API for the sync lockfile primitive Task 2 needs.
+- **`#[allow(dead_code)]` on `ExitCode` / `from_sync_error`** lifts when Task 5 (pipeline) consumes them. Tracked at issue [#113](https://github.com/hherb/secretary/issues/113), with `TODO(#113):` markers at the suppression sites in `cli/src/exit.rs`. Issue #113 also tracks the related Task 5 obligation: validating the `--non-interactive` ↔ `--password-stdin` co-requirement per spec §"Public surface".
 
-### Issues currently open (unchanged from C.2 design close)
+### Issues currently open
 
 - #37 — Sub-project C umbrella. C.2 Task 1 ✅ in this PR.
+- **#113 — C.2 Task 5 cleanup checklist** (filed during PR review): lift `#[allow(dead_code)]` in `cli/src/exit.rs` and add `--non-interactive` ↔ `--password-stdin` validation. Must be addressed by the Task 5 PR.
 - #38, #45, #75, #76, #78, #79, #81, #87, #88, #90, #95, #98 — none block C.2 Task 2.
 
 ### Housekeeping note (stale worktrees on disk)

--- a/docs/superpowers/plans/2026-05-23-c2-headless-sync-cli.md
+++ b/docs/superpowers/plans/2026-05-23-c2-headless-sync-cli.md
@@ -6,7 +6,7 @@
 
 **Architecture:** Library-thin, I/O-at-edges. A pure-function `pipeline::run_one(&UnlockedIdentity, &SecretBytes, &mut SyncState, ...)` performs one sync attempt — `sync_once` → dispatch → optional `prepare_merge` → veto adjudication via a `VetoUx` trait → `commit_with_decisions`. The `run` subcommand wraps `run_one` in a `daemon::run` loop driven by `notify::RecommendedWatcher` events with a debounce state machine and an optional periodic poll. The `once` subcommand is `run_one` plus state-file save plus exit-code mapping. State persistence + host-local lockfile live in `state.rs` (filename = `<vault_uuid_hex>.state.cbor` / `<vault_uuid_hex>.lock` under `dirs`-resolved OS data dir, `--state-dir` override). Partial-download detection composes a pure pattern matcher + size-stability probe in `watcher::ready`. Unlock reads bytes from stdin or TTY into a `SecretBytes` held for the daemon's lifetime.
 
-**Tech Stack:** stable Rust (workspace toolchain). New `cli/` workspace member with binary-only deps: `clap` (derive), `notify` 6.x (RecommendedWatcher), `tracing-subscriber` (env-filter + fmt + json), `dirs` 5.x, `tempfile` `=3.27.0` exact-pinned, `rpassword`, `serde_json`, `fs2` 0.4 (cross-platform flock), `signal-hook`. Dev-deps: `assert_cmd`, `predicates`. No new deps in `core/`. All Rust pure-safe (`#![forbid(unsafe_code)]` per workspace lint).
+**Tech Stack:** stable Rust (workspace toolchain). New `cli/` workspace member with binary-only deps: `clap` (derive), `notify` 6.x (RecommendedWatcher), `tracing-subscriber` (env-filter + fmt + json), `dirs` 5.x, `tempfile` `=3.27.0` exact-pinned, `rpassword`, `serde_json`, `fs4` 1.x (cross-platform flock; maintained fork of the unmaintained `fs2`), `signal-hook`. Dev-deps: `assert_cmd`, `predicates`. No new deps in `core/`. All Rust pure-safe (`#![forbid(unsafe_code)]` per workspace lint, opt-in via `[lints] workspace = true` in `cli/Cargo.toml`).
 
 **Spec:** [`docs/superpowers/specs/2026-05-23-c2-headless-sync-cli-design.md`](../specs/2026-05-23-c2-headless-sync-cli-design.md) (D1–D10 settled 2026-05-23).
 
@@ -168,7 +168,9 @@ dirs = "5"
 tempfile = "=3.27.0"
 rpassword = "7"
 serde_json = "1"
-fs2 = "0.4"
+# `fs4` is a maintained fork of the unmaintained `fs2` crate (fs2's last
+# release was 2019). Drop-in API for the sync lockfile primitive Task 2 uses.
+fs4 = "1"
 signal-hook = "0.3"
 thiserror = "2"
 
@@ -176,6 +178,9 @@ thiserror = "2"
 assert_cmd = "2"
 predicates = "3"
 tempfile = "=3.27.0"
+
+[lints]
+workspace = true
 ```
 
 - [ ] **Step 4: Write the failing test for `args.rs`**
@@ -579,7 +584,7 @@ EOF
 
 ## Task 2: State persistence + lockfile (`cli/src/state.rs`)
 
-**Why:** Every subcommand needs to load/save the `SyncState` CBOR file and acquire the host-local lockfile before doing anything else. The pure-function pieces (`path_for_vault`, `canonical_hex`) are trivially table-testable; the I/O pieces (`load`, `save`, `LockfileGuard`) need temp-dir fixtures. Lockfile uses `fs2::FileExt::try_lock_exclusive` for cross-platform flock/LockFileEx. Atomic state-file write via `tempfile::NamedTempFile::persist` (same `=3.27.0` pin as core).
+**Why:** Every subcommand needs to load/save the `SyncState` CBOR file and acquire the host-local lockfile before doing anything else. The pure-function pieces (`path_for_vault`, `canonical_hex`) are trivially table-testable; the I/O pieces (`load`, `save`, `LockfileGuard`) need temp-dir fixtures. Lockfile uses `fs4::fs_std::FileExt::try_lock_exclusive` for cross-platform flock/LockFileEx (fs4 1.x; verify the exact module path against the live docs at impl time — fs4's v1 line restructured the namespace from fs2's flat layout). Atomic state-file write via `tempfile::NamedTempFile::persist` (same `=3.27.0` pin as core).
 
 **Files:**
 - Create: `cli/src/state.rs`
@@ -610,15 +615,17 @@ Create `cli/src/state.rs`:
 //! exact-pin discipline as the vault format.
 //!
 //! The lockfile is `<state-dir>/<vault_uuid_hex>.lock`, locked via
-//! `fs2::FileExt::try_lock_exclusive` (flock(LOCK_EX|LOCK_NB) on Unix,
-//! LockFileEx on Windows). Kernel auto-releases on process death; no
-//! stale-PID handling required.
+//! `fs4::fs_std::FileExt::try_lock_exclusive` (flock(LOCK_EX|LOCK_NB) on
+//! Unix, LockFileEx on Windows). Kernel auto-releases on process death;
+//! no stale-PID handling required. NOTE: verify the exact fs4 1.x
+//! module path against the live docs — fs4 1.x reorganized the
+//! namespace from fs2's flat layout.
 
 use std::fs::{self, File, OpenOptions};
 use std::io::Write;
 use std::path::{Path, PathBuf};
 
-use fs2::FileExt;
+use fs4::fs_std::FileExt;
 use tempfile::NamedTempFile;
 use thiserror::Error;
 
@@ -883,7 +890,7 @@ cli/src/state.rs:
 - load: empty-on-missing + vault_uuid mismatch check.
 - save: atomic write via tempfile::NamedTempFile::persist (same
   =3.27.0 pin as core; comment cross-references CLAUDE.md).
-- LockfileGuard: fs2::try_lock_exclusive RAII guard; collision returns
+- LockfileGuard: fs4::fs_std::FileExt::try_lock_exclusive RAII guard; collision returns
   the typed StateError::LockfileHeld; drop releases (kernel auto).
 
 9 new unit tests; workspace 812→821.
@@ -898,7 +905,7 @@ gh pr create --base main --title "C.2 Task 2 — state persistence + host-local 
 ## Summary
 - `cli/src/state.rs` — load/save SyncState CBOR + LockfileGuard RAII type.
 - `canonical_hex` / path helpers are pure free functions, table-tested.
-- Lockfile uses `fs2::try_lock_exclusive` (cross-platform).
+- Lockfile uses `fs4::fs_std::FileExt::try_lock_exclusive` (cross-platform; verify exact module path against live fs4 1.x docs at impl time).
 - State-file write uses `tempfile::NamedTempFile::persist` with `tempfile = "=3.27.0"` pinned (matches `core/Cargo.toml`).
 
 ## Test plan


### PR DESCRIPTION
## Summary

First code slice of the C.2 phase per the implementation plan ([`docs/superpowers/plans/2026-05-23-c2-headless-sync-cli.md`](docs/superpowers/plans/2026-05-23-c2-headless-sync-cli.md) §"Task 1"). Lays down the new `cli/` workspace member so subsequent tasks have a place to add modules.

- New `cli/` workspace member with `secretary-sync` binary skeleton.
- `clap` arg parsing for `once` + `run` subcommands per spec §"Public surface" (including the 2000 ms `--ready-window-ms` default frozen at design time).
- `ExitCode` enum + `from_sync_error` mapping per spec exit-code table (0/1/2/10/11/12/13/14).
- 13 new unit tests (4 args + 9 exit); workspace 800 → 813.
- `tempfile = "=3.27.0"` exact pin propagated from `core/Cargo.toml`, cross-referenced via inline comment.

`from_sync_error` and the non-`GenericError` `ExitCode` variants are `#[allow(dead_code)]` for now — they get consumed by the pipeline + dispatch wiring in Task 5. Task 5's PR reviewer should grep for `allow(dead_code)` in `cli/src/exit.rs` and require it removed.

One plan-vs-reality deviation: plan listed `12 new tests / PASSED: 812`. Actual is **13 tests / PASSED: 813** (4 args + 9 exit). Plan was off by one (arithmetic typo). The Task 2 baseline floats up by one accordingly; handoff doc records this.

Spec: [`docs/superpowers/specs/2026-05-23-c2-headless-sync-cli-design.md`](docs/superpowers/specs/2026-05-23-c2-headless-sync-cli-design.md) §D9.
Plan: [`docs/superpowers/plans/2026-05-23-c2-headless-sync-cli.md`](docs/superpowers/plans/2026-05-23-c2-headless-sync-cli.md) §"Task 1" of 10.
Handoff: [`docs/handoffs/2026-05-23-c2-task-1-scaffold-shipped.md`](docs/handoffs/2026-05-23-c2-task-1-scaffold-shipped.md).

## Test plan

- [x] `cargo test --release --workspace --no-fail-fast` → 813 passed / 0 failed / 10 ignored
- [x] `cargo clippy --release --workspace --tests -- -D warnings` → clean
- [x] `cargo fmt --all -- --check` → clean
- [x] `uv run core/tests/python/conformance.py` → PASS
- [x] `uv run core/tests/python/spec_test_name_freshness.py` → PASS (96 resolved / 0 unresolved / 2 suppressed)
- [x] `./target/release/secretary-sync --help` / `once --help` / `run --help` all render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)