### PR TITLE
C.2 Task 5 — pipeline (one sync attempt) + lib/bin split

### DIFF
--- a/NEXT_SESSION.md
+++ b/NEXT_SESSION.md
@@ -1,1 +1,1 @@
-docs/handoffs/2026-05-25-c2-task-4-veto-shipped.md
+docs/handoffs/2026-05-25-c2-task-5-pipeline-shipped.md

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -6,6 +6,15 @@ license.workspace = true
 repository.workspace = true
 rust-version.workspace = true
 
+[lib]
+# Promote `secretary-cli` to a library + binary hybrid so integration
+# tests under `cli/tests/*.rs` can reach the orchestration modules
+# (`pipeline`, `veto`, `unlock`, `state`, `exit`) without going through
+# the binary boundary. The binary still ships as `secretary-sync`; the
+# library is the same set of modules surfaced under `secretary_cli::*`.
+name = "secretary_cli"
+path = "src/lib.rs"
+
 [[bin]]
 name = "secretary-sync"
 path = "src/main.rs"

--- a/cli/src/args.rs
+++ b/cli/src/args.rs
@@ -6,6 +6,7 @@
 use std::path::PathBuf;
 
 use clap::{Parser, Subcommand};
+use thiserror::Error;
 
 #[derive(Parser, Debug)]
 #[command(
@@ -80,6 +81,43 @@ pub struct RunArgs {
 pub enum LogFormat {
     Human,
     Json,
+}
+
+/// Cross-flag validation failures surfaced at the args-parse layer
+/// (before any I/O, before any unlock attempt).
+///
+/// Currently single-variant: `--non-interactive` without
+/// `--password-stdin` would otherwise block on a TTY prompt that
+/// `--non-interactive` mode explicitly forbids — better to reject the
+/// invocation than to hang. The CLI dispatch maps this to
+/// [`crate::exit::ExitCode::UsageError`] (exit 2).
+#[derive(Debug, Error, PartialEq, Eq)]
+pub enum ArgsValidationError {
+    /// `--non-interactive` was passed without `--password-stdin`. With
+    /// no TTY allowed and no stdin password channel selected, the
+    /// unlock layer has nowhere to read the password from. Mirrors the
+    /// typed [`crate::unlock::UnlockReadError::NonInteractiveWithoutStdin`]
+    /// variant at the args layer so the failure surfaces before any
+    /// unlock attempt.
+    #[error("--non-interactive requires --password-stdin to provide the password")]
+    NonInteractiveWithoutStdin,
+}
+
+impl CommonArgs {
+    /// Validate cross-flag constraints. Currently enforces the
+    /// `--non-interactive ↔ --password-stdin` pair: a headless run with
+    /// no stdin channel for the password is unreachable, so reject it
+    /// before we open any vault file.
+    ///
+    /// `--password-stdin` alone (without `--non-interactive`) remains
+    /// valid: the operator may pipe the password but still want
+    /// interactive veto prompts.
+    pub fn validate(&self) -> Result<(), ArgsValidationError> {
+        if self.non_interactive && !self.password_stdin {
+            return Err(ArgsValidationError::NonInteractiveWithoutStdin);
+        }
+        Ok(())
+    }
 }
 
 #[cfg(test)]
@@ -168,5 +206,80 @@ mod tests {
         } else {
             panic!("expected Run");
         }
+    }
+
+    /// `validate()` accepts the default flag-set (neither flag set).
+    #[test]
+    fn validate_accepts_default_flags() {
+        let cli =
+            Cli::try_parse_from(["secretary-sync", "once", "/tmp/vault"]).expect("parse failed");
+        let Command::Once { common, .. } = cli.command else {
+            panic!("expected Once");
+        };
+        common.validate().expect("default flags must validate");
+    }
+
+    /// `validate()` accepts `--password-stdin` alone (operator pipes
+    /// the password but still wants interactive veto prompts).
+    #[test]
+    fn validate_accepts_password_stdin_without_non_interactive() {
+        let cli = Cli::try_parse_from(["secretary-sync", "once", "--password-stdin", "/tmp/vault"])
+            .expect("parse failed");
+        let Command::Once { common, .. } = cli.command else {
+            panic!("expected Once");
+        };
+        common
+            .validate()
+            .expect("--password-stdin alone must validate");
+    }
+
+    /// `validate()` accepts the both-flags-set combination — the
+    /// canonical headless invocation.
+    #[test]
+    fn validate_accepts_non_interactive_with_password_stdin() {
+        let cli = Cli::try_parse_from([
+            "secretary-sync",
+            "once",
+            "--non-interactive",
+            "--password-stdin",
+            "/tmp/vault",
+        ])
+        .expect("parse failed");
+        let Command::Once { common, .. } = cli.command else {
+            panic!("expected Once");
+        };
+        common
+            .validate()
+            .expect("--non-interactive + --password-stdin must validate");
+    }
+
+    /// `--non-interactive` without `--password-stdin` must error with
+    /// the typed `NonInteractiveWithoutStdin` variant. This is the
+    /// args-layer counterpart to the typed
+    /// `UnlockReadError::NonInteractiveWithoutStdin` surface, fired
+    /// before any vault I/O.
+    #[test]
+    fn validate_rejects_non_interactive_without_password_stdin() {
+        let cli =
+            Cli::try_parse_from(["secretary-sync", "once", "--non-interactive", "/tmp/vault"])
+                .expect("parse failed");
+        let Command::Once { common, .. } = cli.command else {
+            panic!("expected Once");
+        };
+        let err = common.validate().expect_err("must reject");
+        assert_eq!(err, ArgsValidationError::NonInteractiveWithoutStdin);
+    }
+
+    /// The same rule applies to the `run` subcommand, since
+    /// [`CommonArgs`] is shared.
+    #[test]
+    fn validate_rejects_run_non_interactive_without_password_stdin() {
+        let cli = Cli::try_parse_from(["secretary-sync", "run", "--non-interactive", "/tmp/vault"])
+            .expect("parse failed");
+        let Command::Run { common, .. } = cli.command else {
+            panic!("expected Run");
+        };
+        let err = common.validate().expect_err("must reject");
+        assert_eq!(err, ArgsValidationError::NonInteractiveWithoutStdin);
     }
 }

--- a/cli/src/args.rs
+++ b/cli/src/args.rs
@@ -89,8 +89,11 @@ pub enum LogFormat {
 /// Currently single-variant: `--non-interactive` without
 /// `--password-stdin` would otherwise block on a TTY prompt that
 /// `--non-interactive` mode explicitly forbids — better to reject the
-/// invocation than to hang. The CLI dispatch maps this to
-/// [`crate::exit::ExitCode::UsageError`] (exit 2).
+/// invocation than to hang. `secretary-sync`'s `main()` invokes
+/// [`CommonArgs::validate`] before dispatching to the (currently-stub)
+/// subcommand bodies and maps this error to
+/// [`crate::exit::ExitCode::UsageError`] (exit 2). The corresponding
+/// binary-level test lives in `cli/tests/main_validate.rs`.
 #[derive(Debug, Error, PartialEq, Eq)]
 pub enum ArgsValidationError {
     /// `--non-interactive` was passed without `--password-stdin`. With

--- a/cli/src/exit.rs
+++ b/cli/src/exit.rs
@@ -17,14 +17,12 @@ use secretary_core::sync::SyncError;
 /// | 12 | EvidenceStale after retry budget exhausted. |
 /// | 13 | BlockFingerprintMismatch on commit. |
 /// | 14 | Lockfile held — another secretary-sync process is running on this vault. |
-// The non-`GenericError` variants and `from_sync_error` are consumed by
-// the pipeline + dispatch wiring landed in Task 5 onward. Task 1 ships
-// only the skeleton; the unit tests below exercise every variant so
-// the discriminant table is locked in. The allow lifts once Task 5
-// references the rest of the surface.
-// TODO(#113): remove this `#[allow(dead_code)]` when Task 5 wires the
-// dispatch layer that consumes every variant.
-#[allow(dead_code)]
+// As of C.2 Task 5, `ExitCode` is library-public (`secretary_cli::exit::ExitCode`)
+// and the discriminant table is locked in by the per-variant unit tests
+// below. Variants not yet referenced from `main.rs` will be wired by
+// the dispatch path in Task 9 (`run_one` outcome → exit code), but the
+// surface is part of the library API today, so no `#[allow(dead_code)]`
+// is needed.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(i32)]
 pub enum ExitCode {
@@ -42,9 +40,6 @@ impl ExitCode {
     /// Map a `SyncError` to the documented exit code. Variants without a
     /// dedicated code map to `GenericError`.
     #[must_use]
-    // TODO(#113): remove this `#[allow(dead_code)]` when Task 5 wires
-    // the dispatch layer that calls `from_sync_error`.
-    #[allow(dead_code)]
     pub fn from_sync_error(err: &SyncError) -> Self {
         match err {
             SyncError::EvidenceStale => Self::EvidenceStale,

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -1,0 +1,16 @@
+//! Library surface of `secretary-cli`.
+//!
+//! Production consumers run the `secretary-sync` binary entry point
+//! (`src/main.rs`); this `lib.rs` re-exports the same orchestration
+//! modules so end-to-end integration tests in `cli/tests/*.rs` can
+//! drive [`pipeline::run_one`] (and the modules it composes) directly,
+//! without spawning the binary.
+//!
+//! Spec: [`docs/superpowers/specs/2026-05-23-c2-headless-sync-cli-design.md`](../../docs/superpowers/specs/2026-05-23-c2-headless-sync-cli-design.md).
+
+pub mod args;
+pub mod exit;
+pub mod pipeline;
+pub mod state;
+pub mod unlock;
+pub mod veto;

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1,13 +1,13 @@
 //! `secretary-sync` entry point. See
 //! [`docs/superpowers/specs/2026-05-23-c2-headless-sync-cli-design.md`](../../docs/superpowers/specs/2026-05-23-c2-headless-sync-cli-design.md).
+//!
+//! As of C.2 Task 5, `cli/` is a library + binary hybrid: this binary
+//! re-exports the orchestration surface through [`secretary_cli`] (see
+//! [`src/lib.rs`](lib.rs)) so integration tests in `cli/tests/*.rs` can
+//! reach the modules without spawning the binary.
 
 use clap::Parser;
-
-mod args;
-mod exit;
-mod state;
-mod unlock;
-mod veto;
+use secretary_cli::{args, exit};
 
 fn main() {
     let cli = args::Cli::parse();

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -11,6 +11,22 @@ use secretary_cli::{args, exit};
 
 fn main() {
     let cli = args::Cli::parse();
+    // Args-layer cross-flag validation runs before any I/O so a
+    // headless invocation that can't reach a password (e.g.
+    // `--non-interactive` without `--password-stdin`) fails fast
+    // with `ExitCode::UsageError` rather than hanging on a TTY
+    // prompt that `--non-interactive` mode forbids. The subcommand
+    // bodies remain stubs (Task 9 wires the dispatch); this guard
+    // is the only behavior `secretary-sync` has today beyond
+    // parsing, and is the load-bearing consumer of
+    // `CommonArgs::validate`.
+    let common = match &cli.command {
+        args::Command::Once { common, .. } | args::Command::Run { common, .. } => common,
+    };
+    if let Err(e) = common.validate() {
+        eprintln!("error: {e}");
+        std::process::exit(exit::ExitCode::UsageError as i32);
+    }
     let code = match cli.command {
         args::Command::Once { .. } => {
             eprintln!("secretary-sync once: not yet implemented");

--- a/cli/src/pipeline.rs
+++ b/cli/src/pipeline.rs
@@ -27,6 +27,8 @@ use secretary_core::sync::{
     commit_with_decisions, prepare_merge, sync_once, SyncError, SyncOutcome, SyncState,
 };
 use secretary_core::unlock::UnlockedIdentity;
+use secretary_core::vault::block::VectorClockEntry;
+use secretary_core::vault::merge_vector_clocks;
 
 use crate::veto::VetoUx;
 
@@ -64,8 +66,13 @@ pub enum RunOutcome {
     /// Concurrent state was detected but the diff plan was empty
     /// (no diverging blocks after authentication; this is the
     /// "concurrent at the manifest level, identical at the block
-    /// level" fast path). `state` advanced to the bundled disk clock;
-    /// no commit was issued.
+    /// level" fast path). `state.highest_vector_clock_seen` advanced
+    /// to the LUB of the canonical disk clock, every conflict-copy
+    /// clock in the bundle, and the prior local-seen — mirroring
+    /// what `commit_with_decisions` returns on the
+    /// [`Self::MergedAndCommitted`] arm via
+    /// [`secretary_core::sync::DraftMerge::post_merge_clock`]. No
+    /// commit was issued.
     SilentMerge,
     /// Disk vector clock is strictly dominated by the local
     /// `highest_vector_clock_seen` (rollback per
@@ -104,8 +111,18 @@ pub enum RunOutcome {
 ///
 /// - [`RunOutcome::NothingToDo`] / [`RunOutcome::RollbackRejected`] —
 ///   `state` is unchanged byte-for-byte.
-/// - [`RunOutcome::AppliedAutomatically`] / [`RunOutcome::SilentMerge`]
-///   — `state.highest_vector_clock_seen` advances to the disk clock.
+/// - [`RunOutcome::AppliedAutomatically`] — `state.highest_vector_clock_seen`
+///   advances to the disk clock (the dominance case — disk strictly
+///   ≥ local, so the disk clock alone is already the LUB).
+/// - [`RunOutcome::SilentMerge`] — `state.highest_vector_clock_seen`
+///   advances to the LUB of the canonical disk clock, every
+///   conflict-copy clock in the authenticated bundle, and the prior
+///   local-seen. Mirrors what `commit_with_decisions` returns on the
+///   [`RunOutcome::MergedAndCommitted`] arm (which folds canonical +
+///   copies into `DraftMerge::post_merge_clock`); folding in the
+///   prior local-seen is defensive — under monotone clock evolution
+///   it's already dominated by the LUB, but the fold is cheap and
+///   keeps the contract independent of that invariant.
 /// - [`RunOutcome::MergedAndCommitted`] — `state` is replaced with the
 ///   `SyncState` returned by `commit_with_decisions` (the post-merge
 ///   clock that includes both local and peer contributions).
@@ -142,10 +159,21 @@ pub fn run_one(
         } => {
             // Silent-merge fast path: the manifest clocks are concurrent
             // but no block-level divergence survived authentication. We
-            // can advance the local clock to the bundled disk clock
-            // without re-encrypting anything.
+            // can advance the local clock without re-encrypting anything,
+            // but we MUST advance it to the LUB of every clock visible at
+            // this moment — not just the canonical disk clock. See
+            // `silent_merge_clock` for the full rationale.
             if plan.diverging_blocks.is_empty() {
-                state.highest_vector_clock_seen = disk_vector_clock;
+                let copy_clocks: Vec<&[VectorClockEntry]> = bundle
+                    .copies
+                    .iter()
+                    .map(|c| c.manifest.vector_clock.as_slice())
+                    .collect();
+                state.highest_vector_clock_seen = silent_merge_clock(
+                    &disk_vector_clock,
+                    &copy_clocks,
+                    &state.highest_vector_clock_seen,
+                );
                 return Ok(RunOutcome::SilentMerge);
             }
             let draft = prepare_merge(vault_folder, identity, &bundle, &plan)?;
@@ -159,6 +187,41 @@ pub fn run_one(
             })
         }
     }
+}
+
+/// Compute the post-silent-merge `highest_vector_clock_seen` as the
+/// LUB of:
+///
+/// 1. The authenticated canonical disk vector clock (`disk_clock`).
+/// 2. Every conflict-copy manifest's `vector_clock` in `copy_clocks`.
+/// 3. The prior `state.highest_vector_clock_seen` (`prior_local_seen`).
+///
+/// (1) + (2) mirrors what `commit_with_decisions` writes into
+/// `DraftMerge::post_merge_clock` on the
+/// [`RunOutcome::MergedAndCommitted`] arm — a conflict-copy's clock
+/// may contain a (device, counter) pair that's strictly greater than
+/// the canonical's, and a silent merge MUST preserve those.
+///
+/// (3) is defensive — `clock_relation(prior, disk) == Concurrent`
+/// implies prior has some entry strictly greater than disk's only if
+/// monotone-clock evolution is somehow violated (e.g. backup restore,
+/// future-protocol bug). The fold is cheap and keeps this function's
+/// correctness independent of that invariant.
+///
+/// Pure function — no I/O, no logging, no side effects. Takes raw
+/// clock slices (rather than `&[ManifestSnapshot]`) so the
+/// `silent_merge_clock_*` unit tests can pin the LUB contract
+/// without constructing manifest fixtures.
+fn silent_merge_clock(
+    disk_clock: &[VectorClockEntry],
+    copy_clocks: &[&[VectorClockEntry]],
+    prior_local_seen: &[VectorClockEntry],
+) -> Vec<VectorClockEntry> {
+    let mut new_clock = disk_clock.to_vec();
+    for copy in copy_clocks {
+        new_clock = merge_vector_clocks(&new_clock, copy);
+    }
+    merge_vector_clocks(&new_clock, prior_local_seen)
 }
 
 #[cfg(test)]
@@ -264,6 +327,94 @@ mod tests {
         let dbg = format!("{merged:?}");
         assert!(dbg.contains("MergedAndCommitted"));
         assert!(dbg.contains('3'));
+    }
+
+    /// Build a `VectorClockEntry` from a fill byte + counter — keeps
+    /// the LUB-helper tests' fixture lines compact and self-evident.
+    fn vc(fill: u8, counter: u64) -> VectorClockEntry {
+        VectorClockEntry {
+            device_uuid: [fill; 16],
+            counter,
+        }
+    }
+
+    /// With no conflict copies and a prior local-seen that's already
+    /// dominated by disk, the LUB is just the disk clock. This is the
+    /// degenerate but most common silent-merge shape — concurrent
+    /// solely because two devices' counters happened to advance, all
+    /// of which the disk now reflects.
+    #[test]
+    fn silent_merge_clock_no_copies_disk_dominates() {
+        let disk = vec![vc(0xAA, 5), vc(0xBB, 3)];
+        let copies: Vec<&[VectorClockEntry]> = Vec::new();
+        let prior = vec![vc(0xAA, 5), vc(0xBB, 3)];
+        let result = silent_merge_clock(&disk, &copies, &prior);
+        assert_eq!(result, vec![vc(0xAA, 5), vc(0xBB, 3)]);
+    }
+
+    /// A conflict-copy carrying a (device, counter) pair strictly
+    /// greater than the canonical disk's MUST land in the LUB.
+    /// This is the regression test for the bug fixed in this commit:
+    /// the previous implementation set `state = disk_clock` only,
+    /// silently dropping any counter that was only in a conflict copy.
+    #[test]
+    fn silent_merge_clock_folds_in_copy_with_higher_counter() {
+        let disk = vec![vc(0xAA, 5)];
+        let copy = vec![vc(0xAA, 7), vc(0xCC, 2)];
+        let copies: Vec<&[VectorClockEntry]> = vec![copy.as_slice()];
+        let prior: Vec<VectorClockEntry> = Vec::new();
+        let result = silent_merge_clock(&disk, &copies, &prior);
+        // 0xAA: max(5, 7) = 7. 0xCC: only-in-copy = 2.
+        assert_eq!(result, vec![vc(0xAA, 7), vc(0xCC, 2)]);
+    }
+
+    /// A prior local-seen entry not present on disk or in any copy
+    /// MUST survive the LUB fold. Defensive: under monotone clock
+    /// evolution this is unreachable (disk-canonical only grows,
+    /// state was previously observed from it), but the helper's
+    /// contract is defined independent of that invariant — a backup
+    /// restore or future-protocol bug shouldn't silently regress the
+    /// local-seen clock.
+    #[test]
+    fn silent_merge_clock_folds_in_prior_local_seen() {
+        let disk = vec![vc(0xAA, 5)];
+        let copies: Vec<&[VectorClockEntry]> = Vec::new();
+        let prior = vec![vc(0xAA, 5), vc(0xDD, 9)];
+        let result = silent_merge_clock(&disk, &copies, &prior);
+        // 0xAA: max(5, 5) = 5. 0xDD: only-in-prior = 9 — must survive.
+        assert_eq!(result, vec![vc(0xAA, 5), vc(0xDD, 9)]);
+    }
+
+    /// Multiple copies, disk, and prior all contribute disjoint
+    /// device entries — the LUB is the union with element-wise max.
+    /// Sanity-check that the three-source fold composes correctly.
+    #[test]
+    fn silent_merge_clock_folds_disjoint_sources() {
+        let disk = vec![vc(0xAA, 3)];
+        let copy1 = vec![vc(0xBB, 4)];
+        let copy2 = vec![vc(0xCC, 5)];
+        let copies: Vec<&[VectorClockEntry]> = vec![copy1.as_slice(), copy2.as_slice()];
+        let prior = vec![vc(0xDD, 6)];
+        let result = silent_merge_clock(&disk, &copies, &prior);
+        // All four sources contributed one disjoint device each.
+        assert_eq!(
+            result,
+            vec![vc(0xAA, 3), vc(0xBB, 4), vc(0xCC, 5), vc(0xDD, 6)]
+        );
+    }
+
+    /// Element-wise max across all three sources: every device's
+    /// counter resolves to the max seen across disk + every copy +
+    /// prior, not the value from any single source.
+    #[test]
+    fn silent_merge_clock_element_wise_max_across_sources() {
+        let disk = vec![vc(0xAA, 1), vc(0xBB, 9)];
+        let copy = vec![vc(0xAA, 5), vc(0xBB, 2)];
+        let copies: Vec<&[VectorClockEntry]> = vec![copy.as_slice()];
+        let prior = vec![vc(0xAA, 3), vc(0xBB, 4)];
+        let result = silent_merge_clock(&disk, &copies, &prior);
+        // 0xAA: max(1, 5, 3) = 5. 0xBB: max(9, 2, 4) = 9.
+        assert_eq!(result, vec![vc(0xAA, 5), vc(0xBB, 9)]);
     }
 
     /// `Clone` round-trip preserves variant + payload. Pins the

--- a/cli/src/pipeline.rs
+++ b/cli/src/pipeline.rs
@@ -1,0 +1,288 @@
+//! One sync attempt — composes
+//! `sync_once → prepare_merge → veto UX → commit_with_decisions` and
+//! updates the caller-held [`SyncState`] in place.
+//!
+//! Spec: [`docs/superpowers/specs/2026-05-23-c2-headless-sync-cli-design.md`](../../docs/superpowers/specs/2026-05-23-c2-headless-sync-cli-design.md)
+//! §"Module layout" + §"Daemon loop sketch".
+//!
+//! The [`run_one`] entry point is the single seam consumed by both
+//! `once` (one attempt then exit) and `run` (daemon loop) subcommands.
+//! It is intentionally pure-orchestration: every disk read/write and
+//! every cryptographic step happens inside the `core::sync` primitives
+//! it dispatches to. The local side effects are limited to:
+//!
+//! - Mutating `state` in place when the disk-side clock moves forward
+//!   (`AppliedAutomatically`, `SilentMerge`, `MergedAndCommitted`).
+//! - Driving the caller-supplied [`VetoUx`] on the
+//!   `ConcurrentDetected` arm.
+//!
+//! `RollbackRejected` deliberately does NOT advance state — `state`
+//! survives byte-for-byte so the caller can persist the same value
+//! after dispatching the [`RunOutcome::RollbackRejected`] exit code.
+
+use std::path::Path;
+
+use secretary_core::crypto::secret::SecretBytes;
+use secretary_core::sync::{
+    commit_with_decisions, prepare_merge, sync_once, SyncError, SyncOutcome, SyncState,
+};
+use secretary_core::unlock::UnlockedIdentity;
+
+use crate::veto::VetoUx;
+
+/// Outcome of one sync attempt. The caller logs the variant and maps
+/// it to an [`crate::exit::ExitCode`] (in `once` mode) or continues the
+/// daemon loop (in `run` mode).
+///
+/// `vetoes_resolved` on the merged-and-committed variant doubles as a
+/// metric (how many record-level vetoes the operator's chosen
+/// [`VetoUx`] adjudicated this pass). Zero means a concurrent state
+/// was detected but every divergence merged cleanly without any veto
+/// candidates — distinct from [`Self::SilentMerge`], where the diff
+/// plan itself was empty.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RunOutcome {
+    /// Disk vector clock equals the local `highest_vector_clock_seen`.
+    /// No state mutation.
+    NothingToDo,
+    /// Disk strictly dominates the local `highest_vector_clock_seen`.
+    /// `state` advanced to match.
+    AppliedAutomatically,
+    /// Concurrent state was detected and the diff plan was non-empty:
+    /// `prepare_merge` produced a draft, the veto UX adjudicated any
+    /// tombstone disputes, and `commit_with_decisions` wrote the
+    /// merged result. `state` advanced to the post-merge clock.
+    /// `vetoes_resolved` reports the number of record-level vetoes the
+    /// UX handled (zero is valid — happens when the concurrent
+    /// divergence was all field-level merges with no tombstone fights).
+    MergedAndCommitted {
+        /// Number of [`secretary_core::sync::RecordTombstoneVeto`]
+        /// entries the veto UX adjudicated. Zero ⇒ silent record merge
+        /// (still a real commit, just no operator decisions surfaced).
+        vetoes_resolved: usize,
+    },
+    /// Concurrent state was detected but the diff plan was empty
+    /// (no diverging blocks after authentication; this is the
+    /// "concurrent at the manifest level, identical at the block
+    /// level" fast path). `state` advanced to the bundled disk clock;
+    /// no commit was issued.
+    SilentMerge,
+    /// Disk vector clock is strictly dominated by the local
+    /// `highest_vector_clock_seen` (rollback per
+    /// `docs/crypto-design.md` §10). `state` is NOT advanced — caller
+    /// surfaces [`crate::exit::ExitCode::RollbackRejected`] and the
+    /// next attempt sees the same disk state.
+    RollbackRejected,
+}
+
+/// Run one sync attempt against `vault_folder` using `identity` for
+/// reads, `password` for the commit-side re-open, and `state` as both
+/// input ("what clock have we already seen?") and output (mutated in
+/// place when the disk-side clock advances).
+///
+/// `veto_ux` is invoked exactly on the
+/// [`SyncOutcome::ConcurrentDetected`] arm with a non-empty diff plan.
+/// Non-interactive callers pass [`crate::veto::noninteractive::AutoKeepLocalVetoUx`];
+/// interactive callers pass [`crate::veto::interactive::TtyVetoUx`].
+/// Either way the trait method takes `&mut self`, so the same UX
+/// instance can adjudicate multiple records in one call.
+///
+/// `now_ms` is forwarded into the underlying merge timestamp; callers
+/// without a wall-clock requirement may pass `0` (the C.1 era pre-
+/// merge-timestamp default — `sync_once` itself currently does not
+/// consume it, but `commit_with_decisions` writes it into tombstone
+/// resurrection metadata).
+///
+/// # Errors
+///
+/// Any [`SyncError`] raised by the underlying `sync_once`,
+/// `prepare_merge`, or `commit_with_decisions` calls bubbles up
+/// verbatim. The caller maps it via
+/// [`crate::exit::ExitCode::from_sync_error`].
+///
+/// # State mutation contract
+///
+/// - [`RunOutcome::NothingToDo`] / [`RunOutcome::RollbackRejected`] —
+///   `state` is unchanged byte-for-byte.
+/// - [`RunOutcome::AppliedAutomatically`] / [`RunOutcome::SilentMerge`]
+///   — `state.highest_vector_clock_seen` advances to the disk clock.
+/// - [`RunOutcome::MergedAndCommitted`] — `state` is replaced with the
+///   `SyncState` returned by `commit_with_decisions` (the post-merge
+///   clock that includes both local and peer contributions).
+///
+/// On `Err`, `state` may have been partially mutated only if the error
+/// came from `commit_with_decisions` after state was updated — but
+/// `commit_with_decisions` returns `Result<SyncState, SyncError>` and
+/// the implementation only assigns to `*state` on `Ok`, so an error
+/// path leaves the caller's previous state intact. Callers that
+/// retry on transient `EvidenceStale` errors can safely re-invoke
+/// `run_one` with the same `state` without re-loading from disk.
+pub fn run_one(
+    vault_folder: &Path,
+    identity: &UnlockedIdentity,
+    password: &SecretBytes,
+    state: &mut SyncState,
+    veto_ux: &mut dyn VetoUx,
+    now_ms: u64,
+) -> Result<RunOutcome, SyncError> {
+    let outcome = sync_once(vault_folder, identity, state, now_ms)?;
+    match outcome {
+        SyncOutcome::NothingToDo => Ok(RunOutcome::NothingToDo),
+        SyncOutcome::AppliedAutomatically { new_state } => {
+            *state = new_state;
+            Ok(RunOutcome::AppliedAutomatically)
+        }
+        SyncOutcome::RollbackRejected(_evidence) => Ok(RunOutcome::RollbackRejected),
+        SyncOutcome::ConcurrentDetected {
+            bundle,
+            plan,
+            manifest_hash: _,
+            disk_vector_clock,
+            local_highest_seen: _,
+        } => {
+            // Silent-merge fast path: the manifest clocks are concurrent
+            // but no block-level divergence survived authentication. We
+            // can advance the local clock to the bundled disk clock
+            // without re-encrypting anything.
+            if plan.diverging_blocks.is_empty() {
+                state.highest_vector_clock_seen = disk_vector_clock;
+                return Ok(RunOutcome::SilentMerge);
+            }
+            let draft = prepare_merge(vault_folder, identity, &bundle, &plan)?;
+            let vetoes_count = draft.vetoes.len();
+            let decisions = veto_ux.decide(&draft.vetoes);
+            let new_state =
+                commit_with_decisions(vault_folder, password, draft, decisions, now_ms)?;
+            *state = new_state;
+            Ok(RunOutcome::MergedAndCommitted {
+                vetoes_resolved: vetoes_count,
+            })
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    //! Pure variant-level tests for [`RunOutcome`]. End-to-end
+    //! orchestration tests for [`run_one`] live in
+    //! [`cli/tests/pipeline_integration.rs`] because they need a real
+    //! `golden_vault_001`-backed on-disk vault that the unit test
+    //! harness can't easily fake (every `sync_once` call authenticates
+    //! a signed manifest and AEAD-decrypts a body).
+
+    use super::*;
+
+    /// Identical variants compare equal via the derived [`Eq`] impl.
+    #[test]
+    fn nothing_to_do_is_self_equal() {
+        assert_eq!(RunOutcome::NothingToDo, RunOutcome::NothingToDo);
+    }
+
+    /// Identical `AppliedAutomatically` values compare equal.
+    #[test]
+    fn applied_automatically_is_self_equal() {
+        assert_eq!(
+            RunOutcome::AppliedAutomatically,
+            RunOutcome::AppliedAutomatically
+        );
+    }
+
+    /// Identical `SilentMerge` values compare equal.
+    #[test]
+    fn silent_merge_is_self_equal() {
+        assert_eq!(RunOutcome::SilentMerge, RunOutcome::SilentMerge);
+    }
+
+    /// Identical `RollbackRejected` values compare equal.
+    #[test]
+    fn rollback_rejected_is_self_equal() {
+        assert_eq!(RunOutcome::RollbackRejected, RunOutcome::RollbackRejected);
+    }
+
+    /// Two `MergedAndCommitted` with the same `vetoes_resolved` count
+    /// compare equal — the variant's discriminant + payload is the
+    /// equality contract callers see.
+    #[test]
+    fn merged_and_committed_eq_when_counts_match() {
+        assert_eq!(
+            RunOutcome::MergedAndCommitted { vetoes_resolved: 0 },
+            RunOutcome::MergedAndCommitted { vetoes_resolved: 0 }
+        );
+        assert_eq!(
+            RunOutcome::MergedAndCommitted { vetoes_resolved: 7 },
+            RunOutcome::MergedAndCommitted { vetoes_resolved: 7 }
+        );
+    }
+
+    /// Two `MergedAndCommitted` with DIFFERENT veto counts must NOT
+    /// compare equal. Pins the discriminant payload as part of the
+    /// equality contract — a future refactor that boxed the count into
+    /// a struct would break this test rather than silently collapsing
+    /// distinct outcomes.
+    #[test]
+    fn merged_and_committed_ne_when_counts_differ() {
+        assert_ne!(
+            RunOutcome::MergedAndCommitted { vetoes_resolved: 0 },
+            RunOutcome::MergedAndCommitted { vetoes_resolved: 1 }
+        );
+        assert_ne!(
+            RunOutcome::MergedAndCommitted { vetoes_resolved: 1 },
+            RunOutcome::MergedAndCommitted { vetoes_resolved: 2 }
+        );
+    }
+
+    /// Distinct variants compare not-equal. Sanity check that the
+    /// derived `PartialEq` discriminates on variant, not just payload.
+    #[test]
+    fn distinct_variants_are_not_equal() {
+        assert_ne!(RunOutcome::NothingToDo, RunOutcome::AppliedAutomatically);
+        assert_ne!(RunOutcome::AppliedAutomatically, RunOutcome::SilentMerge);
+        assert_ne!(RunOutcome::SilentMerge, RunOutcome::RollbackRejected);
+        assert_ne!(RunOutcome::NothingToDo, RunOutcome::RollbackRejected);
+        assert_ne!(
+            RunOutcome::AppliedAutomatically,
+            RunOutcome::MergedAndCommitted { vetoes_resolved: 0 }
+        );
+        assert_ne!(
+            RunOutcome::SilentMerge,
+            RunOutcome::MergedAndCommitted { vetoes_resolved: 0 }
+        );
+    }
+
+    /// `Debug` is available on every variant (rules out a future
+    /// refactor that removed the derive). The exact format isn't part
+    /// of the contract, but we sanity-check that the variant name is
+    /// present in the rendered output — that's what an operator-facing
+    /// log line would surface.
+    #[test]
+    fn debug_format_includes_variant_name() {
+        assert!(format!("{:?}", RunOutcome::NothingToDo).contains("NothingToDo"));
+        assert!(format!("{:?}", RunOutcome::AppliedAutomatically).contains("AppliedAutomatically"));
+        assert!(format!("{:?}", RunOutcome::SilentMerge).contains("SilentMerge"));
+        assert!(format!("{:?}", RunOutcome::RollbackRejected).contains("RollbackRejected"));
+        let merged = RunOutcome::MergedAndCommitted { vetoes_resolved: 3 };
+        let dbg = format!("{merged:?}");
+        assert!(dbg.contains("MergedAndCommitted"));
+        assert!(dbg.contains('3'));
+    }
+
+    /// `Clone` round-trip preserves variant + payload. Pins the
+    /// derived impl in place — callers in the daemon loop will clone
+    /// outcomes for logging while continuing to dispatch on the
+    /// original.
+    #[test]
+    fn clone_preserves_variant_and_payload() {
+        let outcomes = [
+            RunOutcome::NothingToDo,
+            RunOutcome::AppliedAutomatically,
+            RunOutcome::SilentMerge,
+            RunOutcome::RollbackRejected,
+            RunOutcome::MergedAndCommitted {
+                vetoes_resolved: 42,
+            },
+        ];
+        for outcome in &outcomes {
+            assert_eq!(outcome, &outcome.clone());
+        }
+    }
+}

--- a/cli/src/state.rs
+++ b/cli/src/state.rs
@@ -41,7 +41,6 @@ const STATE_FILE_EXTENSION: &str = "state.cbor";
 const LOCK_FILE_EXTENSION: &str = "lock";
 const VAULT_UUID_HEX_LEN: usize = 32;
 
-#[allow(dead_code)] // TODO(#113): consumed when Task 5 pipeline wires state load/save + lockfile acquire.
 #[derive(Debug, Error)]
 pub enum StateError {
     #[error("I/O error reading or writing state file: {0}")]
@@ -112,7 +111,6 @@ pub fn default_state_dir() -> Option<PathBuf> {
 /// TOCTOU window where concurrent deletion (or a non-`secretary-sync`
 /// tool, since the per-vault lockfile only excludes our own binary) would
 /// surface as a confusing `Io` error instead of empty-state semantics.
-#[allow(dead_code)] // TODO(#113): consumed by Task 5 pipeline.
 pub fn load(state_dir: &Path, vault_uuid: [u8; 16]) -> Result<SyncState, StateError> {
     let path = state_file_path(state_dir, vault_uuid);
     let bytes = match fs::read(&path) {
@@ -133,7 +131,6 @@ pub fn load(state_dir: &Path, vault_uuid: [u8; 16]) -> Result<SyncState, StateEr
 /// Atomically persist `SyncState` to `<state-dir>/<vault_uuid_hex>.state.cbor`.
 /// Uses `tempfile::NamedTempFile::persist` for rename(2) / MoveFileExW
 /// semantics — same `=3.27.0` exact pin as the vault format layer.
-#[allow(dead_code)] // TODO(#113): consumed by Task 5 pipeline.
 pub fn save(state_dir: &Path, state: &SyncState) -> Result<(), StateError> {
     fs::create_dir_all(state_dir)?;
     let final_path = state_file_path(state_dir, state.vault_uuid);
@@ -148,14 +145,12 @@ pub fn save(state_dir: &Path, state: &SyncState) -> Result<(), StateError> {
 
 /// RAII guard for the per-vault exclusive lockfile. Holds the locked file
 /// handle; releases on drop (kernel auto-releases flock when fd closes).
-#[allow(dead_code)] // TODO(#113): consumed by Task 5 pipeline.
 #[derive(Debug)]
 pub struct LockfileGuard {
     _file: File,
     path: PathBuf,
 }
 
-#[allow(dead_code)] // TODO(#113): consumed by Task 5 pipeline.
 impl LockfileGuard {
     /// Acquire the exclusive lock on `<state-dir>/<vault_uuid_hex>.lock`.
     /// Returns `Err(StateError::LockfileHeld)` if another process already

--- a/cli/src/unlock.rs
+++ b/cli/src/unlock.rs
@@ -41,7 +41,6 @@ use secretary_core::crypto::secret::SecretBytes;
 /// is intentional — `rpassword::prompt_password` does not append one.
 const PASSWORD_PROMPT: &str = "Vault password: ";
 
-#[allow(dead_code)] // TODO(#113): consumed by Task 5 pipeline.
 #[derive(Debug, Error)]
 pub enum UnlockReadError {
     #[error("--non-interactive requires --password-stdin to provide the password")]
@@ -60,7 +59,6 @@ pub enum UnlockReadError {
 /// Generic over `R: Read` so unit tests (and Task 5's
 /// pipeline-orchestration tests) can drive the `Stream` arm from a
 /// `Cursor<Vec<u8>>` without touching stdin or a TTY.
-#[allow(dead_code)] // TODO(#113): consumed by Task 5 pipeline.
 pub enum PasswordSource<'a, R: Read> {
     /// Read interactively from the TTY via `rpassword` — no echo.
     Tty,
@@ -83,7 +81,6 @@ pub enum PasswordSource<'a, R: Read> {
 /// on stdin, either of which would otherwise pass an empty password
 /// down to `open_with_password` and surface a less obvious unlock
 /// failure further in.
-#[allow(dead_code)] // TODO(#113): consumed by Task 5 pipeline.
 pub fn read_password_from_reader<R: Read>(reader: &mut R) -> Result<SecretBytes, UnlockReadError> {
     let mut buf: Vec<u8> = Vec::new();
     reader.read_to_end(&mut buf)?;
@@ -111,7 +108,6 @@ pub fn read_password_from_reader<R: Read>(reader: &mut R) -> Result<SecretBytes,
 /// The returned [`SecretBytes`] is constructed via [`SecretBytes::new`]
 /// from `String::into_bytes` — the underlying allocation moves, so the
 /// password never lives in an unzeroized `String` after this call.
-#[allow(dead_code)] // TODO(#113): consumed by Task 5 pipeline.
 pub fn read_password_from_tty() -> Result<SecretBytes, UnlockReadError> {
     let s = rpassword::prompt_password(PASSWORD_PROMPT)?;
     finalize_tty(s)

--- a/cli/src/veto/interactive.rs
+++ b/cli/src/veto/interactive.rs
@@ -28,15 +28,14 @@ use super::VetoUx;
 const DEFAULT_DECISION_LABEL: &str = "KeepLocal";
 
 /// TTY veto UX, generic over any [`BufRead`] + [`Write`] pair for
-/// testability. Production wires `stdin().lock()` + `stderr().lock()`.
-#[allow(dead_code)] // TODO(#113): consumed by Task 5 pipeline.
+/// testability. Production wires `stdin().lock()` + `stderr().lock()`;
+/// [`crate::pipeline::run_one`] consumes it via `&mut dyn VetoUx`.
 pub struct TtyVetoUx<R: BufRead, W: Write> {
     reader: R,
     writer: W,
 }
 
 impl<R: BufRead, W: Write> TtyVetoUx<R, W> {
-    #[allow(dead_code)] // TODO(#113): consumed by Task 5 pipeline.
     pub fn new(reader: R, writer: W) -> Self {
         Self { reader, writer }
     }

--- a/cli/src/veto/mod.rs
+++ b/cli/src/veto/mod.rs
@@ -28,9 +28,8 @@ pub(crate) mod test_util;
 /// Implementations are stateless and side-effect-free except for the
 /// actual UX layer (which reads from a [`std::io::Read`] + writes to a
 /// [`std::io::Write`]). The trait is intentionally object-safe so the
-/// upcoming pipeline can pick the impl at runtime behind a
-/// `&mut dyn VetoUx` without monomorphisation.
-#[allow(dead_code)] // TODO(#113): consumed by Task 5 pipeline.
+/// pipeline picks the impl at runtime behind a `&mut dyn VetoUx`
+/// without monomorphisation — see [`crate::pipeline::run_one`].
 pub trait VetoUx {
     /// Produce one [`VetoDecision`] per input veto, **preserving order**.
     ///

--- a/cli/src/veto/noninteractive.rs
+++ b/cli/src/veto/noninteractive.rs
@@ -12,8 +12,9 @@ use super::VetoUx;
 /// unit struct; instantiation is free.
 ///
 /// Order is preserved one-to-one with the input slice so the bijection
-/// check in `commit_with_decisions` is trivially satisfied.
-#[allow(dead_code)] // TODO(#113): consumed by Task 5 pipeline.
+/// check in `commit_with_decisions` is trivially satisfied. Consumed
+/// by [`crate::pipeline::run_one`] when the operator passes
+/// `--non-interactive`.
 pub struct AutoKeepLocalVetoUx;
 
 impl VetoUx for AutoKeepLocalVetoUx {

--- a/cli/tests/main_validate.rs
+++ b/cli/tests/main_validate.rs
@@ -1,0 +1,84 @@
+//! Binary-level integration tests for the `CommonArgs::validate` wiring
+//! in `cli/src/main.rs`. Pins the contract that `--non-interactive`
+//! without `--password-stdin` exits with `ExitCode::UsageError` (2)
+//! before any further work, without printing a stub "not yet
+//! implemented" message.
+//!
+//! These tests complement the parser-level unit tests in
+//! `cli/src/args.rs::tests::validate_*` (which exercise the typed
+//! [`secretary_cli::args::ArgsValidationError`] surface directly).
+//! The binary-level tests close the gap — they prove `main()` actually
+//! calls `validate()` and surfaces the correct exit code, rather than
+//! just defining a method that nobody invokes.
+
+use assert_cmd::Command;
+use predicates::prelude::*;
+
+const BIN_NAME: &str = "secretary-sync";
+
+/// `once --non-interactive` without `--password-stdin` exits 2
+/// (UsageError) with a stderr message that includes the typed error's
+/// `Display` impl. Pins the wiring from `args::CommonArgs::validate`
+/// → `ExitCode::UsageError` for the `once` subcommand.
+#[test]
+fn once_non_interactive_without_password_stdin_exits_usage_error() {
+    Command::cargo_bin(BIN_NAME)
+        .expect("binary built")
+        .args(["once", "--non-interactive", "/tmp/vault"])
+        .assert()
+        .failure()
+        .code(2)
+        .stderr(predicate::str::contains(
+            "--non-interactive requires --password-stdin",
+        ));
+}
+
+/// Same rule for the `run` subcommand — [`secretary_cli::args::CommonArgs`]
+/// is shared, so the dispatch in `main.rs` must apply the validation
+/// to both. Pins the wiring symmetry.
+#[test]
+fn run_non_interactive_without_password_stdin_exits_usage_error() {
+    Command::cargo_bin(BIN_NAME)
+        .expect("binary built")
+        .args(["run", "--non-interactive", "/tmp/vault"])
+        .assert()
+        .failure()
+        .code(2)
+        .stderr(predicate::str::contains(
+            "--non-interactive requires --password-stdin",
+        ));
+}
+
+/// `--password-stdin` alone (without `--non-interactive`) MUST pass
+/// the args-layer validation. The subcommand body is still a Task 9
+/// stub today, so the process exits 1 (`GenericError`) with the "not
+/// yet implemented" message — but critically NOT 2 (UsageError).
+/// Pins the negative side of the validation contract.
+#[test]
+fn once_password_stdin_alone_passes_args_validation() {
+    Command::cargo_bin(BIN_NAME)
+        .expect("binary built")
+        .args(["once", "--password-stdin", "/tmp/vault"])
+        .assert()
+        .failure()
+        .code(1)
+        .stderr(predicate::str::contains("not yet implemented"));
+}
+
+/// Both flags together — the canonical headless invocation. Passes
+/// validation, falls through to the Task 9 stub.
+#[test]
+fn once_non_interactive_with_password_stdin_passes_args_validation() {
+    Command::cargo_bin(BIN_NAME)
+        .expect("binary built")
+        .args([
+            "once",
+            "--non-interactive",
+            "--password-stdin",
+            "/tmp/vault",
+        ])
+        .assert()
+        .failure()
+        .code(1)
+        .stderr(predicate::str::contains("not yet implemented"));
+}

--- a/cli/tests/pipeline_integration.rs
+++ b/cli/tests/pipeline_integration.rs
@@ -1,0 +1,299 @@
+//! End-to-end tests for [`secretary_cli::pipeline::run_one`] against a
+//! real `golden_vault_001`-backed on-disk vault.
+//!
+//! The cli unit tests in `src/pipeline.rs` cover [`RunOutcome`] shape
+//! and equality; these integration tests exercise the actual
+//! orchestration through the underlying `secretary_core` primitives
+//! (`sync_once → prepare_merge → commit_with_decisions`).
+//!
+//! ## Why these tests live here, not in `core/`
+//!
+//! `run_one` is the seam consumed by both `once` (Task 9) and `run`
+//! (Task 7) subcommands. The bottom half — the dispatch logic — is
+//! cli-owned (it folds `SyncOutcome` into `RunOutcome` and threads the
+//! `VetoUx` trait through). Putting orchestration tests here keeps the
+//! contract close to its only caller; `core/tests/sync.rs` already
+//! covers the lower-level `sync_once` dispatch on its own.
+//!
+//! ## Fixture access
+//!
+//! `cli/tests/` reaches the golden vault through the workspace-relative
+//! path `../core/tests/data/golden_vault_001/`. The
+//! `core/tests/fixtures/mod.rs` helpers are not cross-crate (per-test-
+//! binary modules), so this file mirrors the minimum we need: read the
+//! password out of `golden_vault_001_inputs.json`, then call
+//! [`open_with_password`] on the on-disk vault.toml + bundle bytes.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use secretary_cli::pipeline::{run_one, RunOutcome};
+use secretary_cli::veto::noninteractive::AutoKeepLocalVetoUx;
+use secretary_core::crypto::secret::SecretBytes;
+use secretary_core::sync::SyncState;
+use secretary_core::unlock::{open_with_password, vault_toml, UnlockedIdentity};
+use secretary_core::vault::block::VectorClockEntry;
+
+/// Filename of the golden-vault inputs JSON living alongside the
+/// fixture directory; the password we need to drive `open_with_password`
+/// is stored there.
+const GOLDEN_INPUTS_FILENAME: &str = "golden_vault_001_inputs.json";
+
+/// Filename of the golden vault folder under `core/tests/data/`.
+const GOLDEN_VAULT_DIRNAME: &str = "golden_vault_001";
+
+/// Filenames inside the vault folder.
+const VAULT_TOML_FILENAME: &str = "vault.toml";
+const IDENTITY_BUNDLE_FILENAME: &str = "identity.bundle.enc";
+
+/// Path to `core/tests/data/` rooted at the workspace root. The cli's
+/// `CARGO_MANIFEST_DIR` is the `cli/` crate directory; one level up is
+/// the workspace root.
+fn core_test_data_dir() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .expect("cli crate dir has a parent (workspace root)")
+        .join("core")
+        .join("tests")
+        .join("data")
+}
+
+/// Recursively copy `src` into `dst`. Mirrors the helper pattern used
+/// in `core/tests/sync_helpers/mod.rs` so each test owns its own
+/// writable vault tempdir.
+fn copy_dir_recursive(src: &Path, dst: &Path) {
+    fs::create_dir_all(dst).expect("create_dir_all dst");
+    for entry in fs::read_dir(src).expect("read_dir src") {
+        let entry = entry.expect("dir entry");
+        let src_path = entry.path();
+        let dst_path = dst.join(entry.file_name());
+        if entry.file_type().expect("file_type").is_dir() {
+            copy_dir_recursive(&src_path, &dst_path);
+        } else {
+            fs::copy(&src_path, &dst_path).expect("copy file");
+        }
+    }
+}
+
+/// Extract the password from `golden_vault_001_inputs.json`. We use a
+/// lightweight string-scan rather than pulling in a `serde_json`
+/// dev-dep just for this — `golden_vault_001_inputs.json` is a stable
+/// fixture and the inputs schema is single-sourced in `core/tests/`.
+fn golden_vault_password() -> SecretBytes {
+    let raw = fs::read_to_string(core_test_data_dir().join(GOLDEN_INPUTS_FILENAME))
+        .expect("golden_vault_001_inputs.json must exist");
+    // The relevant line looks like `  "password": "correct horse battery staple",`
+    // — extract the value between the colon and the trailing comma.
+    let needle = "\"password\":";
+    let start = raw.find(needle).expect("password key present");
+    let after_key = &raw[start + needle.len()..];
+    let first_quote = after_key
+        .find('"')
+        .expect("opening quote after password key");
+    let rest = &after_key[first_quote + 1..];
+    let closing_quote = rest.find('"').expect("closing quote after password value");
+    let password = &rest[..closing_quote];
+    SecretBytes::new(password.as_bytes().to_vec())
+}
+
+/// Stage a fresh writable copy of `golden_vault_001/` into a tempdir
+/// and unlock it. Returns the tempdir (keep alive for the test's
+/// lifetime), the vault folder path inside it, the unlocked identity,
+/// the password (for `commit_with_decisions` if the test path reaches
+/// it), and the vault's UUID (so the test can build a matching
+/// [`SyncState`]).
+fn stage_and_unlock_golden() -> (
+    tempfile::TempDir,
+    PathBuf,
+    UnlockedIdentity,
+    SecretBytes,
+    [u8; 16],
+) {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let vault_dir = tmp.path().join(GOLDEN_VAULT_DIRNAME);
+    let golden_src = core_test_data_dir().join(GOLDEN_VAULT_DIRNAME);
+    copy_dir_recursive(&golden_src, &vault_dir);
+
+    let vault_toml_bytes = fs::read(vault_dir.join(VAULT_TOML_FILENAME)).expect("read vault.toml");
+    let identity_bundle_bytes =
+        fs::read(vault_dir.join(IDENTITY_BUNDLE_FILENAME)).expect("read identity.bundle.enc");
+
+    let password = golden_vault_password();
+    let identity = open_with_password(&vault_toml_bytes, &identity_bundle_bytes, &password)
+        .expect("open_with_password on golden vault must succeed");
+
+    // Recover the vault_uuid via the vault.toml — `UnlockedIdentity`
+    // doesn't surface it directly (it carries the IBK + identity
+    // bundle, both of which are the secret material), so we re-parse
+    // the same vault.toml the unlock path already authenticated.
+    let vt_str = std::str::from_utf8(&vault_toml_bytes).expect("vault.toml utf-8");
+    let vt = vault_toml::decode(vt_str).expect("decode vault.toml");
+    (tmp, vault_dir, identity, password, vt.vault_uuid)
+}
+
+/// `now_ms = 0` is the C.1-era convention for callers that don't need
+/// a real wall clock (`sync_once` ignores it; `commit_with_decisions`
+/// writes it into tombstone resurrection metadata but no path here
+/// touches a tombstone).
+const TEST_NOW_MS: u64 = 0;
+
+/// Fresh state vs the populated golden vault → `AppliedAutomatically`,
+/// and the state advances to the disk clock.
+///
+/// This is the canonical first-sync happy path: on a new device, the
+/// caller hands [`run_one`] an empty [`SyncState`] (lattice bottom),
+/// and the disk-side clock dominates trivially. Output: state's clock
+/// becomes the disk clock so the next call returns `NothingToDo`.
+#[test]
+fn run_one_returns_applied_automatically_on_fresh_state() {
+    let (_tmp, vault_dir, identity, password, vault_uuid) = stage_and_unlock_golden();
+    let mut state = SyncState::empty(vault_uuid);
+    let mut ux = AutoKeepLocalVetoUx;
+
+    let pre_clock = state.highest_vector_clock_seen.clone();
+    let outcome = run_one(
+        &vault_dir,
+        &identity,
+        &password,
+        &mut state,
+        &mut ux,
+        TEST_NOW_MS,
+    )
+    .expect("run_one must succeed on golden vault");
+
+    assert_eq!(outcome, RunOutcome::AppliedAutomatically);
+    assert_ne!(
+        state.highest_vector_clock_seen, pre_clock,
+        "state.highest_vector_clock_seen must advance past the initial empty clock"
+    );
+    assert!(
+        !state.highest_vector_clock_seen.is_empty(),
+        "golden vault's disk clock is non-empty, so the advanced state's clock must be non-empty too"
+    );
+}
+
+/// Second invocation with the state from the first → `NothingToDo`,
+/// and the state is unchanged.
+///
+/// Pins the idempotence side of the contract: once the local clock
+/// matches disk, a re-sync is a no-op with zero state mutation.
+#[test]
+fn run_one_returns_nothing_to_do_on_second_call() {
+    let (_tmp, vault_dir, identity, password, vault_uuid) = stage_and_unlock_golden();
+    let mut state = SyncState::empty(vault_uuid);
+    let mut ux = AutoKeepLocalVetoUx;
+
+    let first = run_one(
+        &vault_dir,
+        &identity,
+        &password,
+        &mut state,
+        &mut ux,
+        TEST_NOW_MS,
+    )
+    .expect("first run_one must succeed");
+    assert_eq!(first, RunOutcome::AppliedAutomatically);
+
+    let clock_after_first = state.highest_vector_clock_seen.clone();
+    let second = run_one(
+        &vault_dir,
+        &identity,
+        &password,
+        &mut state,
+        &mut ux,
+        TEST_NOW_MS,
+    )
+    .expect("second run_one must succeed");
+    assert_eq!(second, RunOutcome::NothingToDo);
+    assert_eq!(
+        state.highest_vector_clock_seen, clock_after_first,
+        "NothingToDo must not mutate state"
+    );
+}
+
+/// State whose clock strictly dominates the disk's → `RollbackRejected`,
+/// and the state is NOT advanced.
+///
+/// Pins the §10 reject path: a local clock that already saw a
+/// strictly-later value rejects the older disk clock instead of
+/// silently regressing. The caller's `state` survives byte-for-byte so
+/// no persistence step accidentally records the older disk view.
+#[test]
+fn run_one_returns_rollback_rejected_when_state_dominates() {
+    let (_tmp, vault_dir, identity, password, vault_uuid) = stage_and_unlock_golden();
+
+    // First, advance state to disk's clock so we know what's there.
+    let mut state = SyncState::empty(vault_uuid);
+    let mut ux = AutoKeepLocalVetoUx;
+    let first = run_one(
+        &vault_dir,
+        &identity,
+        &password,
+        &mut state,
+        &mut ux,
+        TEST_NOW_MS,
+    )
+    .expect("first run_one must succeed");
+    assert_eq!(first, RunOutcome::AppliedAutomatically);
+
+    // Inject a synthetic entry with a higher counter on a DIFFERENT
+    // device_uuid than any disk entry, plus bump the counter on every
+    // existing entry. The resulting clock strictly dominates disk's.
+    let mut dominating_clock: Vec<VectorClockEntry> = state
+        .highest_vector_clock_seen
+        .iter()
+        .map(|e| VectorClockEntry {
+            device_uuid: e.device_uuid,
+            counter: e.counter + 1,
+        })
+        .collect();
+    // Insert a synthetic device whose UUID is guaranteed to be unique
+    // (0xFF...FF — not a value any real generator would produce). Push
+    // it to the back; SyncState::new will validate sort order.
+    dominating_clock.push(VectorClockEntry {
+        device_uuid: [0xFF; 16],
+        counter: 999,
+    });
+    // Re-sort by device_uuid to satisfy the SyncState invariant.
+    dominating_clock.sort_by_key(|e| e.device_uuid);
+    let mut dominating_state = SyncState::new(vault_uuid, dominating_clock.clone())
+        .expect("dominating clock must satisfy sorted+unique invariant");
+
+    let outcome = run_one(
+        &vault_dir,
+        &identity,
+        &password,
+        &mut dominating_state,
+        &mut ux,
+        TEST_NOW_MS,
+    )
+    .expect("run_one must succeed (rollback returns Ok, not Err)");
+    assert_eq!(outcome, RunOutcome::RollbackRejected);
+    assert_eq!(
+        dominating_state.highest_vector_clock_seen, dominating_clock,
+        "RollbackRejected must NOT mutate state — the local clock stays dominating"
+    );
+}
+
+/// `AutoKeepLocalVetoUx` is consumed through the `&mut dyn VetoUx`
+/// boundary without panicking, even on a happy path where the trait
+/// method never fires (the golden vault is non-concurrent, so the veto
+/// UX is never invoked). This pins the trait-object boundary for the
+/// non-interactive impl as part of the public API contract.
+#[test]
+fn run_one_threads_autokeeplocal_through_dyn_boundary() {
+    let (_tmp, vault_dir, identity, password, vault_uuid) = stage_and_unlock_golden();
+    let mut state = SyncState::empty(vault_uuid);
+    let mut ux = AutoKeepLocalVetoUx;
+    let ux_ref: &mut dyn secretary_cli::veto::VetoUx = &mut ux;
+    let outcome = run_one(
+        &vault_dir,
+        &identity,
+        &password,
+        &mut state,
+        ux_ref,
+        TEST_NOW_MS,
+    )
+    .expect("run_one with dyn-trait UX must succeed");
+    assert_eq!(outcome, RunOutcome::AppliedAutomatically);
+}

--- a/docs/handoffs/2026-05-25-c2-task-5-pipeline-shipped.md
+++ b/docs/handoffs/2026-05-25-c2-task-5-pipeline-shipped.md
@@ -1,0 +1,170 @@
+# NEXT_SESSION.md — C.2 Task 5 (pipeline + lib/bin split) shipped
+
+**Session date:** 2026-05-25 (C.2 Task 5 — `cli/src/pipeline.rs`: `run_one` + `RunOutcome` + lib/bin split + #113 cleanup + `--non-interactive ↔ --password-stdin` validation).
+**Status:** C.2 Task 5 ✅ on branch `feature/c2-task-5`; PR pending. Tasks 6-10 queued.
+
+## (1) What we shipped this session
+
+One commit on `feature/c2-task-5` carrying the fifth code slice of C.2 — the pipeline orchestrator that composes `sync_once → prepare_merge → veto UX → commit_with_decisions` behind a single function. Both subcommands (`once` and `run`) will consume this exact entry point in the upcoming tasks. The slice also promotes the cli crate to library+binary so integration tests can drive the pipeline directly through `secretary_cli::*` (Task 5's `cli/tests/pipeline_integration.rs` is the first end-to-end test that crosses the library boundary), lifts the umbrella `#[allow(dead_code)]` set queued by issue [#113](https://github.com/hherb/secretary/issues/113), and adds the args-layer validation for the `--non-interactive ↔ --password-stdin` flag-pair so the failure surfaces before any vault I/O.
+
+| Artifact | Path | Notes |
+|---|---|---|
+| Pipeline module | [`cli/src/pipeline.rs`](../../cli/src/pipeline.rs) | New. `pub fn run_one(&Path, &UnlockedIdentity, &SecretBytes, &mut SyncState, &mut dyn VetoUx, u64) -> Result<RunOutcome, SyncError>`. Five-variant `RunOutcome` enum (`NothingToDo`, `AppliedAutomatically`, `MergedAndCommitted { vetoes_resolved: usize }`, `SilentMerge`, `RollbackRejected`) plus the documented state-mutation contract (which arms advance `state`, which don't). 9 unit tests pin variant equality + Debug shape + Clone round-trip + the `MergedAndCommitted` payload-discrimination contract. |
+| Library surface | [`cli/src/lib.rs`](../../cli/src/lib.rs) | New. Re-exports `args`, `exit`, `pipeline`, `state`, `unlock`, `veto` so integration tests can reach them. Production consumers still run the `secretary-sync` binary. |
+| Cargo manifest | [`cli/Cargo.toml`](../../cli/Cargo.toml) | Added `[lib] name = "secretary_cli" path = "src/lib.rs"` ahead of the existing `[[bin]]` block. Binary target unchanged. |
+| Binary entry | [`cli/src/main.rs`](../../cli/src/main.rs) | Switched from inline `mod` declarations to `use secretary_cli::{args, exit};`. Subcommand bodies remain stubs (the dispatch + `pipeline::run_one` wiring lands in Task 9). |
+| Args validation | [`cli/src/args.rs`](../../cli/src/args.rs) | New `ArgsValidationError::NonInteractiveWithoutStdin` typed-error variant + `CommonArgs::validate()` method. Mirrors `UnlockReadError::NonInteractiveWithoutStdin` at the args layer so the failure fires before any unlock attempt. 5 new unit tests cover the accept/reject matrix (default-flags, `--password-stdin` alone, both-flags, `--non-interactive` alone on `once`, `--non-interactive` alone on `run`). |
+| Dead-code cleanup | [`cli/src/{exit,state,unlock}.rs`](../../cli/src/), [`cli/src/veto/{mod,interactive,noninteractive}.rs`](../../cli/src/veto/) | All `#[allow(dead_code)]` TODO(#113) markers removed. The cli crate now compiles `-D warnings` with zero allowances. |
+| Integration tests | [`cli/tests/pipeline_integration.rs`](../../cli/tests/pipeline_integration.rs) | New. 4 tests against a fresh-copied `golden_vault_001` tempdir: `run_one_returns_applied_automatically_on_fresh_state` (+ state advanced); `run_one_returns_nothing_to_do_on_second_call` (+ state unchanged); `run_one_returns_rollback_rejected_when_state_dominates` (+ state NOT advanced); `run_one_threads_autokeeplocal_through_dyn_boundary` (the trait-object boundary smoke). Fixture access mirrors `core/tests/fixtures/mod.rs` — `golden_vault_001_inputs.json` for the password, `core/tests/data/golden_vault_001/` for the on-disk vault, via the `cli/`-relative workspace-root path. |
+
+**Commit:** `97dfe85 C.2 Task 5 — pipeline (one sync attempt) + lib/bin split`. 18 new tests across cli (9 pipeline unit + 5 args validation unit + 4 integration); workspace 850 → 868. Issue #113 closes with this commit.
+
+### Plan ↔ reality reconciliations
+
+Three deliberate deviations from the plan, all documented in the commit body:
+
+| Plan note | Reality | Resolution |
+|---|---|---|
+| Plan code referenced `core/tests/data/golden_vault_001_password` file (line 1539). | No such file exists — the password lives at the `password` key inside `golden_vault_001_inputs.json` (verified by reading `core/tests/fixtures/mod.rs::golden_vault_001_password`). | Read the inputs JSON and string-scan for the `"password":` key. Avoids dragging `serde_json` into `cli/dev-dependencies` for a single fixture, and matches the pattern already used by the `fixtures` helper that lives in `core/tests/` (and isn't reachable cross-crate). |
+| Plan code referenced `identity.bundle.cbor` (line 1572). | Actual fixture file is `identity.bundle.enc`. | Used the actual filename. |
+| Plan code referenced `unlocked.vault.vault_uuid` (line 1577). | `UnlockedIdentity` has no `vault` field — it carries `identity_block_key` + `identity: IdentityBundle`. | Re-decode `vault.toml` via `secretary_core::unlock::vault_toml::decode` to recover the `vault_uuid`. Same approach as `core/tests/fixtures/mod.rs::extract_vault_uuid`. |
+
+Plan acceptance line for tests was "2 new integration tests; workspace 835→837". Actual: **18 new tests; workspace 850 → 868**. The baseline (850) accumulated through Tasks 1-4. The test mix expanded beyond the plan's literal 2 to satisfy the baton's broader acceptance criteria ("each outcome variant + each veto policy + state-update side effects + the no-op happy paths. Plan expects ~15-20 new tests"):
+
+- **Pipeline unit tests (9)** — variant equality + Debug + Clone round-trip + `MergedAndCommitted` payload discrimination. Pure (no vault I/O). These are the cheapest possible regression guards on the `RunOutcome` shape.
+- **Args validation tests (5)** — accept/reject matrix for `--non-interactive ↔ --password-stdin` including the `run` subcommand parity (the validation lives on `CommonArgs`, shared by both subcommands).
+- **Integration tests (4)** — see the `cli/tests/pipeline_integration.rs` table row above.
+
+Concurrent-path coverage (`MergedAndCommitted`, `SilentMerge`) is deferred to Task 10's two-instance convergence tests, which can stage the necessary conflict-copy fixtures end-to-end via two cli processes rather than reproducing the `sync_helpers` machinery cross-crate. The unit + integration tests in this slice cover the dispatch arms that don't need a concurrent setup; the merge-arm correctness is already pinned by the core's `sync_merge*` integration tests + proptests.
+
+### Gauntlet snapshot at session close
+
+```
+PASSED: 868 FAILED: 0 IGNORED: 10
+clippy --release --workspace --tests -- -D warnings   clean
+fmt --all -- --check                                  clean
+uv run core/tests/python/conformance.py               PASS
+uv run core/tests/python/spec_test_name_freshness.py  PASS (96 resolved / 0 unresolved / 2 suppressed)
+```
+
+## (2) What's next — start C.2 Task 6
+
+After this PR merges, the next slice is **C.2 Task 6: Watcher submodule — partial-download ready + debounce (`cli/src/watcher/{mod,ready,debounce}.rs`)** ([`docs/superpowers/plans/2026-05-23-c2-headless-sync-cli.md`](../superpowers/plans/2026-05-23-c2-headless-sync-cli.md) §"Task 6").
+
+### Acceptance criteria for Task 6
+
+- [ ] New `cli/src/watcher/mod.rs` (~70 LOC): `WatcherEvent` enum + driver trait surface.
+- [ ] New `cli/src/watcher/ready.rs` (~190 LOC): `matches_partial_pattern` (pure pattern matcher for Dropbox / iCloud / Syncthing partial-download filename suffixes), `is_size_stable` (size + mtime stability probe), `wait_for_ready` (composes the two). Per ADR-0003 partial-download detection.
+- [ ] New `cli/src/watcher/debounce.rs` (~140 LOC): pure state machine that collapses a notify event burst into a single `should_sync_now` signal — `idle → pending(deadline)` transitions, deadline driven by `--debounce-ms`.
+- [ ] New `cli/src/main.rs` line: `mod watcher;` (in the library, not the binary — Task 5 already established the `lib.rs` pattern).
+- [ ] Pure-function unit tests for each new file: pattern matcher covers each cloud's known partial-suffix list (Dropbox `.tmp` / iCloud `.icloud` / Syncthing `~syncthing~`); size-stability probe covers grow-then-stable + stable-throughout + missing-file branches; debounce state machine covers single-event + burst-collapse + post-deadline-emit + reset-on-new-event-after-emit.
+- [ ] Gauntlet target: **PASSED: 868 + N FAILED: 0 IGNORED: 10**. Absolute base is now 868 (bumped from 850 by Task 5's 18 new tests).
+- [ ] Clippy, fmt, conformance, spec freshness all clean.
+
+### Plan handoff
+
+Full step-by-step in [`docs/superpowers/plans/2026-05-23-c2-headless-sync-cli.md`](../superpowers/plans/2026-05-23-c2-headless-sync-cli.md) §"Task 6". Three sub-files (mod / ready / debounce) keep each below the 500-LOC threshold; the debounce file is the densest at ~140 LOC and is the only one with non-trivial state (the others are pure functions).
+
+## (3) Open decisions and risks
+
+### Decisions settled during this session
+
+- **`run_one` returns `Result<RunOutcome, SyncError>`** (not `Result<(ExitCode, RunOutcome), SyncError>`) so the dispatch caller in Task 9 owns the `RunOutcome → ExitCode` mapping. Keeps `pipeline` ignorant of exit-code semantics; mirrors the spec's "pure pipeline, I/O at edges" principle.
+- **`RunOutcome::MergedAndCommitted { vetoes_resolved: usize }`** keeps the operator-visible metric inline rather than in a sibling struct. The discriminant test (`merged_and_committed_ne_when_counts_differ`) pins this — a future refactor that drops the count or boxes it into a struct trips the test.
+- **`RunOutcome::SilentMerge` is distinct from `MergedAndCommitted { vetoes_resolved: 0 }`.** Both denote "concurrent state detected, ended successfully", but SilentMerge means the diff plan itself was empty (no diverging blocks survived authentication — just a clock advance); MergedAndCommitted means the diff plan was non-empty AND every divergence merged without tombstone fights. The two are observably different to the operator (commit happened in one, not the other) and to the daemon loop (filesystem state changed in one, not the other).
+- **State mutation contract is documented + tested.** NothingToDo + RollbackRejected leave `state` byte-for-byte unchanged; AppliedAutomatically + SilentMerge + MergedAndCommitted advance it. The integration tests pin all three of those (advances + NothingToDo-no-mutation + RollbackRejected-no-mutation).
+- **Library + binary hybrid.** The `[lib]` target is `secretary_cli` (underscored — Rust crate-name convention); the `[[bin]]` target is `secretary-sync` (hyphenated — CLI invocation convention). Both modules see the same `src/` tree; the binary's `main.rs` uses `use secretary_cli::{args, exit};`.
+- **`ArgsValidationError` lives in `args` module, not `unlock`.** The args-layer error type runs at parse time, not at unlock time. The two error types share a variant name (`NonInteractiveWithoutStdin`) to make the contract obvious, but they're distinct types because they fire at different lifecycle stages. Task 9's `main.rs` dispatch will map `ArgsValidationError` → `ExitCode::UsageError` (2) and `UnlockReadError::NonInteractiveWithoutStdin` → `ExitCode::UsageError` (2) — same exit code, different sites.
+- **Fixture access via workspace-relative path.** `cli/tests/` reads `../core/tests/data/golden_vault_001/` because `core/tests/fixtures/mod.rs` is a per-test-binary module and not reachable across crates. The pattern is documented at the top of `cli/tests/pipeline_integration.rs` so a future contributor doesn't try the broken cross-crate import.
+
+### Decisions carried forward (unchanged from Task 4 close)
+
+- D1-D10 from the spec are still settled.
+- `--veto-policy=fail`, `--decisions-file`, `--exit-on-error`, `status`, `init` subcommands all deferred to future C.2.x slices.
+- Windows is best-effort per D10 (no CI runner planned for C.2 implementation).
+- Clean-room conformance harness for `cli/` deferred to C.4 or a future C.2.x slice.
+- The `from_sync_error` mapper's exit-code surface (Task 1): every `SyncError` variant without a dedicated code maps to `GenericError = 1`; bijection-failure variants do NOT get distinct codes (CLI bugs, not operator-recoverable).
+- fs4 dep retained over stdlib `File::try_lock` until workspace MSRV bumps past 1.89.
+- `SecretBytes::new(buf)` over `SecretBytes::from(slice) + zeroize` for owned-buffer unlock paths (Task 3 — still in force).
+- `TtyVetoUx` EOF latch + breadcrumb (Task 4) + safe-default `KeepLocal` on empty/error input + silent prompt-write failures: all in force.
+
+### Risks carried into Task 6
+
+- **Cross-platform `notify` quirks land in Task 7.** Task 6's `watcher::ready` / `watcher::debounce` files are pure-function logic and run identically on Linux / macOS / Windows. The actual `notify::RecommendedWatcher` integration (Task 7) is where platform quirks surface (macOS FSEvents coalescing, Linux inotify single-event-per-file, Windows ReadDirectoryChangesW); a `cli/tests/notify_quirk.rs` test is planned for Task 10 to pin those.
+- **Concurrent + merge paths in `run_one` are not unit-tested.** The dispatch logic for `SyncOutcome::ConcurrentDetected` (silent-merge fast path + merge-and-commit) is exercised only by `core/tests/sync_merge*.rs` tests against the lower-level functions, not against `run_one` itself. Task 10's two-instance convergence test will close that gap end-to-end through two `secretary-sync` processes.
+- **`pipeline_integration.rs` password extraction uses string-scan.** The `golden_vault_001_inputs.json` schema is stable, and the test reads only the `password` key — but a future change to that JSON's shape (e.g. nesting password under `unlock.password`) would silently fail the `find("\"password\":")` lookup. Mitigation: the JSON schema is single-sourced in `core/tests/fixtures/mod.rs::Inputs`; a structural change there would change all callers in lockstep.
+
+### Issues currently open
+
+- #37 — Sub-project C umbrella. C.2 Tasks 1-4 ✅ in PRs #112, #114, #115, #116; Task 5 pending PR.
+- ~~#113~~ — **Closed by this commit.** All `cli/` `#[allow(dead_code)]` markers lifted; cli crate compiles `-D warnings` with zero allowances.
+- #117 — `TtyVetoUx` re-prompt loop has no max-attempts cap. Low-priority defensive-coding fix; still queued, not in scope for Task 6.
+- #38, #45, #75, #76, #78, #79, #81, #87, #88, #90, #95, #98 — none block C.2 Task 6.
+
+### Housekeeping note (stale worktrees on disk)
+
+After this PR:
+- `/Users/hherb/src/secretary` — `main` (clean post-merge).
+- `/Users/hherb/src/secretary/.worktrees/c1-1b-sync-merge` — branch `feature/c1-1b-task-17`, remote gone. Safe to remove.
+- `/Users/hherb/src/secretary/.worktrees/c2-task-1-spec` — branch `feature/c2-task-1-spec`, remote gone. Safe to remove.
+- `/Users/hherb/src/secretary/.worktrees/c2-task-1` — branch `feature/c2-task-1`, remote gone. Safe to remove.
+- `/Users/hherb/src/secretary/.worktrees/c2-task-2` — branch `feature/c2-task-2`, remote gone. Safe to remove.
+- `/Users/hherb/src/secretary/.worktrees/c2-task-3` — branch `feature/c2-task-3`, remote gone. Safe to remove.
+- `/Users/hherb/src/secretary/.worktrees/c2-task-4` — branch `feature/c2-task-4`, remote gone. Safe to remove.
+- `/Users/hherb/src/secretary/.worktrees/c2-task-5` — **this session's work**; keep until PR merges, then remove.
+
+```bash
+# One-line each (run from /Users/hherb/src/secretary):
+git worktree remove .worktrees/c1-1b-sync-merge && git branch -D feature/c1-1b-task-17
+git worktree remove .worktrees/c2-task-1-spec   && git branch -D feature/c2-task-1-spec
+git worktree remove .worktrees/c2-task-1        && git branch -D feature/c2-task-1
+git worktree remove .worktrees/c2-task-2        && git branch -D feature/c2-task-2
+git worktree remove .worktrees/c2-task-3        && git branch -D feature/c2-task-3
+git worktree remove .worktrees/c2-task-4        && git branch -D feature/c2-task-4
+```
+
+Cleanup is one-line each and does NOT block Task 6.
+
+## (4) Exact commands to resume
+
+```bash
+# After this C.2 Task 5 PR (feature/c2-task-5) merges:
+cd /Users/hherb/src/secretary
+git fetch --prune origin
+git status --short                       # expect: clean (modulo NEXT_SESSION.md sync, see below)
+git checkout main
+git pull --ff-only origin main
+
+# Verify gauntlet on fresh main (expect 868 / 0 / 10 — same as session close):
+cargo test --release --workspace --no-fail-fast 2>&1 | grep -E "^test result:" | awk '{passed+=$4; failed+=$6; ignored+=$8} END {print "PASSED:", passed, "FAILED:", failed, "IGNORED:", ignored}'
+cargo clippy --release --workspace --tests -- -D warnings 2>&1 | tail -3
+cargo fmt --all -- --check
+uv run core/tests/python/conformance.py 2>&1 | tail -3
+uv run core/tests/python/spec_test_name_freshness.py 2>&1 | tail -3
+
+# Start Task 6:
+git worktree add .worktrees/c2-task-6 -b feature/c2-task-6 main
+cd .worktrees/c2-task-6
+
+# Open the plan and follow Task 6 line-by-line:
+#   docs/superpowers/plans/2026-05-23-c2-headless-sync-cli.md §"Task 6"
+# Task 6 is three new pure-function files under cli/src/watcher/ —
+# ready (partial-download pattern matcher + size stability probe),
+# debounce (state machine), and mod (WatcherEvent enum + driver
+# trait). All three stay well under the 500-LOC threshold; the actual
+# notify::RecommendedWatcher integration lands in Task 7.
+```
+
+## Closing inventory
+
+- **Branch state on close:** `main` at `cedd04c` (PR #116 squash-merged). `feature/c2-task-5` carries 1 commit on top (Task 5 code + tests + cleanup).
+- **Workspace tests on `feature/c2-task-5`:** 868 passed + 10 ignored (850 base + 18 new cli tests: 9 in `pipeline::tests` + 5 in `args::tests::validate_*` + 4 in `cli/tests/pipeline_integration.rs`). Clippy + fmt + Python conformance + spec freshness all clean.
+- **README.md:** unchanged this session — Task 5 ships internal scaffolding + lib/bin split; no user-visible behavior. Plan defers README update to Task 10.
+- **ROADMAP.md:** unchanged this session — same reason; ROADMAP already calls C.2 "queued" since the C.2 design PR.
+- **CLAUDE.md:** unchanged this session — no new convention; pipeline + lib/bin split are local to `cli/` and don't generalise to repo-wide guidance.
+- **NEXT_SESSION.md:** symlink retargeted to this file.
+- **Open issues:** see §(3) — #113 closes with this PR; none block Task 6.
+- **Open PRs:** one to be opened at end of this session (C.2 Task 5).
+- **Worktrees on disk:** see §(3) housekeeping.
+- **Frozen baton snapshots:** all 22 prior C.1.1b + C.2-design + C.2-task-1/2/3/4 handoffs at [`docs/handoffs/`](.) — preserved unchanged.
+- **This file:** the live baton for C.2 Task 5 close.


### PR DESCRIPTION
## Summary

- `cli/src/pipeline.rs`: `run_one(folder, &UnlockedIdentity, &SecretBytes, &mut SyncState, &mut dyn VetoUx, now_ms) -> Result<RunOutcome, SyncError>` — composes `sync_once → prepare_merge → veto UX → commit_with_decisions` behind one entry point that both `once` (Task 9) and `run` (Task 7) subcommands will consume. State mutation is in-place per the documented contract (NothingToDo + RollbackRejected leave it untouched; AppliedAutomatically + SilentMerge + MergedAndCommitted advance it). Five-variant `RunOutcome` enum distinguishes the diff-plan-empty SilentMerge fast path from real merges.
- `cli/src/lib.rs` + `Cargo.toml` `[lib]` target: promote cli to library + binary so integration tests reach the orchestration modules via `secretary_cli::*` without spawning the binary.
- Args-layer `--non-interactive ↔ --password-stdin` validation (`ArgsValidationError::NonInteractiveWithoutStdin` + `CommonArgs::validate()`) so the failure surfaces before any unlock attempt.
- Closes #113: every `#[allow(dead_code)]` TODO marker in `cli/src/` is lifted. The cli crate now compiles `-D warnings` with zero allowances.

## Test plan

- [x] `cargo test --release --workspace --no-fail-fast` — workspace **868 / 0 / 10** (was 850; +18 = 9 pipeline unit + 5 args validation + 4 integration).
- [x] `cargo clippy --release --workspace --tests -- -D warnings` — clean.
- [x] `cargo fmt --all -- --check` — clean.
- [x] `uv run core/tests/python/conformance.py` — PASS.
- [x] `uv run core/tests/python/spec_test_name_freshness.py` — PASS (96 resolved / 0 unresolved / 2 suppressed).

## Notes

- Plan's literal integration-test code referenced three filenames / accessors that don't exist (`golden_vault_001_password` file; `identity.bundle.cbor`; `unlocked.vault.vault_uuid`). Resolved as documented in the commit body — read the password out of `golden_vault_001_inputs.json`, use the actual `identity.bundle.enc` filename, recover `vault_uuid` via re-decoding `vault.toml`.
- `MergedAndCommitted` + `SilentMerge` integration coverage is deferred to Task 10's two-instance convergence tests; the merge-arm correctness is already pinned by core's `sync_merge*` integration tests + proptests, and reproducing the `sync_helpers` machinery cross-crate would just duplicate that work.
- README + ROADMAP unchanged this session — Task 5 ships internal scaffolding; user-visible C.2 row updates land at Task 10 per the plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)