### PR TITLE
C.2 Task 4 — veto UX trait + impls

### DIFF
--- a/NEXT_SESSION.md
+++ b/NEXT_SESSION.md
@@ -1,1 +1,1 @@
-docs/handoffs/2026-05-23-c2-task-3-unlock-shipped.md
+docs/handoffs/2026-05-25-c2-task-4-veto-shipped.md

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -7,6 +7,7 @@ mod args;
 mod exit;
 mod state;
 mod unlock;
+mod veto;
 
 fn main() {
     let cli = args::Cli::parse();

--- a/cli/src/veto/interactive.rs
+++ b/cli/src/veto/interactive.rs
@@ -1,0 +1,236 @@
+//! Interactive TTY veto UX. Prompts per-record `y` (KeepLocal) /
+//! `n` (AcceptTombstone); re-prompts on invalid input.
+//!
+//! Spec: [`docs/superpowers/specs/2026-05-23-c2-headless-sync-cli-design.md`](../../../docs/superpowers/specs/2026-05-23-c2-headless-sync-cli-design.md)
+//! §"Public surface" / §D4.
+//!
+//! Generic over `BufRead + Write` so tests can drive the prompt with
+//! [`std::io::Cursor`]s and verify reply parsing without touching a
+//! real TTY. Production wires `std::io::stdin().lock()` (read) +
+//! `std::io::stderr().lock()` (write) — replies on stderr keep stdout
+//! clean for JSON / scriptable output if Task 9 introduces it.
+
+use std::io::{BufRead, Write};
+
+use secretary_core::sync::{RecordTombstoneVeto, VetoDecision};
+
+use super::VetoUx;
+
+/// Default reply for empty input AND for I/O errors mid-read.
+///
+/// Spec §D4 defines `KeepLocal` as the safe default — it preserves the
+/// local record (recoverable: operator can re-run and decide again),
+/// whereas `AcceptTombstone` is irreversible. We therefore treat both
+/// "operator hit Enter" and "stdin pipe broke / closed early" as
+/// `KeepLocal` rather than panicking or escalating. The operator sees
+/// the prompt and can interrupt with Ctrl-C if they want to abort
+/// before the commit lands.
+const DEFAULT_DECISION_LABEL: &str = "KeepLocal";
+
+/// TTY veto UX, generic over any [`BufRead`] + [`Write`] pair for
+/// testability. Production wires `stdin().lock()` + `stderr().lock()`.
+#[allow(dead_code)] // TODO(#113): consumed by Task 5 pipeline.
+pub struct TtyVetoUx<R: BufRead, W: Write> {
+    reader: R,
+    writer: W,
+}
+
+impl<R: BufRead, W: Write> TtyVetoUx<R, W> {
+    #[allow(dead_code)] // TODO(#113): consumed by Task 5 pipeline.
+    pub fn new(reader: R, writer: W) -> Self {
+        Self { reader, writer }
+    }
+}
+
+impl<R: BufRead, W: Write> VetoUx for TtyVetoUx<R, W> {
+    fn decide(&mut self, vetoes: &[RecordTombstoneVeto]) -> Vec<VetoDecision> {
+        let mut out: Vec<VetoDecision> = Vec::with_capacity(vetoes.len());
+        for veto in vetoes {
+            loop {
+                let _ = writeln!(
+                    self.writer,
+                    "Record {} would be tombstoned by peer. Keep local? [y/n] (empty = {DEFAULT_DECISION_LABEL})",
+                    crate::state::canonical_hex(veto.record_id)
+                );
+                let _ = self.writer.flush();
+                let mut line = String::new();
+                if self.reader.read_line(&mut line).is_err() {
+                    // I/O error reading the reply: conservative
+                    // safe-default per `DEFAULT_DECISION_LABEL`.
+                    out.push(VetoDecision::KeepLocal {
+                        record_id: veto.record_id,
+                    });
+                    break;
+                }
+                let trimmed = line.trim();
+                match trimmed {
+                    "y" | "Y" | "yes" | "" => {
+                        out.push(VetoDecision::KeepLocal {
+                            record_id: veto.record_id,
+                        });
+                        break;
+                    }
+                    "n" | "N" | "no" => {
+                        out.push(VetoDecision::AcceptTombstone {
+                            record_id: veto.record_id,
+                        });
+                        break;
+                    }
+                    _ => {
+                        let _ = writeln!(self.writer, "  (please answer y or n)");
+                    }
+                }
+            }
+        }
+        out
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use secretary_core::sync::{BlockId, RecordId};
+    use secretary_core::vault::record::Record;
+    use std::collections::BTreeMap;
+    use std::io::{BufReader, Cursor};
+
+    /// Build a minimal `RecordTombstoneVeto` with a single-byte-pattern
+    /// `record_id` for assertions about reply ordering.
+    fn dummy_veto(record_id_byte: u8) -> RecordTombstoneVeto {
+        let record_id: RecordId = [record_id_byte; 16];
+        let block_id: BlockId = [0; 16];
+        RecordTombstoneVeto {
+            record_id,
+            block_id,
+            local_state: Record {
+                record_uuid: record_id,
+                record_type: "kv".into(),
+                fields: BTreeMap::new(),
+                tags: Vec::new(),
+                created_at_ms: 0,
+                last_mod_ms: 0,
+                tombstone: false,
+                tombstoned_at_ms: 0,
+                unknown: BTreeMap::new(),
+            },
+            disk_tombstone_at_ms: 1_000,
+            disk_tombstoner_device: [0; 16],
+        }
+    }
+
+    /// Convenience: wrap a scripted reply byte string into the
+    /// `BufReader<Cursor<Vec<u8>>>` shape the UX expects.
+    fn make_ux(replies: &[u8]) -> TtyVetoUx<BufReader<Cursor<Vec<u8>>>, Cursor<Vec<u8>>> {
+        let reader = BufReader::new(Cursor::new(replies.to_vec()));
+        let writer = Cursor::new(Vec::<u8>::new());
+        TtyVetoUx::new(reader, writer)
+    }
+
+    #[test]
+    fn scripted_y_returns_keep_local() {
+        let mut ux = make_ux(b"y\n");
+        let decisions = ux.decide(&[dummy_veto(1)]);
+        assert_eq!(decisions.len(), 1);
+        assert!(matches!(decisions[0], VetoDecision::KeepLocal { .. }));
+    }
+
+    #[test]
+    fn scripted_n_returns_accept_tombstone() {
+        let mut ux = make_ux(b"n\n");
+        let decisions = ux.decide(&[dummy_veto(1)]);
+        assert_eq!(decisions.len(), 1);
+        assert!(matches!(decisions[0], VetoDecision::AcceptTombstone { .. }));
+    }
+
+    #[test]
+    fn scripted_uppercase_y_returns_keep_local() {
+        let mut ux = make_ux(b"Y\n");
+        let decisions = ux.decide(&[dummy_veto(1)]);
+        assert!(matches!(decisions[0], VetoDecision::KeepLocal { .. }));
+    }
+
+    #[test]
+    fn scripted_word_yes_returns_keep_local() {
+        let mut ux = make_ux(b"yes\n");
+        let decisions = ux.decide(&[dummy_veto(1)]);
+        assert!(matches!(decisions[0], VetoDecision::KeepLocal { .. }));
+    }
+
+    #[test]
+    fn scripted_word_no_returns_accept_tombstone() {
+        let mut ux = make_ux(b"no\n");
+        let decisions = ux.decide(&[dummy_veto(1)]);
+        assert!(matches!(decisions[0], VetoDecision::AcceptTombstone { .. }));
+    }
+
+    #[test]
+    fn scripted_empty_line_defaults_to_keep_local() {
+        let mut ux = make_ux(b"\n");
+        let decisions = ux.decide(&[dummy_veto(1)]);
+        assert!(matches!(decisions[0], VetoDecision::KeepLocal { .. }));
+    }
+
+    #[test]
+    fn scripted_eof_with_no_input_defaults_to_keep_local() {
+        // Empty reply stream — read_line returns Ok(0) immediately,
+        // line stays "", trim is "", match falls into the empty-line
+        // branch which is KeepLocal (the documented safe default).
+        let mut ux = make_ux(b"");
+        let decisions = ux.decide(&[dummy_veto(1)]);
+        assert!(matches!(decisions[0], VetoDecision::KeepLocal { .. }));
+    }
+
+    #[test]
+    fn invalid_input_reprompts_then_accepts_valid() {
+        let mut ux = make_ux(b"maybe\ny\n");
+        let decisions = ux.decide(&[dummy_veto(1)]);
+        assert_eq!(decisions.len(), 1);
+        assert!(matches!(decisions[0], VetoDecision::KeepLocal { .. }));
+    }
+
+    #[test]
+    fn invalid_input_reprompt_writes_hint_to_writer() {
+        let mut ux = make_ux(b"huh\nn\n");
+        let _ = ux.decide(&[dummy_veto(1)]);
+        // Drain the writer back out — Cursor lets us inspect the
+        // bytes that would have gone to stderr in production.
+        let written: Vec<u8> = ux.writer.into_inner();
+        let text = String::from_utf8(written).expect("prompt bytes must be UTF-8");
+        assert!(
+            text.contains("(please answer y or n)"),
+            "expected re-prompt hint in prompt output, got:\n{text}"
+        );
+    }
+
+    #[test]
+    fn multiple_vetoes_match_input_order_and_record_ids() {
+        let mut ux = make_ux(b"y\nn\ny\n");
+        let vetoes = vec![dummy_veto(1), dummy_veto(2), dummy_veto(3)];
+        let decisions = ux.decide(&vetoes);
+        assert_eq!(decisions.len(), 3);
+        // Order preserved AND each decision's record_id matches its
+        // corresponding veto's record_id (the bijection that
+        // commit_with_decisions enforces downstream).
+        match &decisions[0] {
+            VetoDecision::KeepLocal { record_id } => assert_eq!(*record_id, vetoes[0].record_id),
+            other => panic!("expected KeepLocal at [0], got {other:?}"),
+        }
+        match &decisions[1] {
+            VetoDecision::AcceptTombstone { record_id } => {
+                assert_eq!(*record_id, vetoes[1].record_id);
+            }
+            other => panic!("expected AcceptTombstone at [1], got {other:?}"),
+        }
+        match &decisions[2] {
+            VetoDecision::KeepLocal { record_id } => assert_eq!(*record_id, vetoes[2].record_id),
+            other => panic!("expected KeepLocal at [2], got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn empty_veto_slice_returns_empty_without_touching_io() {
+        let mut ux = make_ux(b"");
+        let decisions = ux.decide(&[]);
+        assert!(decisions.is_empty());
+    }
+}

--- a/cli/src/veto/interactive.rs
+++ b/cli/src/veto/interactive.rs
@@ -45,8 +45,20 @@ impl<R: BufRead, W: Write> TtyVetoUx<R, W> {
 impl<R: BufRead, W: Write> VetoUx for TtyVetoUx<R, W> {
     fn decide(&mut self, vetoes: &[RecordTombstoneVeto]) -> Vec<VetoDecision> {
         let mut out: Vec<VetoDecision> = Vec::with_capacity(vetoes.len());
+        // EOF (`read_line` → `Ok(0)`) is final: no further reply can ever
+        // arrive on this reader. Track whether we've already surfaced
+        // that to the operator so we emit the breadcrumb at most once
+        // even when several vetoes default in sequence.
+        let mut eof_logged = false;
         for veto in vetoes {
             loop {
+                // Prompt-write failures (`writeln!`, `flush`) are
+                // intentionally swallowed: if stderr is dead but stdin
+                // is alive, the operator may be typing blind, but the
+                // decision they enter still propagates correctly. The
+                // alternative (panic on broken stderr) would be a worse
+                // UX than degraded prompts in a session that's already
+                // half-broken.
                 let _ = writeln!(
                     self.writer,
                     "Record {} would be tombstoned by peer. Keep local? [y/n] (empty = {DEFAULT_DECISION_LABEL})",
@@ -54,13 +66,31 @@ impl<R: BufRead, W: Write> VetoUx for TtyVetoUx<R, W> {
                 );
                 let _ = self.writer.flush();
                 let mut line = String::new();
-                if self.reader.read_line(&mut line).is_err() {
+                let read = self.reader.read_line(&mut line);
+                if read.is_err() {
                     // I/O error reading the reply: conservative
-                    // safe-default per `DEFAULT_DECISION_LABEL`.
+                    // safe-default per `DEFAULT_DECISION_LABEL`. Errors
+                    // may be transient (interrupted syscall etc.), so
+                    // subsequent vetoes still prompt — only the current
+                    // one defaults.
                     out.push(VetoDecision::KeepLocal {
                         record_id: veto.record_id,
                     });
                     break;
+                }
+                if matches!(read, Ok(0)) && !eof_logged {
+                    // First EOF observed: emit one explanatory line so
+                    // an operator whose stderr is still readable can
+                    // tell their session degraded into auto-default
+                    // mode (rather than guessing why subsequent prompts
+                    // got no answer). Falls through to the empty-line
+                    // branch below which records KeepLocal.
+                    let _ = writeln!(
+                        self.writer,
+                        "  (stdin closed; remaining vetoes default to {DEFAULT_DECISION_LABEL})"
+                    );
+                    let _ = self.writer.flush();
+                    eof_logged = true;
                 }
                 let trimmed = line.trim();
                 match trimmed {
@@ -88,35 +118,9 @@ impl<R: BufRead, W: Write> VetoUx for TtyVetoUx<R, W> {
 
 #[cfg(test)]
 mod tests {
+    use super::super::test_util::dummy_veto;
     use super::*;
-    use secretary_core::sync::{BlockId, RecordId};
-    use secretary_core::vault::record::Record;
-    use std::collections::BTreeMap;
     use std::io::{BufReader, Cursor};
-
-    /// Build a minimal `RecordTombstoneVeto` with a single-byte-pattern
-    /// `record_id` for assertions about reply ordering.
-    fn dummy_veto(record_id_byte: u8) -> RecordTombstoneVeto {
-        let record_id: RecordId = [record_id_byte; 16];
-        let block_id: BlockId = [0; 16];
-        RecordTombstoneVeto {
-            record_id,
-            block_id,
-            local_state: Record {
-                record_uuid: record_id,
-                record_type: "kv".into(),
-                fields: BTreeMap::new(),
-                tags: Vec::new(),
-                created_at_ms: 0,
-                last_mod_ms: 0,
-                tombstone: false,
-                tombstoned_at_ms: 0,
-                unknown: BTreeMap::new(),
-            },
-            disk_tombstone_at_ms: 1_000,
-            disk_tombstoner_device: [0; 16],
-        }
-    }
 
     /// Convenience: wrap a scripted reply byte string into the
     /// `BufReader<Cursor<Vec<u8>>>` shape the UX expects.
@@ -178,6 +182,27 @@ mod tests {
         let mut ux = make_ux(b"");
         let decisions = ux.decide(&[dummy_veto(1)]);
         assert!(matches!(decisions[0], VetoDecision::KeepLocal { .. }));
+    }
+
+    #[test]
+    fn eof_emits_breadcrumb_once_and_defaults_remaining_to_keep_local() {
+        // Closed stdin + multiple vetoes: every decision must default
+        // to KeepLocal (safe per spec §D4) AND the operator-facing
+        // breadcrumb must appear exactly once even though three vetoes
+        // hit Ok(0) in sequence (the `eof_logged` latch).
+        let mut ux = make_ux(b"");
+        let decisions = ux.decide(&[dummy_veto(1), dummy_veto(2), dummy_veto(3)]);
+        assert_eq!(decisions.len(), 3);
+        for d in &decisions {
+            assert!(matches!(d, VetoDecision::KeepLocal { .. }));
+        }
+        let written = String::from_utf8(ux.writer.into_inner()).expect("UTF-8");
+        let needle = "(stdin closed; remaining vetoes default to KeepLocal)";
+        let count = written.matches(needle).count();
+        assert_eq!(
+            count, 1,
+            "expected EOF breadcrumb exactly once, found {count}; output:\n{written}"
+        );
     }
 
     #[test]

--- a/cli/src/veto/mod.rs
+++ b/cli/src/veto/mod.rs
@@ -1,0 +1,39 @@
+//! Veto-decision UX for `RecordTombstoneVeto` adjudication.
+//!
+//! Spec: [`docs/superpowers/specs/2026-05-23-c2-headless-sync-cli-design.md`](../../../docs/superpowers/specs/2026-05-23-c2-headless-sync-cli-design.md)
+//! §D4 (default `KeepLocal` veto policy in non-interactive mode).
+//!
+//! Two impls ship together (both tiny) so the upcoming `pipeline.rs`
+//! (Task 5) can wire either one behind a `&mut dyn VetoUx` without
+//! ordering churn:
+//!
+//! - [`noninteractive::AutoKeepLocalVetoUx`] — auto-resolves every veto
+//!   to [`VetoDecision::KeepLocal`]. Used by `--non-interactive`.
+//! - [`interactive::TtyVetoUx`] — per-record `y`/`n` prompt over a
+//!   generic `BufRead` + `Write` pair (production wires
+//!   `stdin().lock()` + `stderr().lock()`; tests wire `Cursor`s).
+
+use secretary_core::sync::{RecordTombstoneVeto, VetoDecision};
+
+pub mod interactive;
+pub mod noninteractive;
+
+/// Strategy for converting a slice of [`RecordTombstoneVeto`] into the
+/// `Vec<VetoDecision>` that [`secretary_core::sync::commit_with_decisions`]
+/// requires.
+///
+/// Implementations are stateless and side-effect-free except for the
+/// actual UX layer (which reads from a [`std::io::Read`] + writes to a
+/// [`std::io::Write`]). The trait is intentionally object-safe so the
+/// upcoming pipeline can pick the impl at runtime behind a
+/// `&mut dyn VetoUx` without monomorphisation.
+#[allow(dead_code)] // TODO(#113): consumed by Task 5 pipeline.
+pub trait VetoUx {
+    /// Produce one [`VetoDecision`] per input veto, **preserving order**.
+    ///
+    /// Each returned decision's `record_id` MUST match the corresponding
+    /// veto's `record_id` — `commit_with_decisions` enforces the
+    /// `vetoes ↔ decisions` bijection and rejects mismatches with a
+    /// typed error (see spec §"Public surface" exit code 1 / generic).
+    fn decide(&mut self, vetoes: &[RecordTombstoneVeto]) -> Vec<VetoDecision>;
+}

--- a/cli/src/veto/mod.rs
+++ b/cli/src/veto/mod.rs
@@ -18,6 +18,9 @@ use secretary_core::sync::{RecordTombstoneVeto, VetoDecision};
 pub mod interactive;
 pub mod noninteractive;
 
+#[cfg(test)]
+pub(crate) mod test_util;
+
 /// Strategy for converting a slice of [`RecordTombstoneVeto`] into the
 /// `Vec<VetoDecision>` that [`secretary_core::sync::commit_with_decisions`]
 /// requires.

--- a/cli/src/veto/noninteractive.rs
+++ b/cli/src/veto/noninteractive.rs
@@ -1,0 +1,81 @@
+//! Auto-`KeepLocal` veto UX for `--non-interactive` mode.
+//!
+//! Spec: [`docs/superpowers/specs/2026-05-23-c2-headless-sync-cli-design.md`](../../../docs/superpowers/specs/2026-05-23-c2-headless-sync-cli-design.md)
+//! §D4 — the safe default for headless mode (no silent record
+//! deletion; every veto becomes `KeepLocal`).
+
+use secretary_core::sync::{RecordTombstoneVeto, VetoDecision};
+
+use super::VetoUx;
+
+/// Auto-resolves every veto to [`VetoDecision::KeepLocal`]. Stateless
+/// unit struct; instantiation is free.
+///
+/// Order is preserved one-to-one with the input slice so the bijection
+/// check in `commit_with_decisions` is trivially satisfied.
+#[allow(dead_code)] // TODO(#113): consumed by Task 5 pipeline.
+pub struct AutoKeepLocalVetoUx;
+
+impl VetoUx for AutoKeepLocalVetoUx {
+    fn decide(&mut self, vetoes: &[RecordTombstoneVeto]) -> Vec<VetoDecision> {
+        vetoes
+            .iter()
+            .map(|v| VetoDecision::KeepLocal {
+                record_id: v.record_id,
+            })
+            .collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use secretary_core::sync::{BlockId, RecordId};
+    use secretary_core::vault::record::Record;
+    use std::collections::BTreeMap;
+
+    /// Build a minimal `RecordTombstoneVeto` with a single-byte-pattern
+    /// `record_id` for ordering assertions.
+    fn dummy_veto(record_id_byte: u8) -> RecordTombstoneVeto {
+        let record_id: RecordId = [record_id_byte; 16];
+        let block_id: BlockId = [0; 16];
+        RecordTombstoneVeto {
+            record_id,
+            block_id,
+            local_state: Record {
+                record_uuid: record_id,
+                record_type: "kv".into(),
+                fields: BTreeMap::new(),
+                tags: Vec::new(),
+                created_at_ms: 0,
+                last_mod_ms: 0,
+                tombstone: false,
+                tombstoned_at_ms: 0,
+                unknown: BTreeMap::new(),
+            },
+            disk_tombstone_at_ms: 1_000,
+            disk_tombstoner_device: [0; 16],
+        }
+    }
+
+    #[test]
+    fn empty_input_returns_empty() {
+        let mut ux = AutoKeepLocalVetoUx;
+        let decisions = ux.decide(&[]);
+        assert!(decisions.is_empty());
+    }
+
+    #[test]
+    fn every_veto_becomes_keep_local_preserving_order() {
+        let mut ux = AutoKeepLocalVetoUx;
+        let vetoes = vec![dummy_veto(1), dummy_veto(2), dummy_veto(3)];
+        let decisions = ux.decide(&vetoes);
+        assert_eq!(decisions.len(), 3);
+        for (d, v) in decisions.iter().zip(vetoes.iter()) {
+            match d {
+                VetoDecision::KeepLocal { record_id } => assert_eq!(*record_id, v.record_id),
+                other => panic!("expected KeepLocal, got {other:?}"),
+            }
+        }
+    }
+}

--- a/cli/src/veto/noninteractive.rs
+++ b/cli/src/veto/noninteractive.rs
@@ -29,34 +29,8 @@ impl VetoUx for AutoKeepLocalVetoUx {
 
 #[cfg(test)]
 mod tests {
+    use super::super::test_util::dummy_veto;
     use super::*;
-    use secretary_core::sync::{BlockId, RecordId};
-    use secretary_core::vault::record::Record;
-    use std::collections::BTreeMap;
-
-    /// Build a minimal `RecordTombstoneVeto` with a single-byte-pattern
-    /// `record_id` for ordering assertions.
-    fn dummy_veto(record_id_byte: u8) -> RecordTombstoneVeto {
-        let record_id: RecordId = [record_id_byte; 16];
-        let block_id: BlockId = [0; 16];
-        RecordTombstoneVeto {
-            record_id,
-            block_id,
-            local_state: Record {
-                record_uuid: record_id,
-                record_type: "kv".into(),
-                fields: BTreeMap::new(),
-                tags: Vec::new(),
-                created_at_ms: 0,
-                last_mod_ms: 0,
-                tombstone: false,
-                tombstoned_at_ms: 0,
-                unknown: BTreeMap::new(),
-            },
-            disk_tombstone_at_ms: 1_000,
-            disk_tombstoner_device: [0; 16],
-        }
-    }
 
     #[test]
     fn empty_input_returns_empty() {

--- a/cli/src/veto/test_util.rs
+++ b/cli/src/veto/test_util.rs
@@ -1,0 +1,31 @@
+//! Test fixtures shared between `interactive.rs` and `noninteractive.rs`
+//! unit tests. Compiled only under `#[cfg(test)]`.
+
+use secretary_core::sync::{BlockId, RecordId, RecordTombstoneVeto};
+use secretary_core::vault::record::Record;
+use std::collections::BTreeMap;
+
+/// Build a minimal [`RecordTombstoneVeto`] whose `record_id` is the
+/// 16-byte repetition of `record_id_byte`. The single-byte pattern
+/// makes per-veto bijection assertions easy to read.
+pub fn dummy_veto(record_id_byte: u8) -> RecordTombstoneVeto {
+    let record_id: RecordId = [record_id_byte; 16];
+    let block_id: BlockId = [0; 16];
+    RecordTombstoneVeto {
+        record_id,
+        block_id,
+        local_state: Record {
+            record_uuid: record_id,
+            record_type: "kv".into(),
+            fields: BTreeMap::new(),
+            tags: Vec::new(),
+            created_at_ms: 0,
+            last_mod_ms: 0,
+            tombstone: false,
+            tombstoned_at_ms: 0,
+            unknown: BTreeMap::new(),
+        },
+        disk_tombstone_at_ms: 1_000,
+        disk_tombstoner_device: [0; 16],
+    }
+}

--- a/docs/handoffs/2026-05-25-c2-task-4-veto-shipped.md
+++ b/docs/handoffs/2026-05-25-c2-task-4-veto-shipped.md
@@ -1,0 +1,155 @@
+# NEXT_SESSION.md — C.2 Task 4 (veto UX) shipped
+
+**Session date:** 2026-05-25 (C.2 Task 4 — `cli/src/veto/`: `VetoUx` trait + non-interactive (`AutoKeepLocalVetoUx`) + interactive (`TtyVetoUx`) impls).
+**Status:** C.2 Task 4 ✅ on branch `feature/c2-task-4`; PR pending. Tasks 5-10 queued.
+
+## (1) What we shipped this session
+
+One commit on `feature/c2-task-4` carrying the fourth code slice of C.2 — the veto-adjudication strategy layer. `prepare_merge` returns `Vec<RecordTombstoneVeto>` for the records where a peer would tombstone something the local side has live; `commit_with_decisions` needs that resolved to `Vec<VetoDecision>` preserving the `record_id ↔ record_id` bijection. The CLI dispatches the two operational modes (`--non-interactive` headless vs. default interactive TTY) through one trait so the upcoming pipeline (Task 5) consumes either via `&mut dyn VetoUx` without ordering churn.
+
+| Artifact | Path | Notes |
+|---|---|---|
+| Veto module root | [`cli/src/veto/mod.rs`](../../cli/src/veto/mod.rs) | New, 39 LOC. `pub trait VetoUx { fn decide(&mut self, vetoes: &[RecordTombstoneVeto]) -> Vec<VetoDecision> }`. Object-safe (the pipeline will hold it as `&mut dyn VetoUx`). `pub mod interactive` + `pub mod noninteractive`. |
+| Non-interactive impl | [`cli/src/veto/noninteractive.rs`](../../cli/src/veto/noninteractive.rs) | New, 81 LOC. `pub struct AutoKeepLocalVetoUx` (unit struct, stateless). `impl VetoUx` maps every veto → `VetoDecision::KeepLocal { record_id: v.record_id }` preserving slice order. 2 unit tests: empty-input no-op, multi-veto order preservation. Spec §D4 safe default. |
+| Interactive impl | [`cli/src/veto/interactive.rs`](../../cli/src/veto/interactive.rs) | New, 236 LOC. `pub struct TtyVetoUx<R: BufRead, W: Write>` generic over reader/writer so tests drive the prompt via `Cursor` without a real TTY (production wires `stdin().lock()` + `stderr().lock()`). Per-veto `y/Y/yes` → `KeepLocal`, `n/N/no` → `AcceptTombstone`, empty line → `KeepLocal` (documented safe default), invalid input → re-prompt with `(please answer y or n)` hint. I/O read error mid-reply also lands on `KeepLocal` (irreversibility argument — see (3) below). 11 unit tests covering all six reply forms + EOF + invalid+re-prompt + hint inspection + multi-veto bijection + empty-slice no-op. |
+| CLI entry point | [`cli/src/main.rs`](../../cli/src/main.rs) | One-line change: `mod veto;` registered alongside the existing `mod args; mod exit; mod state; mod unlock;`. |
+
+Commits:
+- *(this commit)* — "C.2 Task 4 — veto UX trait + non-interactive + interactive impls" on `feature/c2-task-4`. 13 new unit tests; workspace 836 → 849.
+
+### Plan ↔ reality reconciliations
+
+Three deliberate deviations from the plan, all noted in the commit body:
+
+| Plan note | Reality | Resolution |
+|---|---|---|
+| `"Record {} would be tombstoned by peer. Keep local? [y/n]"` (plan prompt) | `"Record {} would be tombstoned by peer. Keep local? [y/n] (empty = KeepLocal)"` | Surfacing the safe default in the prompt itself: spec §D4 makes empty-input → `KeepLocal` policy-significant, so a user who doesn't read the spec sees the consequence next to the question. Pure UX; no semantics change. The hint string is parameterised by a `DEFAULT_DECISION_LABEL` constant for a single source of truth across the prompt and the doc comment. |
+| Plan acceptance: 7 unit tests; workspace 828 → 835. | **13 unit tests; workspace 836 → 849.** | Plan baseline (828) predates Task 3's +12. Beyond the plan's 5 happy-path interactive tests + 2 noninteractive: `scripted_uppercase_y_returns_keep_local`, `scripted_word_yes_returns_keep_local`, `scripted_word_no_returns_accept_tombstone` (close the `[y/Y/yes]` / `[n/N/no]` synonym branches each as their own test rather than implicit-only), `scripted_eof_with_no_input_defaults_to_keep_local` (`Ok(0)` from `read_line` reaches the empty-line branch), `invalid_input_reprompt_writes_hint_to_writer` (asserts the `(please answer y or n)` hint actually flushes to the writer — branch coverage that the plan's pass/fail tests skip), `empty_veto_slice_returns_empty_without_touching_io` (boundary: zero-element loop must not write any prompts). Same `±N` reconciliation pattern as Tasks 1–3. |
+| `cargo test --release -p secretary-cli --lib veto` | `cargo test --release -p secretary-cli veto` | `cli/` is binary-only (no `lib.rs`). The `--lib` filter errors with "no library targets found". Drop the filter; cargo runs the binary's unit tests by default. Same correction as Task 3. |
+
+### Gauntlet snapshot at session close
+
+```
+PASSED: 849 FAILED: 0 IGNORED: 10
+clippy --release --workspace --tests -- -D warnings   clean
+fmt --all -- --check                                  clean
+uv run core/tests/python/conformance.py               PASS
+uv run core/tests/python/spec_test_name_freshness.py  PASS (96 resolved / 0 unresolved / 2 suppressed)
+```
+
+## (2) What's next — start C.2 Task 5
+
+After this PR merges, the next slice is **C.2 Task 5: Pipeline (`cli/src/pipeline.rs`) — one sync attempt** ([`docs/superpowers/plans/2026-05-23-c2-headless-sync-cli.md`](../superpowers/plans/2026-05-23-c2-headless-sync-cli.md) §"Task 5").
+
+### Acceptance criteria for Task 5
+
+- [ ] New `cli/src/pipeline.rs` (~320 LOC):
+  - `pub fn run_one(identity: &UnlockedIdentity, password: &SecretBytes, state: &mut SyncState, vault_folder: &Path, ux: &mut dyn VetoUx, now_ms: u64) -> Result<RunOutcome, PipelineError>`.
+  - Calls `sync_once`, dispatches the returned outcome (NoChange / OurWriteOnly / TheirsOnly / Concurrent), invokes `prepare_merge` + the `VetoUx::decide` adjudication + `commit_with_decisions` on the concurrent path, and updates `SyncState` in place.
+  - `RunOutcome` enum the caller logs + maps to `ExitCode` (the `from_sync_error` mapper in `cli/src/exit.rs` already handles error → code).
+  - Lifts the `#[allow(dead_code)]` on `cli/src/exit.rs`, `cli/src/state.rs`, `cli/src/unlock.rs`, and `cli/src/veto/` items it consumes (this is the umbrella deletion #113 has been queuing up).
+- [ ] New `cli/src/main.rs` registers `mod pipeline;`.
+- [ ] Add `--non-interactive` ↔ `--password-stdin` flag-pair validation at the args-parse layer (the typed-error site for `UnlockReadError::NonInteractiveWithoutStdin`).
+- [ ] Pipeline-level unit tests: each outcome variant + each veto policy + state-update side effects + the no-op happy paths. Plan expects ~15-20 new tests.
+- [ ] Gauntlet target: **PASSED: 849 + N FAILED: 0 IGNORED: 10**. Absolute base is now 849 (bumped from 836 by Task 4's 13 new tests).
+- [ ] Clippy, fmt, conformance, spec freshness all clean.
+
+### Plan handoff
+
+Full step-by-step in [`docs/superpowers/plans/2026-05-23-c2-headless-sync-cli.md`](../superpowers/plans/2026-05-23-c2-headless-sync-cli.md) §"Task 5", which still applies — Task 4's three reconciliations do not affect Task 5's surface (pipeline orchestrates the modules; the trait API is what the plan specified).
+
+## (3) Open decisions and risks
+
+### Decisions settled during this session
+
+- **Object-safe `VetoUx` trait** so the pipeline can choose the impl at runtime behind `&mut dyn VetoUx`. No associated types, no generic methods. The trait method takes `&mut self` so `TtyVetoUx` can mutate its reader/writer through the same handle.
+- **Empty input → `KeepLocal`** (interactive) is policy-significant per spec §D4 and is now surfaced in the prompt itself (`(empty = KeepLocal)`). A user who didn't read the spec still sees what hitting Enter will do.
+- **I/O read error mid-reply → `KeepLocal`.** Reasoning: `AcceptTombstone` is irreversible (the record is gone on the next commit); `KeepLocal` is recoverable (operator re-runs and sees the same prompt). With the trait method returning `Vec<VetoDecision>` (not `Result<...>`), the only places to absorb a read failure are panic, escalate via re-design, or fall back to the safe default. The plan picked the safe default and this implementation preserves it; see the `DEFAULT_DECISION_LABEL` constant + module-doc comment for the in-source justification.
+- **Per-veto reply parsing is loop-local.** `let mut line = String::new();` is declared INSIDE the inner re-prompt `loop`, so a fresh buffer is allocated each re-prompt — `read_line` appends, so reusing the buffer across re-prompts would corrupt the next reply. Tested by `invalid_input_reprompts_then_accepts_valid` (b"maybe\ny\n" → first read gets "maybe\n", re-prompt buffer is fresh, second read gets "y\n").
+- **TtyVetoUx is generic over `BufRead + Write`** (not just `Read + Write`) because `read_line` is on `BufRead`. Production callers wrap `stdin().lock()` in `BufReader` first.
+
+### Decisions carried forward (unchanged from Task 3 close)
+
+- D1-D10 from the spec are still settled.
+- `--veto-policy=fail`, `--decisions-file`, `--exit-on-error`, `status`, `init` subcommands all deferred to future C.2.x slices.
+- Windows is best-effort per D10 (no CI runner planned for C.2 implementation).
+- Clean-room conformance harness for `cli/` deferred to C.4 or a future C.2.x slice.
+- The `from_sync_error` mapper's exit-code surface (Task 1): every `SyncError` variant without a dedicated code maps to `GenericError = 1`; bijection-failure variants do NOT get distinct codes (CLI bugs, not operator-recoverable).
+- fs4 dep retained over stdlib `File::try_lock` until workspace MSRV bumps past 1.89.
+- `SecretBytes::new(buf)` over `SecretBytes::from(slice) + zeroize` for owned-buffer unlock paths (Task 3 — still in force).
+
+### Risks carried into Task 5
+
+- **`#[allow(dead_code)]` on `VetoUx` / `AutoKeepLocalVetoUx` / `TtyVetoUx` / `TtyVetoUx::new`** lifts when Task 5 (pipeline) consumes them. Tracked at issue [#113](https://github.com/hherb/secretary/issues/113) alongside the Task 1/2/3 allowances; all share the `TODO(#113): consumed by Task 5 pipeline.` marker form.
+- **`AcceptTombstone` codepath in `TtyVetoUx` only fires on explicit `n`/`N`/`no` input.** Any future change to "default the policy" must be conscious of the irreversibility — record loss is permanent. The `DEFAULT_DECISION_LABEL` constant + module-doc comment together encode this invariant.
+- **No `cli/` integration tests yet.** Task 4 ships unit tests only. End-to-end CLI testing (via `assert_cmd`) arrives in Task 10's `cli/tests/once_integration.rs`.
+
+### Issues currently open
+
+- #37 — Sub-project C umbrella. C.2 Tasks 1-3 ✅ in PRs #112, #114, #115; Task 4 pending PR.
+- #113 — C.2 Task 5 cleanup checklist: lift `#[allow(dead_code)]` in `cli/src/exit.rs`, `cli/src/state.rs`, `cli/src/unlock.rs`, **and now `cli/src/veto/`**; add `--non-interactive` ↔ `--password-stdin` validation. Task 4 added more allowances under the same TODO(#113) marker — same cleanup obligation.
+- #38, #45, #75, #76, #78, #79, #81, #87, #88, #90, #95, #98 — none block C.2 Task 5.
+
+### Housekeeping note (stale worktrees on disk)
+
+After this PR:
+- `/Users/hherb/src/secretary` — `main` (clean post-merge).
+- `/Users/hherb/src/secretary/.worktrees/c1-1b-sync-merge` — branch `feature/c1-1b-task-17`, remote gone. Safe to remove.
+- `/Users/hherb/src/secretary/.worktrees/c2-task-1-spec` — branch `feature/c2-task-1-spec`, remote gone. Safe to remove.
+- `/Users/hherb/src/secretary/.worktrees/c2-task-1` — branch `feature/c2-task-1`, remote gone. Safe to remove.
+- `/Users/hherb/src/secretary/.worktrees/c2-task-2` — branch `feature/c2-task-2`, remote gone. Safe to remove.
+- `/Users/hherb/src/secretary/.worktrees/c2-task-3` — branch `feature/c2-task-3`, remote gone after PR #115 merged. Safe to remove.
+- `/Users/hherb/src/secretary/.worktrees/c2-task-4` — **this session's work**; keep until PR merges, then remove.
+
+```bash
+# One-line each (run from /Users/hherb/src/secretary):
+git worktree remove .worktrees/c1-1b-sync-merge && git branch -D feature/c1-1b-task-17
+git worktree remove .worktrees/c2-task-1-spec   && git branch -D feature/c2-task-1-spec
+git worktree remove .worktrees/c2-task-1        && git branch -D feature/c2-task-1
+git worktree remove .worktrees/c2-task-2        && git branch -D feature/c2-task-2
+git worktree remove .worktrees/c2-task-3        && git branch -D feature/c2-task-3
+```
+
+Cleanup is one-line each and does NOT block Task 5.
+
+## (4) Exact commands to resume
+
+```bash
+# After this C.2 Task 4 PR (feature/c2-task-4) merges:
+cd /Users/hherb/src/secretary
+git fetch --prune origin
+git status --short                       # expect: clean (modulo NEXT_SESSION.md sync, see below)
+git checkout main
+git pull --ff-only origin main
+
+# Verify gauntlet on fresh main (expect 849 / 0 / 10 — same as session close):
+cargo test --release --workspace --no-fail-fast 2>&1 | grep -E "^test result:" | awk '{passed+=$4; failed+=$6; ignored+=$8} END {print "PASSED:", passed, "FAILED:", failed, "IGNORED:", ignored}'
+cargo clippy --release --workspace --tests -- -D warnings 2>&1 | tail -3
+cargo fmt --all -- --check
+uv run core/tests/python/conformance.py 2>&1 | tail -3
+uv run core/tests/python/spec_test_name_freshness.py 2>&1 | tail -3
+
+# Start Task 5:
+git worktree add .worktrees/c2-task-5 -b feature/c2-task-5 main
+cd .worktrees/c2-task-5
+
+# Open the plan and follow Task 5 line-by-line:
+#   docs/superpowers/plans/2026-05-23-c2-headless-sync-cli.md §"Task 5"
+# This is the longest task (320 LOC pipeline + N unit tests). Plan steps include
+# the umbrella deletion of `#[allow(dead_code)]` markers (#113) as the pipeline
+# starts consuming the args/exit/state/unlock/veto modules.
+```
+
+## Closing inventory
+
+- **Branch state on close:** `main` at `7fc1c61` (PR #115 squash-merged). `feature/c2-task-4` carries 1 commit on top.
+- **Workspace tests on `feature/c2-task-4`:** 849 passed + 10 ignored (836 base + 13 new cli `veto` unit tests: 11 in `interactive.rs` + 2 in `noninteractive.rs`). Clippy + fmt + Python conformance + spec freshness all clean.
+- **README.md:** unchanged this session — Task 4 ships internal scaffolding (veto UX trait + impls), no user-visible behavior. Plan defers README update to Task 10.
+- **ROADMAP.md:** unchanged this session — same reason; ROADMAP already calls C.2 "queued" since the C.2 design PR.
+- **CLAUDE.md:** unchanged this session — no new convention; veto trait + Cursor-based test pattern are local to `cli/src/veto/` and don't generalise to repo-wide guidance.
+- **NEXT_SESSION.md:** symlink retargeted to this file.
+- **Open issues:** see §(3) — none block Task 5.
+- **Open PRs:** one to be opened at end of this session (C.2 Task 4).
+- **Worktrees on disk:** see §(3) housekeeping.
+- **Frozen baton snapshots:** all 21 prior C.1.1b + C.2-design + C.2-task-1/2/3 handoffs at [`docs/handoffs/`](.) — preserved unchanged.
+- **This file:** the live baton for C.2 Task 4 close.

--- a/docs/handoffs/2026-05-25-c2-task-4-veto-shipped.md
+++ b/docs/handoffs/2026-05-25-c2-task-4-veto-shipped.md
@@ -9,13 +9,15 @@ One commit on `feature/c2-task-4` carrying the fourth code slice of C.2 — the 
 
 | Artifact | Path | Notes |
 |---|---|---|
-| Veto module root | [`cli/src/veto/mod.rs`](../../cli/src/veto/mod.rs) | New, 39 LOC. `pub trait VetoUx { fn decide(&mut self, vetoes: &[RecordTombstoneVeto]) -> Vec<VetoDecision> }`. Object-safe (the pipeline will hold it as `&mut dyn VetoUx`). `pub mod interactive` + `pub mod noninteractive`. |
-| Non-interactive impl | [`cli/src/veto/noninteractive.rs`](../../cli/src/veto/noninteractive.rs) | New, 81 LOC. `pub struct AutoKeepLocalVetoUx` (unit struct, stateless). `impl VetoUx` maps every veto → `VetoDecision::KeepLocal { record_id: v.record_id }` preserving slice order. 2 unit tests: empty-input no-op, multi-veto order preservation. Spec §D4 safe default. |
-| Interactive impl | [`cli/src/veto/interactive.rs`](../../cli/src/veto/interactive.rs) | New, 236 LOC. `pub struct TtyVetoUx<R: BufRead, W: Write>` generic over reader/writer so tests drive the prompt via `Cursor` without a real TTY (production wires `stdin().lock()` + `stderr().lock()`). Per-veto `y/Y/yes` → `KeepLocal`, `n/N/no` → `AcceptTombstone`, empty line → `KeepLocal` (documented safe default), invalid input → re-prompt with `(please answer y or n)` hint. I/O read error mid-reply also lands on `KeepLocal` (irreversibility argument — see (3) below). 11 unit tests covering all six reply forms + EOF + invalid+re-prompt + hint inspection + multi-veto bijection + empty-slice no-op. |
+| Veto module root | [`cli/src/veto/mod.rs`](../../cli/src/veto/mod.rs) | New. `pub trait VetoUx { fn decide(&mut self, vetoes: &[RecordTombstoneVeto]) -> Vec<VetoDecision> }`. Object-safe (the pipeline will hold it as `&mut dyn VetoUx`). `pub mod interactive` + `pub mod noninteractive` + `#[cfg(test)] pub(crate) mod test_util`. |
+| Non-interactive impl | [`cli/src/veto/noninteractive.rs`](../../cli/src/veto/noninteractive.rs) | New. `pub struct AutoKeepLocalVetoUx` (unit struct, stateless). `impl VetoUx` maps every veto → `VetoDecision::KeepLocal { record_id: v.record_id }` preserving slice order. 2 unit tests: empty-input no-op, multi-veto order preservation. Spec §D4 safe default. |
+| Interactive impl | [`cli/src/veto/interactive.rs`](../../cli/src/veto/interactive.rs) | New. `pub struct TtyVetoUx<R: BufRead, W: Write>` generic over reader/writer so tests drive the prompt via `Cursor` without a real TTY (production wires `stdin().lock()` + `stderr().lock()`). Per-veto `y/Y/yes` → `KeepLocal`, `n/N/no` → `AcceptTombstone`, empty line → `KeepLocal` (documented safe default), invalid input → re-prompt with `(please answer y or n)` hint. I/O read error mid-reply also lands on `KeepLocal` (irreversibility argument — see (3) below). EOF (`Ok(0)`) emits a one-time `(stdin closed; remaining vetoes default to KeepLocal)` breadcrumb to the writer (latched by `eof_logged`) so an operator whose stderr is still readable can tell the session degraded into auto-default mode. 12 unit tests covering all six reply forms + EOF + EOF breadcrumb (once-only across multi-veto) + invalid+re-prompt + hint inspection + multi-veto bijection + empty-slice no-op. |
+| Shared test fixture | [`cli/src/veto/test_util.rs`](../../cli/src/veto/test_util.rs) | New, `#[cfg(test)]`-only. `pub fn dummy_veto(record_id_byte: u8) -> RecordTombstoneVeto`. Single source of truth used by both `interactive::tests` and `noninteractive::tests` (replaces two identical inline copies). |
 | CLI entry point | [`cli/src/main.rs`](../../cli/src/main.rs) | One-line change: `mod veto;` registered alongside the existing `mod args; mod exit; mod state; mod unlock;`. |
 
 Commits:
-- *(this commit)* — "C.2 Task 4 — veto UX trait + non-interactive + interactive impls" on `feature/c2-task-4`. 13 new unit tests; workspace 836 → 849.
+- "C.2 Task 4 — veto UX trait + non-interactive + interactive impls" — initial slice. 13 new unit tests; workspace 836 → 849.
+- "C.2 Task 4 — review fixes: EOF breadcrumb, error-swallow comment, shared test_util" — review follow-up addressing all four issues from PR #116 review: (1) EOF latch + breadcrumb in `TtyVetoUx::decide` + 1 new test, (2) explicit comment near the silenced `writeln!`/`flush` calls explaining the trade-off, (3) `dummy_veto` extracted to `cli/src/veto/test_util.rs`, (4) the no-max-attempts re-prompt cap concern is logged as issue [#117](https://github.com/hherb/secretary/issues/117) (low-priority defensive-coding fix; not in scope for Task 4). Workspace 849 → 850.
 
 ### Plan ↔ reality reconciliations
 
@@ -24,13 +26,13 @@ Three deliberate deviations from the plan, all noted in the commit body:
 | Plan note | Reality | Resolution |
 |---|---|---|
 | `"Record {} would be tombstoned by peer. Keep local? [y/n]"` (plan prompt) | `"Record {} would be tombstoned by peer. Keep local? [y/n] (empty = KeepLocal)"` | Surfacing the safe default in the prompt itself: spec §D4 makes empty-input → `KeepLocal` policy-significant, so a user who doesn't read the spec sees the consequence next to the question. Pure UX; no semantics change. The hint string is parameterised by a `DEFAULT_DECISION_LABEL` constant for a single source of truth across the prompt and the doc comment. |
-| Plan acceptance: 7 unit tests; workspace 828 → 835. | **13 unit tests; workspace 836 → 849.** | Plan baseline (828) predates Task 3's +12. Beyond the plan's 5 happy-path interactive tests + 2 noninteractive: `scripted_uppercase_y_returns_keep_local`, `scripted_word_yes_returns_keep_local`, `scripted_word_no_returns_accept_tombstone` (close the `[y/Y/yes]` / `[n/N/no]` synonym branches each as their own test rather than implicit-only), `scripted_eof_with_no_input_defaults_to_keep_local` (`Ok(0)` from `read_line` reaches the empty-line branch), `invalid_input_reprompt_writes_hint_to_writer` (asserts the `(please answer y or n)` hint actually flushes to the writer — branch coverage that the plan's pass/fail tests skip), `empty_veto_slice_returns_empty_without_touching_io` (boundary: zero-element loop must not write any prompts). Same `±N` reconciliation pattern as Tasks 1–3. |
+| Plan acceptance: 7 unit tests; workspace 828 → 835. | **14 unit tests; workspace 836 → 850.** | Plan baseline (828) predates Task 3's +12. Beyond the plan's 5 happy-path interactive tests + 2 noninteractive: `scripted_uppercase_y_returns_keep_local`, `scripted_word_yes_returns_keep_local`, `scripted_word_no_returns_accept_tombstone` (close the `[y/Y/yes]` / `[n/N/no]` synonym branches each as their own test rather than implicit-only), `scripted_eof_with_no_input_defaults_to_keep_local` (`Ok(0)` from `read_line` reaches the empty-line branch), `eof_emits_breadcrumb_once_and_defaults_remaining_to_keep_local` (review follow-up: latched EOF breadcrumb is emitted exactly once across N vetoes), `invalid_input_reprompt_writes_hint_to_writer` (asserts the `(please answer y or n)` hint actually flushes to the writer — branch coverage that the plan's pass/fail tests skip), `empty_veto_slice_returns_empty_without_touching_io` (boundary: zero-element loop must not write any prompts). Same `±N` reconciliation pattern as Tasks 1–3. |
 | `cargo test --release -p secretary-cli --lib veto` | `cargo test --release -p secretary-cli veto` | `cli/` is binary-only (no `lib.rs`). The `--lib` filter errors with "no library targets found". Drop the filter; cargo runs the binary's unit tests by default. Same correction as Task 3. |
 
 ### Gauntlet snapshot at session close
 
 ```
-PASSED: 849 FAILED: 0 IGNORED: 10
+PASSED: 850 FAILED: 0 IGNORED: 10
 clippy --release --workspace --tests -- -D warnings   clean
 fmt --all -- --check                                  clean
 uv run core/tests/python/conformance.py               PASS
@@ -51,7 +53,7 @@ After this PR merges, the next slice is **C.2 Task 5: Pipeline (`cli/src/pipelin
 - [ ] New `cli/src/main.rs` registers `mod pipeline;`.
 - [ ] Add `--non-interactive` ↔ `--password-stdin` flag-pair validation at the args-parse layer (the typed-error site for `UnlockReadError::NonInteractiveWithoutStdin`).
 - [ ] Pipeline-level unit tests: each outcome variant + each veto policy + state-update side effects + the no-op happy paths. Plan expects ~15-20 new tests.
-- [ ] Gauntlet target: **PASSED: 849 + N FAILED: 0 IGNORED: 10**. Absolute base is now 849 (bumped from 836 by Task 4's 13 new tests).
+- [ ] Gauntlet target: **PASSED: 850 + N FAILED: 0 IGNORED: 10**. Absolute base is now 850 (bumped from 836 by Task 4's 14 new tests, including the review-follow-up EOF-breadcrumb test).
 - [ ] Clippy, fmt, conformance, spec freshness all clean.
 
 ### Plan handoff
@@ -67,6 +69,9 @@ Full step-by-step in [`docs/superpowers/plans/2026-05-23-c2-headless-sync-cli.md
 - **I/O read error mid-reply → `KeepLocal`.** Reasoning: `AcceptTombstone` is irreversible (the record is gone on the next commit); `KeepLocal` is recoverable (operator re-runs and sees the same prompt). With the trait method returning `Vec<VetoDecision>` (not `Result<...>`), the only places to absorb a read failure are panic, escalate via re-design, or fall back to the safe default. The plan picked the safe default and this implementation preserves it; see the `DEFAULT_DECISION_LABEL` constant + module-doc comment for the in-source justification.
 - **Per-veto reply parsing is loop-local.** `let mut line = String::new();` is declared INSIDE the inner re-prompt `loop`, so a fresh buffer is allocated each re-prompt — `read_line` appends, so reusing the buffer across re-prompts would corrupt the next reply. Tested by `invalid_input_reprompts_then_accepts_valid` (b"maybe\ny\n" → first read gets "maybe\n", re-prompt buffer is fresh, second read gets "y\n").
 - **TtyVetoUx is generic over `BufRead + Write`** (not just `Read + Write`) because `read_line` is on `BufRead`. Production callers wrap `stdin().lock()` in `BufReader` first.
+- **EOF detection via latched `eof_logged` flag** (review follow-up). `read_line` returning `Ok(0)` is terminal — no further input can ever arrive on the same reader — so we emit one operator-facing breadcrumb (`(stdin closed; remaining vetoes default to KeepLocal)`) the first time it happens, then fall through to the empty-line branch (still `KeepLocal`). Without the latch, N closed-stdin vetoes would produce N identical breadcrumbs. Tested by `eof_emits_breadcrumb_once_and_defaults_remaining_to_keep_local`.
+- **Silent prompt-write failures are intentional** (review follow-up). The `let _ = writeln!(...)` / `let _ = self.writer.flush()` pattern is now explicitly documented in the impl: if stderr dies but stdin is alive, the operator may type blind, but the decision they enter still propagates correctly. Panicking on broken stderr would degrade a half-broken session into a hard crash. Trade-off noted at the first call site.
+- **Shared `dummy_veto` test fixture** (review follow-up). Moved from two identical inline definitions in `interactive::tests` and `noninteractive::tests` to a single `pub fn` in `cli/src/veto/test_util.rs` (`#[cfg(test)] pub(crate) mod test_util` in `mod.rs`). Sibling test modules import it via `super::super::test_util::dummy_veto`.
 
 ### Decisions carried forward (unchanged from Task 3 close)
 
@@ -88,6 +93,7 @@ Full step-by-step in [`docs/superpowers/plans/2026-05-23-c2-headless-sync-cli.md
 
 - #37 — Sub-project C umbrella. C.2 Tasks 1-3 ✅ in PRs #112, #114, #115; Task 4 pending PR.
 - #113 — C.2 Task 5 cleanup checklist: lift `#[allow(dead_code)]` in `cli/src/exit.rs`, `cli/src/state.rs`, `cli/src/unlock.rs`, **and now `cli/src/veto/`**; add `--non-interactive` ↔ `--password-stdin` validation. Task 4 added more allowances under the same TODO(#113) marker — same cleanup obligation.
+- #117 — **NEW**, filed during Task 4 review cleanup. `TtyVetoUx` re-prompt loop has no max-attempts cap; a pathological reader could hang `decide` forever. Low-priority defensive-coding fix (operator Ctrl-C and Task 5's `--non-interactive` ↔ `--password-stdin` validation both mitigate); logged for traceability rather than fixed in-task to keep Task 4 surface tight.
 - #38, #45, #75, #76, #78, #79, #81, #87, #88, #90, #95, #98 — none block C.2 Task 5.
 
 ### Housekeeping note (stale worktrees on disk)
@@ -122,7 +128,7 @@ git status --short                       # expect: clean (modulo NEXT_SESSION.md
 git checkout main
 git pull --ff-only origin main
 
-# Verify gauntlet on fresh main (expect 849 / 0 / 10 — same as session close):
+# Verify gauntlet on fresh main (expect 850 / 0 / 10 — same as session close):
 cargo test --release --workspace --no-fail-fast 2>&1 | grep -E "^test result:" | awk '{passed+=$4; failed+=$6; ignored+=$8} END {print "PASSED:", passed, "FAILED:", failed, "IGNORED:", ignored}'
 cargo clippy --release --workspace --tests -- -D warnings 2>&1 | tail -3
 cargo fmt --all -- --check
@@ -142,8 +148,8 @@ cd .worktrees/c2-task-5
 
 ## Closing inventory
 
-- **Branch state on close:** `main` at `7fc1c61` (PR #115 squash-merged). `feature/c2-task-4` carries 1 commit on top.
-- **Workspace tests on `feature/c2-task-4`:** 849 passed + 10 ignored (836 base + 13 new cli `veto` unit tests: 11 in `interactive.rs` + 2 in `noninteractive.rs`). Clippy + fmt + Python conformance + spec freshness all clean.
+- **Branch state on close:** `main` at `7fc1c61` (PR #115 squash-merged). `feature/c2-task-4` carries 2 commits on top (initial slice + review follow-up).
+- **Workspace tests on `feature/c2-task-4`:** 850 passed + 10 ignored (836 base + 14 new cli `veto` unit tests: 12 in `interactive.rs` + 2 in `noninteractive.rs`). Clippy + fmt + Python conformance + spec freshness all clean.
 - **README.md:** unchanged this session — Task 4 ships internal scaffolding (veto UX trait + impls), no user-visible behavior. Plan defers README update to Task 10.
 - **ROADMAP.md:** unchanged this session — same reason; ROADMAP already calls C.2 "queued" since the C.2 design PR.
 - **CLAUDE.md:** unchanged this session — no new convention; veto trait + Cursor-based test pattern are local to `cli/src/veto/` and don't generalise to repo-wide guidance.


### PR DESCRIPTION
## Summary

Ships the veto-adjudication strategy layer for `secretary-sync` (4th of 10 code slices in the C.2 plan). The upcoming pipeline (Task 5) will dispatch one of two impls behind `&mut dyn VetoUx`:

- **`AutoKeepLocalVetoUx`** (`cli/src/veto/noninteractive.rs`) — `--non-interactive` headless default; every `RecordTombstoneVeto` becomes `VetoDecision::KeepLocal { record_id }`, slice order preserved. Spec §D4 safe default (no silent record deletion).
- **`TtyVetoUx<R: BufRead, W: Write>`** (`cli/src/veto/interactive.rs`) — per-record `y/Y/yes` → KeepLocal, `n/N/no` → AcceptTombstone, empty line → KeepLocal, invalid → re-prompt with hint. Generic over reader/writer so tests drive replies via `Cursor` without a real TTY (production wires `stdin().lock()` + `stderr().lock()`).
- **`VetoUx` trait** (`cli/src/veto/mod.rs`) — object-safe, single method `fn decide(&mut self, &[RecordTombstoneVeto]) -> Vec<VetoDecision>`.

13 new unit tests; workspace **836 → 849**.

### Plan ↔ reality reconciliations (3, all noted in commit body)

1. **Prompt text** adds `(empty = KeepLocal)` so the safe default is visible without reading spec §D4. Hint string is a `DEFAULT_DECISION_LABEL` constant for single source of truth.
2. **13 tests** vs plan's 7 — extras close the `[y/Y/yes]` / `[n/N/no]` synonym branches, the `Ok(0)` EOF path, the re-prompt hint flushing assertion, and the zero-veto no-op boundary.
3. **`cargo test -p secretary-cli veto`** (no `--lib` filter) — `cli/` is binary-only; same correction as Task 3.

### Design notes

- **I/O read error mid-reply → `KeepLocal`** rather than panic / escalate. `AcceptTombstone` is irreversible (record gone after next commit); `KeepLocal` is recoverable (operator re-runs, sees same prompt). The trade-off is in the module-doc.
- **Per-veto `let mut line = String::new()` inside the inner re-prompt loop** — `read_line` appends, so reusing the buffer across re-prompts would corrupt the next reply. Covered by `invalid_input_reprompts_then_accepts_valid`.

### Allow(dead_code)

All veto items carry `#[allow(dead_code)] // TODO(#113): consumed by Task 5 pipeline.` — lifted en bloc when Task 5's `run_one` wires the trait. Same convention as the Task 1/2/3 allowances.

## Test plan

- [x] `cargo test --release --workspace --no-fail-fast` → **PASSED: 849 FAILED: 0 IGNORED: 10**
- [x] `cargo clippy --release --workspace --tests -- -D warnings` → clean
- [x] `cargo fmt --all -- --check` → clean
- [x] `uv run core/tests/python/conformance.py` → PASS
- [x] `uv run core/tests/python/spec_test_name_freshness.py` → PASS (96 resolved / 0 unresolved / 2 suppressed)
- [x] 13 new tests cover: every reply synonym (y, Y, yes, n, N, no), empty line default, EOF default, invalid + re-prompt, hint flushing to writer, multi-veto order + record_id bijection, zero-veto no-op
- [ ] (Deferred to Task 10) End-to-end `assert_cmd`-driven CLI integration test

See spec [`docs/superpowers/specs/2026-05-23-c2-headless-sync-cli-design.md`](docs/superpowers/specs/2026-05-23-c2-headless-sync-cli-design.md) §D4 + §"Public surface"; plan [`docs/superpowers/plans/2026-05-23-c2-headless-sync-cli.md`](docs/superpowers/plans/2026-05-23-c2-headless-sync-cli.md) §"Task 4".

Closes part of #37 (C.2 umbrella).