### PR TITLE
C.2 Task 3 — unlock module: TTY + stdin password sourcing

### DIFF
--- a/NEXT_SESSION.md
+++ b/NEXT_SESSION.md
@@ -1,1 +1,1 @@
-docs/handoffs/2026-05-23-c2-task-2-state-lockfile-shipped.md
+docs/handoffs/2026-05-23-c2-task-3-unlock-shipped.md

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -6,6 +6,7 @@ use clap::Parser;
 mod args;
 mod exit;
 mod state;
+mod unlock;
 
 fn main() {
     let cli = args::Cli::parse();

--- a/cli/src/unlock.rs
+++ b/cli/src/unlock.rs
@@ -1,0 +1,208 @@
+//! Password sourcing — TTY prompt or `--password-stdin` stream.
+//!
+//! Spec: [`docs/superpowers/specs/2026-05-23-c2-headless-sync-cli-design.md`](../../docs/superpowers/specs/2026-05-23-c2-headless-sync-cli-design.md)
+//! §D2 (`--password-stdin` is the only headless unlock channel).
+//!
+//! The pure-function piece — [`read_password_from_reader`] — takes any
+//! [`Read`] so unit tests can drive it from an in-memory `Cursor` without
+//! touching a real TTY. The interactive TTY path lives in
+//! [`read_password_from_tty`] (thin wrapper around `rpassword`).
+//!
+//! ## Zeroize discipline
+//!
+//! Both paths funnel the password bytes into a freshly allocated
+//! [`SecretBytes`] via [`SecretBytes::new`] (ownership move, single
+//! allocation). [`SecretBytes`] derives `ZeroizeOnDrop`, and the
+//! `Zeroize` impl for `Vec<u8>` wipes the entire backing slice up to
+//! `capacity` — including any bytes past `len` (e.g. the trailing
+//! newline byte popped off before construction). The intermediate
+//! `Vec<u8>` / `String` allocation is moved into the wrapper, never
+//! copied, so the password never lives in an unzeroized heap location
+//! after this module returns control.
+//!
+//! See [`CLAUDE.md`](../../CLAUDE.md) "Memory hygiene: zeroize discipline".
+
+use std::io::{self, Read};
+
+use thiserror::Error;
+
+use secretary_core::crypto::secret::SecretBytes;
+
+/// Prompt rendered to the TTY in interactive unlock mode. Trailing space
+/// is intentional — `rpassword::prompt_password` does not append one.
+const PASSWORD_PROMPT: &str = "Vault password: ";
+
+#[allow(dead_code)] // TODO(#113): consumed by Task 5 pipeline.
+#[derive(Debug, Error)]
+pub enum UnlockReadError {
+    #[error("--non-interactive requires --password-stdin to provide the password")]
+    NonInteractiveWithoutStdin,
+    #[error("I/O error reading password: {0}")]
+    Io(#[from] io::Error),
+    #[error("password is empty after stripping trailing newline")]
+    Empty,
+}
+
+/// Strategy for sourcing the unlock password. Carried by the CLI's
+/// top-level dispatch into [`pipeline::run_one`] (Task 5), which selects
+/// between the TTY prompt and a `Read`-backed stream based on
+/// `--password-stdin`.
+///
+/// Generic over `R: Read` so unit tests (and Task 5's
+/// pipeline-orchestration tests) can drive the `Stream` arm from a
+/// `Cursor<Vec<u8>>` without touching stdin or a TTY.
+#[allow(dead_code)] // TODO(#113): consumed by Task 5 pipeline.
+pub enum PasswordSource<'a, R: Read> {
+    /// Read interactively from the TTY via `rpassword` — no echo.
+    Tty,
+    /// Read from any `Read` impl (production: `stdin().lock()`; tests:
+    /// `Cursor<Vec<u8>>`) until EOF.
+    Stream(&'a mut R),
+}
+
+/// Read a password from `--password-stdin` (or any `Read` for testing)
+/// and return it in a zeroize-on-drop [`SecretBytes`].
+///
+/// Strips exactly one trailing line ending (`\n` or `\r\n`) — operators
+/// commonly pipe `echo "secret" | secretary-sync --password-stdin ...`
+/// and the shell appends a newline. Multiple trailing newlines past the
+/// first are preserved verbatim (the password legitimately ends in a
+/// newline character).
+///
+/// Returns [`UnlockReadError::Empty`] if the remaining buffer is empty
+/// after the strip — this catches both `echo "" | ...` and a bare `\n`
+/// on stdin, either of which would otherwise pass an empty password
+/// down to `open_with_password` and surface a less obvious unlock
+/// failure further in.
+#[allow(dead_code)] // TODO(#113): consumed by Task 5 pipeline.
+pub fn read_password_from_reader<R: Read>(reader: &mut R) -> Result<SecretBytes, UnlockReadError> {
+    let mut buf: Vec<u8> = Vec::new();
+    reader.read_to_end(&mut buf)?;
+    if buf.last() == Some(&b'\n') {
+        buf.pop();
+        if buf.last() == Some(&b'\r') {
+            buf.pop();
+        }
+    }
+    if buf.is_empty() {
+        return Err(UnlockReadError::Empty);
+    }
+    // Move ownership of `buf` into the SecretBytes — its ZeroizeOnDrop
+    // derive then wipes the entire `capacity`-sized backing slice on
+    // drop, including any bytes past `len` (e.g. the popped trailing
+    // newline byte). No double allocation, no `zeroize` direct dep in
+    // `cli/Cargo.toml`.
+    Ok(SecretBytes::new(buf))
+}
+
+/// Read a password from the TTY via `rpassword::prompt_password`. Used
+/// in interactive mode (no `--password-stdin`). Returns
+/// [`UnlockReadError::Empty`] if the operator submitted an empty line.
+///
+/// The returned [`SecretBytes`] is constructed via [`SecretBytes::new`]
+/// from `String::into_bytes` — the underlying allocation moves, so the
+/// password never lives in an unzeroized `String` after this call.
+#[allow(dead_code)] // TODO(#113): consumed by Task 5 pipeline.
+pub fn read_password_from_tty() -> Result<SecretBytes, UnlockReadError> {
+    let s = rpassword::prompt_password(PASSWORD_PROMPT)?;
+    let bytes = s.into_bytes();
+    if bytes.is_empty() {
+        return Err(UnlockReadError::Empty);
+    }
+    Ok(SecretBytes::new(bytes))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Cursor;
+
+    /// A password with no trailing newline at all is preserved verbatim.
+    #[test]
+    fn reader_returns_password_bytes() {
+        let mut input = Cursor::new(b"hunter2".to_vec());
+        let secret = read_password_from_reader(&mut input).expect("read failed");
+        assert_eq!(secret.expose(), b"hunter2");
+    }
+
+    /// A single trailing `\n` is stripped.
+    #[test]
+    fn reader_strips_trailing_newline() {
+        let mut input = Cursor::new(b"hunter2\n".to_vec());
+        let secret = read_password_from_reader(&mut input).expect("read failed");
+        assert_eq!(secret.expose(), b"hunter2");
+    }
+
+    /// A single trailing `\r\n` (Windows / cat-from-CRLF-file) is stripped.
+    #[test]
+    fn reader_strips_trailing_crlf() {
+        let mut input = Cursor::new(b"hunter2\r\n".to_vec());
+        let secret = read_password_from_reader(&mut input).expect("read failed");
+        assert_eq!(secret.expose(), b"hunter2");
+    }
+
+    /// Only ONE trailing line ending is stripped — two trailing `\n`
+    /// keeps the inner `\n` as part of the password (the operator
+    /// intentionally piped a multi-line value).
+    #[test]
+    fn reader_only_strips_one_newline() {
+        let mut input = Cursor::new(b"hunter2\n\n".to_vec());
+        let secret = read_password_from_reader(&mut input).expect("read failed");
+        assert_eq!(secret.expose(), b"hunter2\n");
+    }
+
+    /// A lone `\r` (no `\n` after it) is NOT stripped — we only treat
+    /// `\r\n` as a line ending when the `\n` is present.
+    #[test]
+    fn reader_lone_cr_is_preserved() {
+        let mut input = Cursor::new(b"hunter2\r".to_vec());
+        let secret = read_password_from_reader(&mut input).expect("read failed");
+        assert_eq!(secret.expose(), b"hunter2\r");
+    }
+
+    /// Empty stdin → typed `Empty` error (not a silent empty-password
+    /// pass-through to `open_with_password`).
+    #[test]
+    fn reader_empty_input_errors() {
+        let mut input = Cursor::new(Vec::<u8>::new());
+        let err = read_password_from_reader(&mut input).unwrap_err();
+        assert!(
+            matches!(err, UnlockReadError::Empty),
+            "expected Empty, got {err:?}"
+        );
+    }
+
+    /// A bare `\n` reduces to empty after the strip → typed `Empty`
+    /// error.
+    #[test]
+    fn reader_newline_only_errors_as_empty() {
+        let mut input = Cursor::new(b"\n".to_vec());
+        let err = read_password_from_reader(&mut input).unwrap_err();
+        assert!(
+            matches!(err, UnlockReadError::Empty),
+            "expected Empty, got {err:?}"
+        );
+    }
+
+    /// A bare `\r\n` reduces to empty after the strip → typed `Empty`
+    /// error.
+    #[test]
+    fn reader_crlf_only_errors_as_empty() {
+        let mut input = Cursor::new(b"\r\n".to_vec());
+        let err = read_password_from_reader(&mut input).unwrap_err();
+        assert!(
+            matches!(err, UnlockReadError::Empty),
+            "expected Empty, got {err:?}"
+        );
+    }
+
+    /// Both [`PasswordSource`] variants can be constructed under the
+    /// `<R: Read>` bound — guards against future refactors that
+    /// accidentally tighten the bound or rename a variant.
+    #[test]
+    fn password_source_variants_compile() {
+        let _ = PasswordSource::<Cursor<Vec<u8>>>::Tty;
+        let mut cursor = Cursor::new(b"x".to_vec());
+        let _ = PasswordSource::Stream(&mut cursor);
+    }
+}

--- a/cli/src/unlock.rs
+++ b/cli/src/unlock.rs
@@ -18,7 +18,16 @@
 //! newline byte popped off before construction). The intermediate
 //! `Vec<u8>` / `String` allocation is moved into the wrapper, never
 //! copied, so the password never lives in an unzeroized heap location
-//! after this module returns control.
+//! **after this module returns control**.
+//!
+//! Residual caveat: `Vec::read_to_end` (stdin path) and the `String`
+//! buffer inside `rpassword::prompt_password` (TTY path) may reallocate
+//! and grow as they read. Each grow frees the *previous* allocation
+//! without zeroizing it, so a small window of unzeroed heap residue
+//! exists during the read itself. This is the same cross-workspace
+//! caveat documented in [`docs/manual/contributors/memory-hygiene-audit-internal.md`](../../docs/manual/contributors/memory-hygiene-audit-internal.md);
+//! for typical password lengths (well under the default `Vec` initial
+//! capacity progression), the practical exposure is one or two grows.
 //!
 //! See [`CLAUDE.md`](../../CLAUDE.md) "Memory hygiene: zeroize discipline".
 
@@ -105,6 +114,15 @@ pub fn read_password_from_reader<R: Read>(reader: &mut R) -> Result<SecretBytes,
 #[allow(dead_code)] // TODO(#113): consumed by Task 5 pipeline.
 pub fn read_password_from_tty() -> Result<SecretBytes, UnlockReadError> {
     let s = rpassword::prompt_password(PASSWORD_PROMPT)?;
+    finalize_tty(s)
+}
+
+/// Convert an `rpassword`-returned `String` into a zeroize-on-drop
+/// [`SecretBytes`], rejecting empty input with
+/// [`UnlockReadError::Empty`]. Split out from [`read_password_from_tty`]
+/// so the empty-input branch is exercisable in unit tests without
+/// driving a real TTY.
+fn finalize_tty(s: String) -> Result<SecretBytes, UnlockReadError> {
     let bytes = s.into_bytes();
     if bytes.is_empty() {
         return Err(UnlockReadError::Empty);
@@ -149,6 +167,17 @@ mod tests {
         let mut input = Cursor::new(b"hunter2\n\n".to_vec());
         let secret = read_password_from_reader(&mut input).expect("read failed");
         assert_eq!(secret.expose(), b"hunter2\n");
+    }
+
+    /// Symmetric to `reader_only_strips_one_newline`: a trailing
+    /// `\r\n\r\n` strips one full `\r\n` and preserves the inner one.
+    /// Locks in "strip one line ending atomically" rather than "strip
+    /// one `\n` then maybe one `\r`."
+    #[test]
+    fn reader_only_strips_one_crlf() {
+        let mut input = Cursor::new(b"hunter2\r\n\r\n".to_vec());
+        let secret = read_password_from_reader(&mut input).expect("read failed");
+        assert_eq!(secret.expose(), b"hunter2\r\n");
     }
 
     /// A lone `\r` (no `\n` after it) is NOT stripped — we only treat
@@ -204,5 +233,28 @@ mod tests {
         let _ = PasswordSource::<Cursor<Vec<u8>>>::Tty;
         let mut cursor = Cursor::new(b"x".to_vec());
         let _ = PasswordSource::Stream(&mut cursor);
+    }
+
+    /// TTY-path empty-input branch: `finalize_tty("")` must return the
+    /// typed `Empty` error, matching the stdin path's behavior. The
+    /// helper exists specifically so this branch is reachable without
+    /// driving a pty.
+    #[test]
+    fn finalize_tty_empty_string_errors_as_empty() {
+        let err = finalize_tty(String::new()).unwrap_err();
+        assert!(
+            matches!(err, UnlockReadError::Empty),
+            "expected Empty, got {err:?}"
+        );
+    }
+
+    /// TTY-path happy path: `finalize_tty` moves the `String`'s buffer
+    /// into a `SecretBytes` whose bytes match the input verbatim. The
+    /// TTY caller does NOT strip a trailing newline — `rpassword`
+    /// already consumes the Enter keystroke before returning.
+    #[test]
+    fn finalize_tty_preserves_password_bytes() {
+        let secret = finalize_tty(String::from("hunter2")).expect("finalize failed");
+        assert_eq!(secret.expose(), b"hunter2");
     }
 }

--- a/docs/handoffs/2026-05-23-c2-task-3-unlock-shipped.md
+++ b/docs/handoffs/2026-05-23-c2-task-3-unlock-shipped.md
@@ -1,0 +1,152 @@
+# NEXT_SESSION.md — C.2 Task 3 (unlock module) shipped
+
+**Session date:** 2026-05-23 (C.2 Task 3 — `cli/src/unlock.rs`: `PasswordSource` enum + reader/TTY password sourcing).
+**Status:** C.2 Task 3 ✅ on branch `feature/c2-task-3`; PR pending. Tasks 4-10 queued.
+
+## (1) What we shipped this session
+
+A single commit on `feature/c2-task-3` carrying the third code slice of C.2 — the password-sourcing primitives. The TTY path is a thin `rpassword` wrapper; the `--password-stdin` path is a pure-function (`Cursor`-testable) reader. Both funnel bytes into a freshly allocated [`SecretBytes`] via [`SecretBytes::new`], moving ownership of the underlying allocation so the password never lingers in an unzeroized location after the function returns.
+
+| Artifact | Path | Notes |
+|---|---|---|
+| Unlock module | [`cli/src/unlock.rs`](../../cli/src/unlock.rs) | New, ~200 LOC. `UnlockReadError` (3 variants: `NonInteractiveWithoutStdin`, `Io`, `Empty`). `PasswordSource<'a, R: Read>` enum (`Tty` / `Stream(&mut R)`). `read_password_from_reader<R: Read>(&mut R) -> Result<SecretBytes, _>` strips exactly one `\n` or `\r\n`, returns `Empty` if the remainder is empty. `read_password_from_tty() -> Result<SecretBytes, _>` calls `rpassword::prompt_password("Vault password: ")`. 9 unit tests. |
+| CLI entry point | [`cli/src/main.rs`](../../cli/src/main.rs) | One-line change: `mod unlock;` registered alongside the existing `mod args; mod exit; mod state;`. |
+
+Commits:
+- *(this commit)* — "C.2 Task 3 — unlock module: TTY + stdin password sourcing" on `feature/c2-task-3`.
+
+### Plan ↔ reality reconciliations
+
+Three deliberate deviations from the plan, all noted in the commit body:
+
+| Plan note | Reality | Resolution |
+|---|---|---|
+| `SecretBytes::from(buf.as_slice())` + `zeroize::Zeroize::zeroize(&mut buf)` | `SecretBytes::new(buf)` (ownership move) | The plan's pattern would have required adding `zeroize` as a direct dep of `cli/Cargo.toml` AND double-allocated (`From<&[u8]>` calls `bytes.to_vec()`). `SecretBytes::new(Vec<u8>)` takes ownership of the original allocation; the `ZeroizeOnDrop` derive on `SecretBytes` wipes the entire `capacity` slice on drop, including bytes past `len` (e.g. the popped trailing-newline byte). Single allocation, no new dep, aligned with CLAUDE.md §"Memory hygiene: zeroize discipline". |
+| `cargo test -p secretary-cli --lib unlock` | `cargo test -p secretary-cli unlock` | `cli/` is binary-only (`[[bin]]` in `Cargo.toml`, no `lib.rs`). The `--lib` filter errors with "no library targets found in package `secretary-cli`". Drop the filter; cargo runs the binary's unit tests by default. |
+| "5 tests" (plan prose) / "N unit tests" (acceptance) | **9 unit tests** / **PASSED: 833** | Two additional edge-case tests beyond the plan body: `reader_lone_cr_is_preserved` (lone `\r` is NOT stripped — only `\r\n`) and `reader_crlf_only_errors_as_empty` (a bare `\r\n` reduces to empty). These close the line-ending strip's branch coverage. Same `±1` reconciliation pattern as Tasks 1 and 2. |
+
+### Gauntlet snapshot at session close
+
+```
+PASSED: 833 FAILED: 0 IGNORED: 10
+clippy --release --workspace --tests -- -D warnings   clean
+fmt --all -- --check                                  clean
+uv run core/tests/python/conformance.py               PASS
+uv run core/tests/python/spec_test_name_freshness.py  PASS (96 resolved / 0 unresolved / 2 suppressed)
+```
+
+(`fmt --check` initially flagged a long `#[allow(dead_code)] // TODO(...):` line that rustfmt rewrapped onto two lines splitting the attribute from the next `#[derive(...)]`. Tightened the TODO comment to the brief form `// TODO(#113): consumed by Task 5 pipeline.` to match the state.rs convention; `fmt --check` then re-ran clean.)
+
+## (2) What's next — start C.2 Task 4
+
+After this PR merges, the next slice is **C.2 Task 4: Veto trait + non-interactive + interactive impls** ([`docs/superpowers/plans/2026-05-23-c2-headless-sync-cli.md`](../superpowers/plans/2026-05-23-c2-headless-sync-cli.md) §"Task 4").
+
+### Acceptance criteria for Task 4
+
+- [ ] New `cli/src/veto/mod.rs` (~60 LOC):
+  - `VetoUx` trait with `fn decide(&mut self, vetoes: &[RecordTombstoneVeto]) -> Vec<VetoDecision>`.
+  - `pub mod interactive;` + `pub mod noninteractive;`.
+- [ ] New `cli/src/veto/noninteractive.rs` (~70 LOC):
+  - `AutoKeepLocalVetoUx` unit struct, `impl VetoUx` returning `Vec<VetoDecision::KeepLocal>` preserving order.
+  - 2 unit tests (empty input, multi-veto preservation of `record_id` order).
+- [ ] New `cli/src/veto/interactive.rs` (~140 LOC):
+  - `TtyVetoUx<R: BufRead, W: Write>` generic over reader/writer for testability.
+  - Prompts per-record `y/n`; empty line = `KeepLocal` (safe default); invalid input re-prompts.
+  - Scripted-reader tests covering `y`, `n`, empty, invalid+re-prompt.
+- [ ] `cli/src/main.rs` gains `mod veto;`.
+- [ ] Gauntlet target: **PASSED: 833 + N FAILED: 0 IGNORED: 10**. Absolute base is now 833 (bumped from 824 by Task 3's 9 new tests).
+- [ ] Clippy, fmt, conformance, spec freshness all clean.
+
+### Plan handoff
+
+Full step-by-step in [`docs/superpowers/plans/2026-05-23-c2-headless-sync-cli.md`](../superpowers/plans/2026-05-23-c2-headless-sync-cli.md) §"Task 4", which still applies — Task 3's three reconciliations do not affect Task 4's surface (veto is a separate module tree with no dep on unlock.rs).
+
+## (3) Open decisions and risks
+
+### Decisions settled during this session
+
+- **`SecretBytes::new(buf)` over `SecretBytes::from(slice) + zeroize`.** Take ownership of the `Vec<u8>` once; `ZeroizeOnDrop` on `SecretBytes` wipes the entire backing slice (including bytes past `len`, e.g. the popped newline) when the wrapper drops. Avoids the double allocation and the direct `zeroize` dep in `cli/Cargo.toml`. Same pattern adopted for the TTY path: `String::into_bytes()` moves the inner `Vec<u8>` out of `rpassword`'s returned `String`.
+- **Lone `\r` is NOT stripped.** Only `\r\n` (and `\n`) count as a line ending. A bare `\r` is preserved verbatim — protects passwords that legitimately end in `\r`. Tested by `reader_lone_cr_is_preserved`.
+- **Empty stdin → typed `Empty` error, not silent empty password.** Bare `\n` and `\r\n` also reduce to empty after strip and return `Empty`. Surfaces the "you forgot to pipe a password" mistake at the read site instead of downstream as a less obvious unlock failure. Tested by three separate cases.
+- **TTY prompt constant is `"Vault password: "`** — trailing space intentional since `rpassword::prompt_password` does not append one.
+
+### Decisions carried forward (unchanged from C.2 Task 2 close)
+
+- D1-D10 from the spec are still settled.
+- `--veto-policy=fail`, `--decisions-file`, `--exit-on-error`, `status`, `init` subcommands all deferred to future C.2.x slices.
+- Windows is best-effort per D10 (no CI runner planned for C.2 implementation).
+- Clean-room conformance harness for `cli/` deferred to C.4 or a future C.2.x slice.
+- The `from_sync_error` mapper's exit-code surface (Task 1): every `SyncError` variant without a dedicated code maps to `GenericError = 1`; bijection-failure variants do NOT get distinct codes (CLI bugs, not operator-recoverable).
+- fs4 dep retained over stdlib `File::try_lock` until workspace MSRV bumps past 1.89.
+
+### Risks carried into Task 4
+
+- **`#[allow(dead_code)]` on `UnlockReadError` / `PasswordSource` / `read_password_from_reader` / `read_password_from_tty`** lifts when Task 5 (pipeline) consumes them. Tracked at issue [#113](https://github.com/hherb/secretary/issues/113) alongside the Task 1 `ExitCode` / `from_sync_error` and Task 2 `state.rs` allowances; all share the same `TODO(#113): consumed by Task 5 pipeline.` marker form.
+- **`UnlockReadError::NonInteractiveWithoutStdin` is constructed by no code yet.** It's the typed error Task 5's `--non-interactive ↔ --password-stdin` flag validation will return. Same `#[allow(dead_code)]` umbrella as the rest of the enum. Issue #113 will lift it.
+- **No `cli/` integration tests yet.** Task 3 ships unit tests only. End-to-end CLI testing (via `assert_cmd`) arrives in Task 10's `cli/tests/once_integration.rs`.
+
+### Issues currently open
+
+- #37 — Sub-project C umbrella. C.2 Tasks 1-3 ✅ in PRs #112, #114, and (pending #).
+- #113 — C.2 Task 5 cleanup checklist: lift `#[allow(dead_code)]` in `cli/src/exit.rs`, `cli/src/state.rs`, and now `cli/src/unlock.rs`; add `--non-interactive` ↔ `--password-stdin` validation. Task 3 added more allowances under the same TODO(#113) marker — same cleanup obligation.
+- #38, #45, #75, #76, #78, #79, #81, #87, #88, #90, #95, #98 — none block C.2 Task 4.
+
+### Housekeeping note (stale worktrees on disk)
+
+After this PR:
+- `/Users/hherb/src/secretary` — `main` (clean post-merge).
+- `/Users/hherb/src/secretary/.worktrees/c1-1b-sync-merge` — branch `feature/c1-1b-task-17`, remote gone. Safe to remove.
+- `/Users/hherb/src/secretary/.worktrees/c2-task-1-spec` — branch `feature/c2-task-1-spec`, remote gone. Safe to remove.
+- `/Users/hherb/src/secretary/.worktrees/c2-task-1` — branch `feature/c2-task-1`, remote gone. Safe to remove.
+- `/Users/hherb/src/secretary/.worktrees/c2-task-2` — branch `feature/c2-task-2`, remote gone after PR #114 merged. Safe to remove.
+- `/Users/hherb/src/secretary/.worktrees/c2-task-3` — **this session's work**; keep until PR merges, then remove.
+
+```bash
+# One-line each (run from /Users/hherb/src/secretary):
+git worktree remove .worktrees/c1-1b-sync-merge && git branch -D feature/c1-1b-task-17
+git worktree remove .worktrees/c2-task-1-spec   && git branch -D feature/c2-task-1-spec
+git worktree remove .worktrees/c2-task-1        && git branch -D feature/c2-task-1
+git worktree remove .worktrees/c2-task-2        && git branch -D feature/c2-task-2
+```
+
+Cleanup is one-line each and does NOT block Task 4.
+
+## (4) Exact commands to resume
+
+```bash
+# After this C.2 Task 3 PR (feature/c2-task-3) merges:
+cd /Users/hherb/src/secretary
+git fetch --prune origin
+git status --short                       # expect: clean (modulo NEXT_SESSION.md sync, see below)
+git checkout main
+git pull --ff-only origin main
+
+# Verify gauntlet on fresh main (expect 833 / 0 / 10 — same as session close):
+cargo test --release --workspace --no-fail-fast 2>&1 | grep -E "^test result:" | awk '{passed+=$4; failed+=$6; ignored+=$8} END {print "PASSED:", passed, "FAILED:", failed, "IGNORED:", ignored}'
+cargo clippy --release --workspace --tests -- -D warnings 2>&1 | tail -3
+cargo fmt --all -- --check
+uv run core/tests/python/conformance.py 2>&1 | tail -3
+uv run core/tests/python/spec_test_name_freshness.py 2>&1 | tail -3
+
+# Start Task 4:
+git worktree add .worktrees/c2-task-4 -b feature/c2-task-4 main
+cd .worktrees/c2-task-4
+
+# Open the plan and follow Task 4 line-by-line:
+#   docs/superpowers/plans/2026-05-23-c2-headless-sync-cli.md §"Task 4"
+# Steps 1-5 cover the full scaffold + commit + PR.
+```
+
+## Closing inventory
+
+- **Branch state on close:** `main` at `e6c9d4f` (PR #114 squash-merged). `feature/c2-task-3` carries 1 commit on top.
+- **Workspace tests on `feature/c2-task-3`:** 833 passed + 10 ignored (824 base + 9 new cli `unlock` unit tests). Clippy + fmt + Python conformance + spec freshness all clean.
+- **README.md:** unchanged this session — Task 3 ships internal scaffolding (password-sourcing primitives), no user-visible behavior. Plan defers README update to Task 10.
+- **ROADMAP.md:** unchanged this session — same reason; ROADMAP already calls C.2 "queued" since the C.2 design PR.
+- **CLAUDE.md:** unchanged this session — the zeroize-discipline note (Task 3's `SecretBytes::new(buf)` ownership-move pattern) is already in CLAUDE.md's "Memory hygiene: zeroize discipline" section; no new convention.
+- **NEXT_SESSION.md:** symlink retargeted to this file.
+- **Open issues:** see §(3) — none block Task 4.
+- **Open PRs:** one to be opened at end of this session (C.2 Task 3).
+- **Worktrees on disk:** see §(3) housekeeping.
+- **Frozen baton snapshots:** all 20 prior C.1.1b + C.2-design + C.2-task-1/2 handoffs at [`docs/handoffs/`](.) — preserved unchanged.
+- **This file:** the live baton for C.2 Task 3 close.

--- a/docs/handoffs/2026-05-23-c2-task-3-unlock-shipped.md
+++ b/docs/handoffs/2026-05-23-c2-task-3-unlock-shipped.md
@@ -5,15 +5,16 @@
 
 ## (1) What we shipped this session
 
-A single commit on `feature/c2-task-3` carrying the third code slice of C.2 — the password-sourcing primitives. The TTY path is a thin `rpassword` wrapper; the `--password-stdin` path is a pure-function (`Cursor`-testable) reader. Both funnel bytes into a freshly allocated [`SecretBytes`] via [`SecretBytes::new`], moving ownership of the underlying allocation so the password never lingers in an unzeroized location after the function returns.
+Two commits on `feature/c2-task-3` carrying the third code slice of C.2 — the password-sourcing primitives. The TTY path is a thin `rpassword` wrapper; the `--password-stdin` path is a pure-function (`Cursor`-testable) reader. Both funnel bytes into a freshly allocated [`SecretBytes`] via [`SecretBytes::new`], moving ownership of the underlying allocation so the password never lingers in an unzeroized location after the function returns.
 
 | Artifact | Path | Notes |
 |---|---|---|
-| Unlock module | [`cli/src/unlock.rs`](../../cli/src/unlock.rs) | New, ~200 LOC. `UnlockReadError` (3 variants: `NonInteractiveWithoutStdin`, `Io`, `Empty`). `PasswordSource<'a, R: Read>` enum (`Tty` / `Stream(&mut R)`). `read_password_from_reader<R: Read>(&mut R) -> Result<SecretBytes, _>` strips exactly one `\n` or `\r\n`, returns `Empty` if the remainder is empty. `read_password_from_tty() -> Result<SecretBytes, _>` calls `rpassword::prompt_password("Vault password: ")`. 9 unit tests. |
+| Unlock module | [`cli/src/unlock.rs`](../../cli/src/unlock.rs) | New, ~230 LOC. `UnlockReadError` (3 variants: `NonInteractiveWithoutStdin`, `Io`, `Empty`). `PasswordSource<'a, R: Read>` enum (`Tty` / `Stream(&mut R)`). `read_password_from_reader<R: Read>(&mut R) -> Result<SecretBytes, _>` strips exactly one `\n` or `\r\n`, returns `Empty` if the remainder is empty. `read_password_from_tty() -> Result<SecretBytes, _>` delegates to a private `finalize_tty(String) -> Result<SecretBytes, _>` helper so the empty-input branch is testable without a pty. 12 unit tests. |
 | CLI entry point | [`cli/src/main.rs`](../../cli/src/main.rs) | One-line change: `mod unlock;` registered alongside the existing `mod args; mod exit; mod state;`. |
 
 Commits:
-- *(this commit)* — "C.2 Task 3 — unlock module: TTY + stdin password sourcing" on `feature/c2-task-3`.
+- `15c58fa` — "C.2 Task 3 — unlock module: TTY + stdin password sourcing" on `feature/c2-task-3`.
+- *(this commit)* — post-review touch-up: module-doc caveat about intermediate `Vec::read_to_end` / `rpassword` `String` reallocations leaving unzeroed heap residue during the read window; `finalize_tty` helper extracted to make the TTY empty-input branch reachable in unit tests without driving a pty; symmetric `\r\n\r\n` → `\r\n` test added to lock in "strip one line ending atomically" semantics. No behavioral change; +3 tests (9 → 12).
 
 ### Plan ↔ reality reconciliations
 
@@ -23,12 +24,12 @@ Three deliberate deviations from the plan, all noted in the commit body:
 |---|---|---|
 | `SecretBytes::from(buf.as_slice())` + `zeroize::Zeroize::zeroize(&mut buf)` | `SecretBytes::new(buf)` (ownership move) | The plan's pattern would have required adding `zeroize` as a direct dep of `cli/Cargo.toml` AND double-allocated (`From<&[u8]>` calls `bytes.to_vec()`). `SecretBytes::new(Vec<u8>)` takes ownership of the original allocation; the `ZeroizeOnDrop` derive on `SecretBytes` wipes the entire `capacity` slice on drop, including bytes past `len` (e.g. the popped trailing-newline byte). Single allocation, no new dep, aligned with CLAUDE.md §"Memory hygiene: zeroize discipline". |
 | `cargo test -p secretary-cli --lib unlock` | `cargo test -p secretary-cli unlock` | `cli/` is binary-only (`[[bin]]` in `Cargo.toml`, no `lib.rs`). The `--lib` filter errors with "no library targets found in package `secretary-cli`". Drop the filter; cargo runs the binary's unit tests by default. |
-| "5 tests" (plan prose) / "N unit tests" (acceptance) | **9 unit tests** / **PASSED: 833** | Two additional edge-case tests beyond the plan body: `reader_lone_cr_is_preserved` (lone `\r` is NOT stripped — only `\r\n`) and `reader_crlf_only_errors_as_empty` (a bare `\r\n` reduces to empty). These close the line-ending strip's branch coverage. Same `±1` reconciliation pattern as Tasks 1 and 2. |
+| "5 tests" (plan prose) / "N unit tests" (acceptance) | **12 unit tests** / **PASSED: 836** | Beyond the plan's 5 happy-path tests: `reader_lone_cr_is_preserved` (lone `\r` is NOT stripped), `reader_crlf_only_errors_as_empty` (bare `\r\n` reduces to empty), `reader_only_strips_one_crlf` (post-review: symmetric `\r\n\r\n` strip-once test), `finalize_tty_empty_string_errors_as_empty` + `finalize_tty_preserves_password_bytes` (post-review: TTY-path branch coverage via the extracted helper). Close the line-ending strip's branch coverage and the TTY path's empty-input branch. Same `±N` reconciliation pattern as Tasks 1 and 2. |
 
 ### Gauntlet snapshot at session close
 
 ```
-PASSED: 833 FAILED: 0 IGNORED: 10
+PASSED: 836 FAILED: 0 IGNORED: 10
 clippy --release --workspace --tests -- -D warnings   clean
 fmt --all -- --check                                  clean
 uv run core/tests/python/conformance.py               PASS
@@ -54,7 +55,7 @@ After this PR merges, the next slice is **C.2 Task 4: Veto trait + non-interacti
   - Prompts per-record `y/n`; empty line = `KeepLocal` (safe default); invalid input re-prompts.
   - Scripted-reader tests covering `y`, `n`, empty, invalid+re-prompt.
 - [ ] `cli/src/main.rs` gains `mod veto;`.
-- [ ] Gauntlet target: **PASSED: 833 + N FAILED: 0 IGNORED: 10**. Absolute base is now 833 (bumped from 824 by Task 3's 9 new tests).
+- [ ] Gauntlet target: **PASSED: 836 + N FAILED: 0 IGNORED: 10**. Absolute base is now 836 (bumped from 824 by Task 3's 12 new tests, including the 3 post-review additions).
 - [ ] Clippy, fmt, conformance, spec freshness all clean.
 
 ### Plan handoff
@@ -121,7 +122,7 @@ git status --short                       # expect: clean (modulo NEXT_SESSION.md
 git checkout main
 git pull --ff-only origin main
 
-# Verify gauntlet on fresh main (expect 833 / 0 / 10 — same as session close):
+# Verify gauntlet on fresh main (expect 836 / 0 / 10 — same as session close):
 cargo test --release --workspace --no-fail-fast 2>&1 | grep -E "^test result:" | awk '{passed+=$4; failed+=$6; ignored+=$8} END {print "PASSED:", passed, "FAILED:", failed, "IGNORED:", ignored}'
 cargo clippy --release --workspace --tests -- -D warnings 2>&1 | tail -3
 cargo fmt --all -- --check
@@ -140,7 +141,7 @@ cd .worktrees/c2-task-4
 ## Closing inventory
 
 - **Branch state on close:** `main` at `e6c9d4f` (PR #114 squash-merged). `feature/c2-task-3` carries 1 commit on top.
-- **Workspace tests on `feature/c2-task-3`:** 833 passed + 10 ignored (824 base + 9 new cli `unlock` unit tests). Clippy + fmt + Python conformance + spec freshness all clean.
+- **Workspace tests on `feature/c2-task-3`:** 836 passed + 10 ignored (824 base + 12 new cli `unlock` unit tests, 9 in the initial commit + 3 in the post-review touch-up). Clippy + fmt + Python conformance + spec freshness all clean.
 - **README.md:** unchanged this session — Task 3 ships internal scaffolding (password-sourcing primitives), no user-visible behavior. Plan defers README update to Task 10.
 - **ROADMAP.md:** unchanged this session — same reason; ROADMAP already calls C.2 "queued" since the C.2 design PR.
 - **CLAUDE.md:** unchanged this session — the zeroize-discipline note (Task 3's `SecretBytes::new(buf)` ownership-move pattern) is already in CLAUDE.md's "Memory hygiene: zeroize discipline" section; no new convention.


### PR DESCRIPTION
## Summary
- `cli/src/unlock.rs` — `PasswordSource<'a, R: Read>` enum + `read_password_from_reader` (pure, Cursor-testable) + `read_password_from_tty` (rpassword wrapper) + `UnlockReadError` (3 variants).
- Strips exactly one trailing `\n` or `\r\n`; lone `\r` preserved verbatim; empty after strip → typed `Empty` (no silent empty-password pass-through).
- Zeroize discipline: `SecretBytes::new(buf)` takes ownership of the `Vec<u8>` in one move — `ZeroizeOnDrop` wipes the entire `capacity` slice on drop (including bytes past `len`, e.g. the popped trailing newline). No double allocation, no direct `zeroize` dep in `cli/Cargo.toml`. Same pattern for the TTY path via `String::into_bytes`.

## Plan ↔ reality reconciliations
- `SecretBytes::from(slice) + zeroize::Zeroize::zeroize(&mut buf)` → `SecretBytes::new(buf)` (ownership move) — avoids the direct `zeroize` dep and the double allocation. Aligned with `CLAUDE.md` §"Memory hygiene: zeroize discipline".
- `cargo test -p secretary-cli --lib unlock` → `cargo test -p secretary-cli unlock` — `cli/` is binary-only, no `--lib` target.
- "5 tests" (plan prose) → **9 tests** (plan body listed 7; +2 edge cases for lone `\r` preservation and `\r\n`-only-as-empty). Same `±1` reconciliation pattern as Tasks 1+2.

## Test plan
- [x] 9 new unit tests; workspace 824→833.
- [x] cargo clippy --release --workspace --tests -- -D warnings — clean.
- [x] cargo fmt --all -- --check — clean.
- [x] uv run core/tests/python/conformance.py — PASS.
- [x] uv run core/tests/python/spec_test_name_freshness.py — PASS (96 resolved / 0 unresolved / 2 suppressed).

## Deferred to Task 5 cleanup (#113)
Every new symbol carries `#[allow(dead_code)] // TODO(#113): consumed by Task 5 pipeline.` Lifts when Task 5 wires the pipeline.

Spec: docs/superpowers/specs/2026-05-23-c2-headless-sync-cli-design.md §D2
Plan: docs/superpowers/plans/2026-05-23-c2-headless-sync-cli.md (Task 3 of 10)

🤖 Generated with [Claude Code](https://claude.com/claude-code)