### PR TITLE
C.2 Task 2 — state persistence + host-local lockfile

### DIFF
--- a/NEXT_SESSION.md
+++ b/NEXT_SESSION.md
@@ -1,1 +1,1 @@
-docs/handoffs/2026-05-23-c2-task-1-scaffold-shipped.md
+docs/handoffs/2026-05-23-c2-task-2-state-lockfile-shipped.md

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -27,8 +27,11 @@ tempfile = "=3.27.0"
 rpassword = "7"
 serde_json = "1"
 # `fs4` is a maintained fork of the unmaintained `fs2` crate (fs2's last
-# release was 2019). API for sync `FileExt::try_lock_exclusive` is
-# drop-in compatible. Used by Task 2's host-local lockfile.
+# release was 2019). Used by Task 2's host-local lockfile through the
+# `fs4::FileExt::try_lock` trait method. NOTE: stdlib stabilized an
+# inherent `File::try_lock` in Rust 1.89 that shadows the trait; we
+# keep fs4 because the workspace MSRV (1.87) is below 1.89, and the
+# call site uses UFCS (`Fs4FileExt::try_lock(&file)`) to disambiguate.
 fs4 = "1"
 signal-hook = "0.3"
 thiserror = "2"

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -5,6 +5,7 @@ use clap::Parser;
 
 mod args;
 mod exit;
+mod state;
 
 fn main() {
     let cli = args::Cli::parse();

--- a/cli/src/state.rs
+++ b/cli/src/state.rs
@@ -1,0 +1,304 @@
+//! Per-vault `SyncState` persistence + host-local lockfile.
+//!
+//! Spec: [`docs/superpowers/specs/2026-05-23-c2-headless-sync-cli-design.md`](../../docs/superpowers/specs/2026-05-23-c2-headless-sync-cli-design.md)
+//! §"State persistence" and §D7 (single-process-per-vault lockfile).
+//!
+//! The state file is `<state-dir>/<vault_uuid_hex>.state.cbor` — `SyncState`
+//! encoded via `core::sync::SyncState::to_canonical_cbor`. Atomic write via
+//! `tempfile::NamedTempFile::persist`, sharing the `=3.27.0` exact pin
+//! discipline with the vault format layer (see `cli/Cargo.toml` and the
+//! `CLAUDE.md` "exact pins on security-critical paths" note).
+//!
+//! The lockfile is `<state-dir>/<vault_uuid_hex>.lock`, locked via
+//! `fs4::FileExt::try_lock` — the exclusive non-blocking lock
+//! (flock(LOCK_EX | LOCK_NB) on Unix, LockFileEx on Windows). Kernel
+//! auto-releases on process death; no stale-PID handling required.
+//!
+//! fs4 1.x API note: the trait is `fs4::FileExt` (re-exported at the
+//! crate root; no `fs_std` module in v1, unlike the early plan draft).
+//! The exclusive try-variant is `try_lock()` and returns
+//! `Result<(), fs4::TryLockError>` — `Err(TryLockError::WouldBlock)`
+//! signals another process holds the lock; `Err(TryLockError::Error(io))`
+//! is a genuine I/O failure.
+//!
+//! MSRV note: stdlib stabilized an inherent `File::try_lock` in Rust
+//! 1.89 that would otherwise shadow the fs4 trait method. The workspace
+//! MSRV is 1.87 (`Cargo.toml` `rust-version`), so we keep the fs4 dep
+//! and explicitly invoke the trait via the `Fs4FileExt::try_lock(&file)`
+//! UFCS form to make the call site unambiguous on any toolchain ≥ 1.87.
+
+use std::fs::{self, File, OpenOptions};
+use std::io::Write;
+use std::path::{Path, PathBuf};
+
+use fs4::{FileExt as Fs4FileExt, TryLockError};
+use tempfile::NamedTempFile;
+use thiserror::Error;
+
+use secretary_core::sync::{SyncError, SyncState};
+
+const STATE_FILE_EXTENSION: &str = "state.cbor";
+const LOCK_FILE_EXTENSION: &str = "lock";
+const VAULT_UUID_HEX_LEN: usize = 32;
+
+#[allow(dead_code)] // TODO(#113): consumed when Task 5 pipeline wires state load/save + lockfile acquire.
+#[derive(Debug, Error)]
+pub enum StateError {
+    #[error("I/O error reading or writing state file: {0}")]
+    Io(#[from] std::io::Error),
+    #[error("state file vault_uuid mismatch (file is for vault {file_uuid_hex}, expected {expected_uuid_hex})")]
+    VaultUuidMismatch {
+        file_uuid_hex: String,
+        expected_uuid_hex: String,
+    },
+    #[error("CBOR decode failed: {0}")]
+    Decode(SyncError),
+    #[error("CBOR encode failed: {0}")]
+    Encode(SyncError),
+    #[error("lockfile {0} already held by another secretary-sync process")]
+    LockfileHeld(PathBuf),
+}
+
+/// 16-byte vault UUID → lowercase hex string (32 chars, no separator).
+#[must_use]
+pub fn canonical_hex(vault_uuid: [u8; 16]) -> String {
+    let mut out = String::with_capacity(VAULT_UUID_HEX_LEN);
+    for byte in vault_uuid {
+        use std::fmt::Write as _;
+        let _ = write!(out, "{byte:02x}");
+    }
+    out
+}
+
+/// Compute `<state-dir>/<vault_uuid_hex>.state.cbor`.
+#[must_use]
+pub fn state_file_path(state_dir: &Path, vault_uuid: [u8; 16]) -> PathBuf {
+    state_dir.join(format!(
+        "{}.{}",
+        canonical_hex(vault_uuid),
+        STATE_FILE_EXTENSION
+    ))
+}
+
+/// Compute `<state-dir>/<vault_uuid_hex>.lock`.
+#[must_use]
+pub fn lock_file_path(state_dir: &Path, vault_uuid: [u8; 16]) -> PathBuf {
+    state_dir.join(format!(
+        "{}.{}",
+        canonical_hex(vault_uuid),
+        LOCK_FILE_EXTENSION
+    ))
+}
+
+/// Resolve the default state dir via the `dirs` crate.
+///
+/// - Linux: `$XDG_DATA_HOME/secretary/sync/` (typically `~/.local/share/...`)
+/// - macOS: `~/Library/Application Support/secretary/sync/`
+/// - Windows: `%LOCALAPPDATA%\secretary\sync\`
+///
+/// Returns `None` if no platform data dir is available (very rare — minimal
+/// headless installs without `$HOME`).
+#[must_use]
+pub fn default_state_dir() -> Option<PathBuf> {
+    dirs::data_dir().map(|p| p.join("secretary").join("sync"))
+}
+
+/// Load `SyncState` from `<state-dir>/<vault_uuid_hex>.state.cbor`. If the
+/// file does not exist, return `SyncState::empty(vault_uuid)`. Validates
+/// that any decoded state's `vault_uuid` matches the expected one.
+#[allow(dead_code)] // TODO(#113): consumed by Task 5 pipeline.
+pub fn load(state_dir: &Path, vault_uuid: [u8; 16]) -> Result<SyncState, StateError> {
+    let path = state_file_path(state_dir, vault_uuid);
+    if !path.exists() {
+        return Ok(SyncState::empty(vault_uuid));
+    }
+    let bytes = fs::read(&path)?;
+    let state = SyncState::from_canonical_cbor(&bytes).map_err(StateError::Decode)?;
+    if state.vault_uuid != vault_uuid {
+        return Err(StateError::VaultUuidMismatch {
+            file_uuid_hex: canonical_hex(state.vault_uuid),
+            expected_uuid_hex: canonical_hex(vault_uuid),
+        });
+    }
+    Ok(state)
+}
+
+/// Atomically persist `SyncState` to `<state-dir>/<vault_uuid_hex>.state.cbor`.
+/// Uses `tempfile::NamedTempFile::persist` for rename(2) / MoveFileExW
+/// semantics — same `=3.27.0` exact pin as the vault format layer.
+#[allow(dead_code)] // TODO(#113): consumed by Task 5 pipeline.
+pub fn save(state_dir: &Path, state: &SyncState) -> Result<(), StateError> {
+    fs::create_dir_all(state_dir)?;
+    let final_path = state_file_path(state_dir, state.vault_uuid);
+    let bytes = state.to_canonical_cbor().map_err(StateError::Encode)?;
+
+    let mut tmp = NamedTempFile::new_in(state_dir)?;
+    tmp.write_all(&bytes)?;
+    tmp.persist(&final_path)
+        .map_err(|e| StateError::Io(e.error))?;
+    Ok(())
+}
+
+/// RAII guard for the per-vault exclusive lockfile. Holds the locked file
+/// handle; releases on drop (kernel auto-releases flock when fd closes).
+#[allow(dead_code)] // TODO(#113): consumed by Task 5 pipeline.
+#[derive(Debug)]
+pub struct LockfileGuard {
+    _file: File,
+    path: PathBuf,
+}
+
+#[allow(dead_code)] // TODO(#113): consumed by Task 5 pipeline.
+impl LockfileGuard {
+    /// Acquire the exclusive lock on `<state-dir>/<vault_uuid_hex>.lock`.
+    /// Returns `Err(StateError::LockfileHeld)` if another process already
+    /// holds it.
+    pub fn acquire(state_dir: &Path, vault_uuid: [u8; 16]) -> Result<Self, StateError> {
+        fs::create_dir_all(state_dir)?;
+        let path = lock_file_path(state_dir, vault_uuid);
+        let file = OpenOptions::new()
+            .create(true)
+            .read(true)
+            .write(true)
+            .truncate(false)
+            .open(&path)?;
+        match Fs4FileExt::try_lock(&file) {
+            Ok(()) => Ok(Self { _file: file, path }),
+            Err(TryLockError::WouldBlock) => Err(StateError::LockfileHeld(path)),
+            Err(TryLockError::Error(io)) => Err(StateError::Io(io)),
+        }
+    }
+
+    #[must_use]
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    /// `canonical_hex` produces 32-char lowercase hex with no separator.
+    #[test]
+    fn canonical_hex_format() {
+        let uuid = [0xab; 16];
+        let hex = canonical_hex(uuid);
+        assert_eq!(hex.len(), VAULT_UUID_HEX_LEN);
+        assert_eq!(hex, "abababababababababababababababab");
+    }
+
+    /// `state_file_path` composes `<state-dir>/<hex>.state.cbor`.
+    #[test]
+    fn state_file_path_layout() {
+        let dir = Path::new("/tmp/sync");
+        let path = state_file_path(dir, [1; 16]);
+        assert_eq!(
+            path,
+            PathBuf::from("/tmp/sync/01010101010101010101010101010101.state.cbor")
+        );
+    }
+
+    /// `lock_file_path` composes `<state-dir>/<hex>.lock`.
+    #[test]
+    fn lock_file_path_layout() {
+        let dir = Path::new("/tmp/sync");
+        let path = lock_file_path(dir, [1; 16]);
+        assert_eq!(
+            path,
+            PathBuf::from("/tmp/sync/01010101010101010101010101010101.lock")
+        );
+    }
+
+    /// Load returns `SyncState::empty` when no file exists for the vault.
+    #[test]
+    fn load_missing_returns_empty() {
+        let dir = TempDir::new().unwrap();
+        let loaded = load(dir.path(), [9; 16]).unwrap();
+        assert_eq!(loaded.vault_uuid, [9; 16]);
+        assert!(loaded.highest_vector_clock_seen.is_empty());
+    }
+
+    /// Save + load round-trips byte-identically.
+    #[test]
+    fn save_load_roundtrip() {
+        let dir = TempDir::new().unwrap();
+        let state = SyncState::empty([7; 16]);
+        save(dir.path(), &state).unwrap();
+        let loaded = load(dir.path(), [7; 16]).unwrap();
+        assert_eq!(loaded, state);
+    }
+
+    /// Loading a file whose internal vault_uuid mismatches the expected one
+    /// (e.g. operator copied a state file from a different vault) returns
+    /// the typed mismatch error.
+    #[test]
+    fn load_wrong_uuid_returns_mismatch_error() {
+        let dir = TempDir::new().unwrap();
+        let state = SyncState::empty([7; 16]);
+        save(dir.path(), &state).unwrap();
+        // Rename the file to make it look like the file for vault [9; 16].
+        let from = state_file_path(dir.path(), [7; 16]);
+        let to = state_file_path(dir.path(), [9; 16]);
+        std::fs::rename(&from, &to).unwrap();
+        let err = load(dir.path(), [9; 16]).unwrap_err();
+        match err {
+            StateError::VaultUuidMismatch {
+                file_uuid_hex,
+                expected_uuid_hex,
+            } => {
+                assert_eq!(file_uuid_hex, canonical_hex([7; 16]));
+                assert_eq!(expected_uuid_hex, canonical_hex([9; 16]));
+            }
+            other => panic!("expected VaultUuidMismatch, got {other:?}"),
+        }
+    }
+
+    /// First acquire succeeds; second concurrent acquire returns LockfileHeld.
+    #[test]
+    fn lockfile_collision_returns_held() {
+        let dir = TempDir::new().unwrap();
+        let _g1 = LockfileGuard::acquire(dir.path(), [3; 16]).expect("first acquire");
+        let err = LockfileGuard::acquire(dir.path(), [3; 16]).unwrap_err();
+        match err {
+            StateError::LockfileHeld(path) => {
+                assert_eq!(path, lock_file_path(dir.path(), [3; 16]));
+            }
+            other => panic!("expected LockfileHeld, got {other:?}"),
+        }
+    }
+
+    /// Releasing the first guard (drop) allows a subsequent acquire to succeed.
+    #[test]
+    fn lockfile_releases_on_drop() {
+        let dir = TempDir::new().unwrap();
+        {
+            let _g1 = LockfileGuard::acquire(dir.path(), [3; 16]).expect("first acquire");
+        } // drop releases
+        let _g2 =
+            LockfileGuard::acquire(dir.path(), [3; 16]).expect("second acquire after first drop");
+    }
+
+    /// Different vault UUIDs do NOT collide on the lockfile (each vault
+    /// has its own lock).
+    #[test]
+    fn lockfile_different_vaults_dont_collide() {
+        let dir = TempDir::new().unwrap();
+        let _g1 = LockfileGuard::acquire(dir.path(), [3; 16]).expect("vault A");
+        let _g2 = LockfileGuard::acquire(dir.path(), [4; 16]).expect("vault B");
+    }
+
+    /// `default_state_dir` returns Some on supported platforms; we only
+    /// assert it does not panic and that the path ends in `secretary/sync`
+    /// when returned.
+    #[test]
+    fn default_state_dir_ends_in_sync_subdir() {
+        if let Some(dir) = default_state_dir() {
+            assert!(
+                dir.ends_with("secretary/sync"),
+                "expected path ending in secretary/sync, got {dir:?}"
+            );
+        }
+    }
+}

--- a/cli/src/state.rs
+++ b/cli/src/state.rs
@@ -28,7 +28,7 @@
 //! UFCS form to make the call site unambiguous on any toolchain ≥ 1.87.
 
 use std::fs::{self, File, OpenOptions};
-use std::io::Write;
+use std::io::{ErrorKind, Write};
 use std::path::{Path, PathBuf};
 
 use fs4::{FileExt as Fs4FileExt, TryLockError};
@@ -106,13 +106,20 @@ pub fn default_state_dir() -> Option<PathBuf> {
 /// Load `SyncState` from `<state-dir>/<vault_uuid_hex>.state.cbor`. If the
 /// file does not exist, return `SyncState::empty(vault_uuid)`. Validates
 /// that any decoded state's `vault_uuid` matches the expected one.
+///
+/// Treats `ErrorKind::NotFound` from the single `fs::read` syscall as the
+/// "missing file" signal — a `Path::exists` pre-check would introduce a
+/// TOCTOU window where concurrent deletion (or a non-`secretary-sync`
+/// tool, since the per-vault lockfile only excludes our own binary) would
+/// surface as a confusing `Io` error instead of empty-state semantics.
 #[allow(dead_code)] // TODO(#113): consumed by Task 5 pipeline.
 pub fn load(state_dir: &Path, vault_uuid: [u8; 16]) -> Result<SyncState, StateError> {
     let path = state_file_path(state_dir, vault_uuid);
-    if !path.exists() {
-        return Ok(SyncState::empty(vault_uuid));
-    }
-    let bytes = fs::read(&path)?;
+    let bytes = match fs::read(&path) {
+        Ok(bytes) => bytes,
+        Err(e) if e.kind() == ErrorKind::NotFound => return Ok(SyncState::empty(vault_uuid)),
+        Err(e) => return Err(StateError::Io(e)),
+    };
     let state = SyncState::from_canonical_cbor(&bytes).map_err(StateError::Decode)?;
     if state.vault_uuid != vault_uuid {
         return Err(StateError::VaultUuidMismatch {
@@ -300,5 +307,20 @@ mod tests {
                 "expected path ending in secretary/sync, got {dir:?}"
             );
         }
+    }
+
+    /// Loading a file that exists but holds non-CBOR bytes returns the
+    /// typed `Decode` error (and not e.g. `Io` or a panic). Exercises the
+    /// `StateError::Decode` arm directly.
+    #[test]
+    fn load_corrupt_bytes_returns_decode_error() {
+        let dir = TempDir::new().unwrap();
+        let path = state_file_path(dir.path(), [5; 16]);
+        std::fs::write(&path, b"\xff\xff\xff\xff").unwrap();
+        let err = load(dir.path(), [5; 16]).unwrap_err();
+        assert!(
+            matches!(err, StateError::Decode(_)),
+            "expected Decode, got {err:?}"
+        );
     }
 }

--- a/docs/handoffs/2026-05-23-c2-task-2-state-lockfile-shipped.md
+++ b/docs/handoffs/2026-05-23-c2-task-2-state-lockfile-shipped.md
@@ -1,0 +1,145 @@
+# NEXT_SESSION.md — C.2 Task 2 (state persistence + host-local lockfile) shipped
+
+**Session date:** 2026-05-23 (C.2 Task 2 — `cli/src/state.rs`: SyncState CBOR persistence + per-vault flock-based lockfile).
+**Status:** C.2 Task 2 ✅ on branch `feature/c2-task-2`; PR pending. Tasks 3-10 queued.
+
+## (1) What we shipped this session
+
+A single commit on `feature/c2-task-2` carrying the second code slice of C.2 — the per-vault state-file + lockfile primitives that subsequent tasks consume.
+
+| Artifact | Path | Notes |
+|---|---|---|
+| State module | [`cli/src/state.rs`](../../cli/src/state.rs) | New, ~225 LOC. `canonical_hex` / `state_file_path` / `lock_file_path` / `default_state_dir` (pure helpers). `load` (empty-on-missing + vault-UUID mismatch typed error). `save` (atomic via `tempfile::NamedTempFile::persist`, same `=3.27.0` pin). `LockfileGuard` RAII type via `fs4::FileExt::try_lock` UFCS form. 10 unit tests. |
+| CLI entry point | [`cli/src/main.rs`](../../cli/src/main.rs) | One-line change: `mod state;` registered alongside the existing `mod args; mod exit;`. |
+| Crate manifest | [`cli/Cargo.toml`](../../cli/Cargo.toml) | `fs4` comment updated to reflect the actual API used (`FileExt::try_lock`) + the MSRV rationale for keeping the dep instead of switching to stdlib's stabilized `File::try_lock`. |
+
+Commit: `b8d3c0a` ("C.2 Task 2 — state persistence + host-local lockfile").
+
+### Plan ↔ reality reconciliations
+
+Three deliberate deviations from the plan, all noted in the commit message + PR body:
+
+| Plan note | Reality | Resolution |
+|---|---|---|
+| `SyncState::to_cbor_bytes` / `from_cbor_bytes` | Actual API: `to_canonical_cbor` / `from_canonical_cbor` ([`core/src/sync/state.rs:87`](../../core/src/sync/state.rs#L87) / [`core/src/sync/state.rs:132`](../../core/src/sync/state.rs#L132)) | Used the actual method names. No plan amendment needed — the names are equivalent in intent. |
+| `fs4::fs_std::FileExt::try_lock_exclusive` | fs4 1.x reorganized: the trait is `fs4::FileExt` (re-exported at crate root, no `fs_std` module); the exclusive try-variant is `try_lock()` returning `Result<(), fs4::TryLockError>` | Plan explicitly flagged this verification as required at impl time. Code uses `fs4::{FileExt as Fs4FileExt, TryLockError}` + UFCS call (`Fs4FileExt::try_lock(&file)`) because stdlib 1.89 stabilized an inherent `File::try_lock` that shadows the trait method (workspace MSRV is 1.87, so we can't rely on the stdlib form). |
+| "9 new tests" / target PASSED: 822 | Actual: **10 new tests** / **PASSED: 823** | Plan body listed 10 tests but the prose count said 9 — same arithmetic-off-by-one as Task 1 (where 13 vs 12 was reconciled the same way). No plan amendment; Task 3 baseline becomes "823" by ship reality. |
+
+### Gauntlet snapshot at session close
+
+```
+PASSED: 823 FAILED: 0 IGNORED: 10
+clippy --release --workspace --tests -- -D warnings   clean
+fmt --all -- --check                                  clean
+uv run core/tests/python/conformance.py               PASS
+uv run core/tests/python/spec_test_name_freshness.py  PASS (96 resolved / 0 unresolved / 2 suppressed)
+```
+
+(`fmt` ran once with `--check` and surfaced a single re-wrap on a long
+`expect("...")` line in a test; `cargo fmt --all` applied it before commit.)
+
+## (2) What's next — start C.2 Task 3
+
+After this PR merges, the next slice is **C.2 Task 3: Unlock module** ([`docs/superpowers/plans/2026-05-23-c2-headless-sync-cli.md`](../superpowers/plans/2026-05-23-c2-headless-sync-cli.md) §"Task 3").
+
+### Acceptance criteria for Task 3
+
+- [ ] New `cli/src/unlock.rs` (~180 LOC) with the following surface:
+  - `PasswordSource<'a, R: Read>` enum (`Tty` / `Stream(&'a mut R)`).
+  - `read_password_from_reader<R: Read>(reader: &mut R) -> Result<SecretBytes, UnlockReadError>` — strips one trailing `\n` or `\r\n`; empty after strip → `UnlockReadError::Empty`.
+  - `UnlockReadError` enum: `NonInteractiveWithoutStdin`, `Io(#[from] io::Error)`, `Empty`.
+  - TTY path uses `rpassword::prompt_password(PASSWORD_PROMPT)`; stream path uses the pure-function helper above.
+- [ ] `cli/src/main.rs` gains `mod unlock;`.
+- [ ] N unit tests cover: roundtrip from `Cursor<Vec<u8>>`, trailing `\n` strip, trailing `\r\n` strip, empty-after-strip returns `Empty`, no-trailing-newline preserved verbatim. Plan text says "5 tests"; per Task 2's reconciliation pattern, the actual count may float by ±1 depending on body vs prose.
+- [ ] Gauntlet target: **PASSED: 823 + N FAILED: 0 IGNORED: 10**. Absolute base is now 823 (not the plan's 821/822).
+- [ ] Clippy, fmt, conformance, spec freshness all clean.
+
+### Plan handoff
+
+Full step-by-step in [`docs/superpowers/plans/2026-05-23-c2-headless-sync-cli.md`](../superpowers/plans/2026-05-23-c2-headless-sync-cli.md) §"Task 3", which still applies — Task 2's three reconciliations do not affect Task 3's surface (unlock is a separate module with no dep on state.rs).
+
+## (3) Open decisions and risks
+
+### Decisions settled during this session
+
+- **fs4 dep retained, not swapped for stdlib `File::try_lock`.** Stdlib stabilized the inherent method in Rust 1.89, but our workspace `rust-version = "1.87"` is below that. Switching to stdlib would force a workspace MSRV bump, which is a meaningfully larger change than this task's scope. The fs4 trait call uses UFCS (`Fs4FileExt::try_lock(&file)`) to remain unambiguous on any toolchain ≥ 1.87. If a future task wants to revisit MSRV, fs4 can be dropped in one line at that point.
+- **`StateError::VaultUuidMismatch` carries both hex strings (`file_uuid_hex` + `expected_uuid_hex`)**, not just the typed variant — so the displayed error gives operators enough context to identify which file is wrong without re-running with extra logging. Costs ~32 chars per error; negligible. Tested by `load_wrong_uuid_returns_mismatch_error`.
+- **`LockfileGuard` derives `Debug`** — required so the test `assert!(matches!(err, StateError::LockfileHeld(_)))` compiles via `unwrap_err()`. Holds a `File` (which itself derives `Debug`) + a `PathBuf`; no secrets.
+
+### Decisions carried forward (unchanged from C.2 Task 1 close)
+
+- D1-D10 from the spec are still settled.
+- `--veto-policy=fail`, `--decisions-file`, `--exit-on-error`, `status`, `init` subcommands all deferred to future C.2.x slices.
+- Windows is best-effort per D10 (no CI runner planned for C.2 implementation).
+- Clean-room conformance harness for `cli/` deferred to C.4 or a future C.2.x slice.
+- The `from_sync_error` mapper's exit-code surface (Task 1 design): every `SyncError` variant without a dedicated code maps to `GenericError = 1`; bijection-failure variants (`UnknownVetoDecision` / `MissingVetoDecision` / `EmptyDraftWithVetoes`) do NOT get distinct codes because they indicate CLI bugs, not operator-recoverable conditions.
+
+### Risks carried into Task 3
+
+- **`#[allow(dead_code)]` on `StateError` / `load` / `save` / `LockfileGuard`** lifts when Task 5 (pipeline) consumes them. Tracked at issue [#113](https://github.com/hherb/secretary/issues/113) alongside the Task 1 `ExitCode` / `from_sync_error` allowances; the `TODO(#113):` markers in `cli/src/state.rs` annotate every suppression site.
+- **`tempfile = "=3.27.0"` exact pin** is in `cli/Cargo.toml` already (added in Task 1). Task 2's `save()` is the first consumer in `cli/`. Same discipline as `core` — bump only via deliberate changelog review.
+- **No `cli/` integration tests yet.** Task 2 ships unit tests only, which exercise the I/O paths via `tempfile::TempDir`. End-to-end CLI testing arrives in Task 10's `assert_cmd`-driven `cli/tests/once_integration.rs`.
+
+### Issues currently open
+
+- #37 — Sub-project C umbrella. C.2 Tasks 1-2 ✅ in PRs #112 and (pending #).
+- #113 — C.2 Task 5 cleanup checklist (filed during Task 1 PR review): lift `#[allow(dead_code)]` in `cli/src/exit.rs` + `cli/src/state.rs`, and add `--non-interactive` ↔ `--password-stdin` validation. Task 2 added more allowances under the same TODO(#113) marker — same cleanup obligation.
+- #38, #45, #75, #76, #78, #79, #81, #87, #88, #90, #95, #98 — none block C.2 Task 3.
+
+### Housekeeping note (stale worktrees on disk)
+
+After this PR:
+- `/Users/hherb/src/secretary` — `main` (clean post-merge).
+- `/Users/hherb/src/secretary/.worktrees/c1-1b-sync-merge` — branch `feature/c1-1b-task-17`, remote gone. Safe to remove.
+- `/Users/hherb/src/secretary/.worktrees/c2-task-1-spec` — branch `feature/c2-task-1-spec`, remote gone. Safe to remove.
+- `/Users/hherb/src/secretary/.worktrees/c2-task-1` — branch `feature/c2-task-1`, remote gone after PR #112 merged. Safe to remove.
+- `/Users/hherb/src/secretary/.worktrees/c2-task-2` — **this session's work**; keep until PR merges, then remove.
+
+```bash
+# One-line each (run from /Users/hherb/src/secretary):
+git worktree remove .worktrees/c1-1b-sync-merge && git branch -D feature/c1-1b-task-17
+git worktree remove .worktrees/c2-task-1-spec   && git branch -D feature/c2-task-1-spec
+git worktree remove .worktrees/c2-task-1        && git branch -D feature/c2-task-1
+```
+
+Cleanup is one-line each and does NOT block Task 3.
+
+## (4) Exact commands to resume
+
+```bash
+# After this C.2 Task 2 PR (feature/c2-task-2) merges:
+cd /Users/hherb/src/secretary
+git fetch --prune origin
+git status --short                       # expect: clean (modulo NEXT_SESSION.md sync, see below)
+git checkout main
+git pull --ff-only origin main
+
+# Verify gauntlet on fresh main (expect 823 / 0 / 10 — same as session close):
+cargo test --release --workspace --no-fail-fast 2>&1 | grep -E "^test result:" | awk '{passed+=$4; failed+=$6; ignored+=$8} END {print "PASSED:", passed, "FAILED:", failed, "IGNORED:", ignored}'
+cargo clippy --release --workspace --tests -- -D warnings 2>&1 | tail -3
+cargo fmt --all -- --check
+uv run core/tests/python/conformance.py 2>&1 | tail -3
+uv run core/tests/python/spec_test_name_freshness.py 2>&1 | tail -3
+
+# Start Task 3:
+git worktree add .worktrees/c2-task-3 -b feature/c2-task-3 main
+cd .worktrees/c2-task-3
+
+# Open the plan and follow Task 3 line-by-line:
+#   docs/superpowers/plans/2026-05-23-c2-headless-sync-cli.md §"Task 3"
+# Steps 1-5 cover the full scaffold + commit + PR.
+```
+
+## Closing inventory
+
+- **Branch state on close:** `main` at `968aee1` (PR #112 squash-merged). `feature/c2-task-2` carries 1 commit (`b8d3c0a`) on top.
+- **Workspace tests on `feature/c2-task-2`:** 823 passed + 10 ignored (813 base + 10 new cli `state` unit tests). Clippy + fmt + Python conformance + spec freshness all clean.
+- **README.md:** unchanged this session — Task 2 ships internal scaffolding (state/lockfile primitives), no user-visible behavior. Plan defers README update to Task 10.
+- **ROADMAP.md:** unchanged this session — same reason; ROADMAP already calls C.2 "queued" since the C.2 design PR.
+- **CLAUDE.md:** unchanged this session — the `tempfile` exact-pin discipline noted in `cli/Cargo.toml` is a cross-reference, not a new convention.
+- **NEXT_SESSION.md:** symlink retargeted to this file.
+- **Open issues:** see §(3) — none block Task 3.
+- **Open PRs:** one to be opened at end of this session (C.2 Task 2).
+- **Worktrees on disk:** see §(3) housekeeping.
+- **Frozen baton snapshots:** all 19 prior C.1.1b + C.2-design + C.2-task-1 handoffs at [`docs/handoffs/`](.) — preserved unchanged.
+- **This file:** the live baton for C.2 Task 2 close.

--- a/docs/handoffs/2026-05-23-c2-task-2-state-lockfile-shipped.md
+++ b/docs/handoffs/2026-05-23-c2-task-2-state-lockfile-shipped.md
@@ -9,11 +9,15 @@ A single commit on `feature/c2-task-2` carrying the second code slice of C.2 —
 
 | Artifact | Path | Notes |
 |---|---|---|
-| State module | [`cli/src/state.rs`](../../cli/src/state.rs) | New, ~225 LOC. `canonical_hex` / `state_file_path` / `lock_file_path` / `default_state_dir` (pure helpers). `load` (empty-on-missing + vault-UUID mismatch typed error). `save` (atomic via `tempfile::NamedTempFile::persist`, same `=3.27.0` pin). `LockfileGuard` RAII type via `fs4::FileExt::try_lock` UFCS form. 10 unit tests. |
+| State module | [`cli/src/state.rs`](../../cli/src/state.rs) | New, ~230 LOC. `canonical_hex` / `state_file_path` / `lock_file_path` / `default_state_dir` (pure helpers). `load` (single-syscall `fs::read` with `ErrorKind::NotFound` → empty-state; vault-UUID mismatch typed error). `save` (atomic via `tempfile::NamedTempFile::persist`, same `=3.27.0` pin). `LockfileGuard` RAII type via `fs4::FileExt::try_lock` UFCS form. 11 unit tests. |
 | CLI entry point | [`cli/src/main.rs`](../../cli/src/main.rs) | One-line change: `mod state;` registered alongside the existing `mod args; mod exit;`. |
 | Crate manifest | [`cli/Cargo.toml`](../../cli/Cargo.toml) | `fs4` comment updated to reflect the actual API used (`FileExt::try_lock`) + the MSRV rationale for keeping the dep instead of switching to stdlib's stabilized `File::try_lock`. |
 
-Commit: `b8d3c0a` ("C.2 Task 2 — state persistence + host-local lockfile").
+Commits:
+- `b8d3c0a` — "C.2 Task 2 — state persistence + host-local lockfile" (initial slice).
+- *(this commit)* — post-review touch-up: tighten `load` to a single-syscall `fs::read` with `ErrorKind::NotFound` (closes a benign TOCTOU window where `Path::exists` could race a non-`secretary-sync` deleter, since the per-vault lockfile only excludes our own binary). Adds one new test (`load_corrupt_bytes_returns_decode_error`) exercising the `StateError::Decode` arm directly. Workspace 823 → 824.
+
+A third nit from review — switching `canonical_hex` to the `hex` crate — was checked-and-skipped: `core/Cargo.toml` declares `hex` only under `[dev-dependencies]`; runtime hex sites in `core` (`identity/fingerprint.rs::hex_form`, `unlock/vault_toml.rs::hex_nibble`) hand-roll the encoding. The current `canonical_hex` follows the established convention.
 
 ### Plan ↔ reality reconciliations
 
@@ -28,7 +32,7 @@ Three deliberate deviations from the plan, all noted in the commit message + PR 
 ### Gauntlet snapshot at session close
 
 ```
-PASSED: 823 FAILED: 0 IGNORED: 10
+PASSED: 824 FAILED: 0 IGNORED: 10
 clippy --release --workspace --tests -- -D warnings   clean
 fmt --all -- --check                                  clean
 uv run core/tests/python/conformance.py               PASS
@@ -51,7 +55,7 @@ After this PR merges, the next slice is **C.2 Task 3: Unlock module** ([`docs/su
   - TTY path uses `rpassword::prompt_password(PASSWORD_PROMPT)`; stream path uses the pure-function helper above.
 - [ ] `cli/src/main.rs` gains `mod unlock;`.
 - [ ] N unit tests cover: roundtrip from `Cursor<Vec<u8>>`, trailing `\n` strip, trailing `\r\n` strip, empty-after-strip returns `Empty`, no-trailing-newline preserved verbatim. Plan text says "5 tests"; per Task 2's reconciliation pattern, the actual count may float by ±1 depending on body vs prose.
-- [ ] Gauntlet target: **PASSED: 823 + N FAILED: 0 IGNORED: 10**. Absolute base is now 823 (not the plan's 821/822).
+- [ ] Gauntlet target: **PASSED: 824 + N FAILED: 0 IGNORED: 10**. Absolute base is now 824 (not the plan's 821/822) — bumped from 823 by the post-review `load_corrupt_bytes_returns_decode_error` test.
 - [ ] Clippy, fmt, conformance, spec freshness all clean.
 
 ### Plan handoff
@@ -114,7 +118,7 @@ git status --short                       # expect: clean (modulo NEXT_SESSION.md
 git checkout main
 git pull --ff-only origin main
 
-# Verify gauntlet on fresh main (expect 823 / 0 / 10 — same as session close):
+# Verify gauntlet on fresh main (expect 824 / 0 / 10 — same as session close):
 cargo test --release --workspace --no-fail-fast 2>&1 | grep -E "^test result:" | awk '{passed+=$4; failed+=$6; ignored+=$8} END {print "PASSED:", passed, "FAILED:", failed, "IGNORED:", ignored}'
 cargo clippy --release --workspace --tests -- -D warnings 2>&1 | tail -3
 cargo fmt --all -- --check
@@ -133,7 +137,7 @@ cd .worktrees/c2-task-3
 ## Closing inventory
 
 - **Branch state on close:** `main` at `968aee1` (PR #112 squash-merged). `feature/c2-task-2` carries 1 commit (`b8d3c0a`) on top.
-- **Workspace tests on `feature/c2-task-2`:** 823 passed + 10 ignored (813 base + 10 new cli `state` unit tests). Clippy + fmt + Python conformance + spec freshness all clean.
+- **Workspace tests on `feature/c2-task-2`:** 824 passed + 10 ignored (813 base + 11 new cli `state` unit tests; the 11th is `load_corrupt_bytes_returns_decode_error`, added during post-review touch-up). Clippy + fmt + Python conformance + spec freshness all clean.
 - **README.md:** unchanged this session — Task 2 ships internal scaffolding (state/lockfile primitives), no user-visible behavior. Plan defers README update to Task 10.
 - **ROADMAP.md:** unchanged this session — same reason; ROADMAP already calls C.2 "queued" since the C.2 design PR.
 - **CLAUDE.md:** unchanged this session — the `tempfile` exact-pin discipline noted in `cli/Cargo.toml` is a cross-reference, not a new convention.


### PR DESCRIPTION
## Summary

Second code slice of C.2 (the headless `secretary-sync` CLI). Adds `cli/src/state.rs` — the per-vault state-file + lockfile primitives that subsequent C.2 tasks consume.

- **`SyncState` CBOR persistence:** `load` (empty-on-missing, vault-UUID mismatch returns typed `StateError::VaultUuidMismatch` with both hex strings) + `save` (atomic via `tempfile::NamedTempFile::persist`, sharing the `=3.27.0` exact pin with the vault format layer).
- **Host-local lockfile:** `LockfileGuard::acquire` is an RAII type wrapping `fs4::FileExt::try_lock` (flock(LOCK_EX|LOCK_NB) on Unix, LockFileEx on Windows). Kernel auto-releases on process death — no stale-PID handling.
- **Pure helpers:** `canonical_hex(uuid) -> String`, `state_file_path(dir, uuid) -> PathBuf`, `lock_file_path(dir, uuid) -> PathBuf`, `default_state_dir() -> Option<PathBuf>` (via the `dirs` crate).
- **10 new unit tests** (workspace 813 → 823).

## Plan ↔ reality reconciliations

Three deliberate deviations from [docs/superpowers/plans/2026-05-23-c2-headless-sync-cli.md §"Task 2"](docs/superpowers/plans/2026-05-23-c2-headless-sync-cli.md):

| Plan | Reality | Resolution |
|---|---|---|
| `SyncState::to_cbor_bytes` / `from_cbor_bytes` | Actual API: `to_canonical_cbor` / `from_canonical_cbor` (`core/src/sync/state.rs:87` / `:132`) | Used actual names; intent-equivalent. |
| `fs4::fs_std::FileExt::try_lock_exclusive` | fs4 1.x reorganized: trait is `fs4::FileExt` at crate root, method is `try_lock()` returning `Result<(), fs4::TryLockError>`. The plan explicitly flagged this as required to verify at impl time. | Used `fs4::{FileExt as Fs4FileExt, TryLockError}` + UFCS call `Fs4FileExt::try_lock(&file)`. **The UFCS form is required because stdlib 1.89 stabilized an inherent `File::try_lock` that shadows the trait method; the workspace MSRV is 1.87 so we can't rely on the stdlib form yet.** |
| "9 new tests" / target 822 | 10 new tests / 823 | Same arithmetic-off-by-one as Task 1 — plan body lists 10 tests, prose says 9. |

## Test plan

- [x] 10 new unit tests; workspace `PASSED: 823 FAILED: 0 IGNORED: 10`.
- [x] `cargo clippy --release --workspace --tests -- -D warnings` clean.
- [x] `cargo fmt --all -- --check` clean.
- [x] `uv run core/tests/python/conformance.py` PASS.
- [x] `uv run core/tests/python/spec_test_name_freshness.py` PASS (96 resolved / 0 unresolved / 2 suppressed).

## Issues touched

- Adds more `#[allow(dead_code)] // TODO(#113):` suppressions on the not-yet-consumed `StateError` / `load` / `save` / `LockfileGuard` surface. Lifts when Task 5 (pipeline) wires them. Tracked under issue #113 alongside the Task 1 `ExitCode` / `from_sync_error` allowances.

🤖 Generated with [Claude Code](https://claude.com/claude-code)