### PR TITLE
C.2 Task 6 — watcher submodule: ready + debounce

### DIFF
--- a/NEXT_SESSION.md
+++ b/NEXT_SESSION.md
@@ -1,1 +1,1 @@
-docs/handoffs/2026-05-25-c2-task-5-pipeline-shipped.md
+docs/handoffs/2026-05-25-c2-task-6-watcher-ready-debounce-shipped.md

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -14,3 +14,4 @@ pub mod pipeline;
 pub mod state;
 pub mod unlock;
 pub mod veto;
+pub mod watcher;

--- a/cli/src/watcher/debounce.rs
+++ b/cli/src/watcher/debounce.rs
@@ -1,0 +1,161 @@
+//! Debounce state machine — collapses a burst of `notify` events into
+//! a single `SyncCandidate` per `--debounce-ms` window.
+//!
+//! Spec: [`docs/superpowers/specs/2026-05-23-c2-headless-sync-cli-design.md`](../../../docs/superpowers/specs/2026-05-23-c2-headless-sync-cli-design.md)
+//! §D3 (events + debounce + optional poll).
+//!
+//! **Pure** — [`step`] takes `(now, pending_since, window)` and returns
+//! a `(decision, new_pending_since)` tuple. The daemon loop owns the
+//! actual [`Instant`] and translates `decision` into either:
+//!
+//! - arming/extending a `recv_timeout` deadline (on
+//!   [`DebounceDecision::Schedule`] / [`DebounceDecision::Reschedule`]),
+//!   or
+//! - emitting [`super::WatcherEvent::SyncCandidate`] when the deadline
+//!   fires.
+//!
+//! Semantics: **trailing-edge** debounce. Each new event extends the
+//! window — the sync attempt fires after the operator has been quiet
+//! for one full window. Mirrors the user-facing expectation that the
+//! daemon waits for the burst to end before reacting (matches
+//! `notify`'s recommended pattern + `--debounce-ms` flag intent).
+
+use std::time::{Duration, Instant};
+
+/// Decision returned by [`step`] for the current event.
+///
+/// Both variants carry the **same** `delay` (= `window`); the driver
+/// uses the variant to log/telemeter "scheduled fresh" vs "extended
+/// due to burst" while applying the deadline identically.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DebounceDecision {
+    /// No pending schedule existed (or the previous one had already
+    /// elapsed) — start a new debounce window from `now`. Driver
+    /// arms a deadline `delay` from now.
+    Schedule {
+        /// How long until the schedule fires.
+        delay: Duration,
+    },
+    /// A pending schedule was still in-window — reset its deadline
+    /// to `delay` from `now`. Driver replaces the existing deadline.
+    Reschedule {
+        /// How long until the (now reset) schedule fires.
+        delay: Duration,
+    },
+}
+
+/// Pure debounce step.
+///
+/// Inputs:
+/// - `now` — the wall-clock instant at which the event arrived.
+/// - `pending_since` — `Some(t)` if a previous event set a debounce
+///   timer at `t`; `None` if no timer is currently armed.
+/// - `window` — the debounce window (typically `--debounce-ms`).
+///
+/// Returns `(decision, new_pending_since)`:
+/// - `decision` tells the driver what to do (schedule / reschedule);
+/// - `new_pending_since = Some(now)` — the caller stores this so the
+///   next call sees the latest reset point.
+///
+/// The function is **pure**: same inputs → same outputs, no I/O, no
+/// global state. The driver loop's responsibility is to drive the
+/// `Instant`s and apply the decision.
+#[must_use]
+pub fn step(
+    now: Instant,
+    pending_since: Option<Instant>,
+    window: Duration,
+) -> (DebounceDecision, Option<Instant>) {
+    let decision = match pending_since {
+        // No pending timer — fresh schedule.
+        None => DebounceDecision::Schedule { delay: window },
+        // Previous timer is conceptually expired (deadline has passed
+        // before this event arrived) — treat as a fresh schedule.
+        // Boundary semantics: `>=` (equal-to-window counts as expired).
+        Some(prev) if now.duration_since(prev) >= window => {
+            DebounceDecision::Schedule { delay: window }
+        }
+        // Previous timer is still in-window — reset the deadline.
+        Some(_) => DebounceDecision::Reschedule { delay: window },
+    };
+    (decision, Some(now))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Debounce window used across this module's tests. One named
+    /// constant keeps each test focused on the timing scenario rather
+    /// than the duration literal (avoids "magic-numbers" drift).
+    const WINDOW: Duration = Duration::from_millis(500);
+
+    /// In-window event arrival — well below `WINDOW` so the reschedule
+    /// path is unambiguously exercised.
+    const WITHIN_WINDOW: Duration = Duration::from_millis(100);
+
+    /// Past-window event arrival — well above `WINDOW` so the fresh-
+    /// schedule path is unambiguously exercised.
+    const PAST_WINDOW: Duration = Duration::from_millis(600);
+
+    #[test]
+    fn first_event_schedules_fresh() {
+        let now = Instant::now();
+        let (decision, pending) = step(now, None, WINDOW);
+        assert_eq!(decision, DebounceDecision::Schedule { delay: WINDOW });
+        assert_eq!(pending, Some(now));
+    }
+
+    #[test]
+    fn second_event_within_window_reschedules() {
+        let t0 = Instant::now();
+        let t1 = t0 + WITHIN_WINDOW;
+        let (decision, pending) = step(t1, Some(t0), WINDOW);
+        assert_eq!(decision, DebounceDecision::Reschedule { delay: WINDOW });
+        assert_eq!(pending, Some(t1));
+    }
+
+    #[test]
+    fn event_after_window_schedules_fresh() {
+        // Previous timer logically expired (PAST_WINDOW > WINDOW) —
+        // covers both the "post-deadline-emit" boundary and the
+        // "reset-on-new-event-after-emit" acceptance criterion.
+        let t0 = Instant::now();
+        let t1 = t0 + PAST_WINDOW;
+        let (decision, pending) = step(t1, Some(t0), WINDOW);
+        assert_eq!(decision, DebounceDecision::Schedule { delay: WINDOW });
+        assert_eq!(pending, Some(t1));
+    }
+
+    #[test]
+    fn equal_to_window_treated_as_after() {
+        // Boundary: `duration_since(prev) == window` returns Schedule
+        // (not Reschedule). Pins the `>=` predicate against drift.
+        let t0 = Instant::now();
+        let t1 = t0 + WINDOW;
+        let (decision, pending) = step(t1, Some(t0), WINDOW);
+        assert_eq!(decision, DebounceDecision::Schedule { delay: WINDOW });
+        assert_eq!(pending, Some(t1));
+    }
+
+    #[test]
+    fn burst_of_three_events_collapses_into_single_reschedule_chain() {
+        // First event arms; second + third (each WITHIN_WINDOW after
+        // the previous) extend the window. Pins burst-collapse — three
+        // events do NOT produce two separate sync attempts.
+        let t0 = Instant::now();
+        let (d0, p0) = step(t0, None, WINDOW);
+        assert_eq!(d0, DebounceDecision::Schedule { delay: WINDOW });
+
+        let t1 = t0 + WITHIN_WINDOW;
+        let (d1, p1) = step(t1, p0, WINDOW);
+        assert_eq!(d1, DebounceDecision::Reschedule { delay: WINDOW });
+
+        let t2 = t1 + WITHIN_WINDOW;
+        let (d2, p2) = step(t2, p1, WINDOW);
+        assert_eq!(d2, DebounceDecision::Reschedule { delay: WINDOW });
+
+        // The final `pending_since` is the latest event time (t2).
+        assert_eq!(p2, Some(t2));
+    }
+}

--- a/cli/src/watcher/mod.rs
+++ b/cli/src/watcher/mod.rs
@@ -27,7 +27,7 @@ pub mod ready;
 /// driver tick. The driver is responsible for collapsing
 /// `notify::Event` bursts into at most one [`Self::SyncCandidate`] per
 /// debounce window (see [`debounce::step`]).
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum WatcherEvent {
     /// One or more files in the vault folder changed; the daemon
     /// should attempt a sync after the debounce window expires.
@@ -55,9 +55,12 @@ mod tests {
     }
 
     #[test]
-    fn watcher_event_clone_round_trip() {
+    fn watcher_event_copy_round_trip() {
+        // Pin the `Copy` derive — Task 7's daemon loop passes these by
+        // value across debounce/poll/shutdown branches; losing `Copy`
+        // would force `.clone()` calls at every match arm.
         let original = WatcherEvent::SyncCandidate;
-        let copied = original.clone();
+        let copied = original;
         assert_eq!(original, copied);
     }
 

--- a/cli/src/watcher/mod.rs
+++ b/cli/src/watcher/mod.rs
@@ -1,0 +1,72 @@
+//! File-watcher abstractions for the `run` subcommand.
+//!
+//! Spec: [`docs/superpowers/specs/2026-05-23-c2-headless-sync-cli-design.md`](../../../docs/superpowers/specs/2026-05-23-c2-headless-sync-cli-design.md)
+//! §D3 (events + debounce + optional poll) + §D6 (partial-download).
+//!
+//! This task ships the **pure-function pieces only**:
+//!
+//! - [`ready`] — partial-download filename filter + size-stability
+//!   probe + a [`ready::Clock`]-parameterised orchestrator. No `notify`
+//!   integration; pattern matching and metadata comparison run
+//!   identically on Linux / macOS / Windows.
+//! - [`debounce`] — pure state machine that collapses an event burst
+//!   into one scheduled `SyncCandidate` per `--debounce-ms` window.
+//!
+//! The [`notify::RecommendedWatcher`](https://docs.rs/notify) integration
+//! that produces the actual event stream lives in
+//! `cli/src/watcher/notify_driver.rs` (Task 7) and consumes both pure
+//! pieces through a [`WatcherEvent`]-emitting driver.
+
+pub mod debounce;
+pub mod ready;
+
+/// What the watcher dispatcher tells the [`crate::pipeline::run_one`]
+/// caller (the daemon loop) to do next.
+///
+/// Variants are mutually exclusive — exactly one is delivered per
+/// driver tick. The driver is responsible for collapsing
+/// `notify::Event` bursts into at most one [`Self::SyncCandidate`] per
+/// debounce window (see [`debounce::step`]).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum WatcherEvent {
+    /// One or more files in the vault folder changed; the daemon
+    /// should attempt a sync after the debounce window expires.
+    SyncCandidate,
+    /// Periodic poll-tick fired. Used when the operator passes
+    /// `--poll-ms` (off by default) to defend against notify backends
+    /// that miss events under load (e.g. macOS FSEvents coalescing,
+    /// Linux inotify queue overflow).
+    PollTick,
+    /// Operator requested shutdown (SIGINT or SIGTERM). The daemon
+    /// loop should finish any in-flight sync attempt cleanly, then
+    /// exit.
+    ShutdownRequested,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn watcher_event_variants_are_distinct() {
+        assert_ne!(WatcherEvent::SyncCandidate, WatcherEvent::PollTick);
+        assert_ne!(WatcherEvent::SyncCandidate, WatcherEvent::ShutdownRequested);
+        assert_ne!(WatcherEvent::PollTick, WatcherEvent::ShutdownRequested);
+    }
+
+    #[test]
+    fn watcher_event_clone_round_trip() {
+        let original = WatcherEvent::SyncCandidate;
+        let copied = original.clone();
+        assert_eq!(original, copied);
+    }
+
+    #[test]
+    fn watcher_event_debug_is_non_empty() {
+        // Pin a Debug shape so operators see informative log lines (the
+        // daemon loop in Task 7 will log `?event` on every tick).
+        assert!(!format!("{:?}", WatcherEvent::SyncCandidate).is_empty());
+        assert!(!format!("{:?}", WatcherEvent::PollTick).is_empty());
+        assert!(!format!("{:?}", WatcherEvent::ShutdownRequested).is_empty());
+    }
+}

--- a/cli/src/watcher/ready.rs
+++ b/cli/src/watcher/ready.rs
@@ -44,6 +44,12 @@ const PARTIAL_SUFFIXES: &[&str] = &[
 /// `.~lock.foo.odt#`) and Dropbox dot-prefixed temp files (e.g.
 /// `.~dropbox-abc.tmp`). `~$` catches Microsoft Office lockfiles
 /// (e.g. `~$report.docx`). Both come from spec §D6.
+///
+/// **Case-folding intentionally omitted.** Every entry is pure
+/// punctuation, so `starts_with` matches identically on any platform's
+/// case-folding rules. A future letter-bearing entry would need the
+/// same `to_ascii_lowercase` treatment that `PARTIAL_SUFFIXES` uses;
+/// the case-insensitive `PARTIAL_BASENAMES` check is a third path.
 const PARTIAL_PREFIXES: &[&str] = &[".~", "~$"];
 
 /// Whole-basename markers for OS filesystem-metadata droppings that
@@ -118,7 +124,15 @@ impl Clock for RealClock {
     }
 }
 
-/// Wait up to `window` for `path` to become size-stable.
+/// Probe `path` for size-stability across a single `window`-length
+/// sleep.
+///
+/// Performs **one** `stat()`, sleeps for exactly `window` via
+/// [`Clock::sleep`], then performs a **second** `stat()` and compares.
+/// This is a single probe, **not** a retry loop: a still-changing file
+/// yields `Ok(false)` on the first miss. The driver (Task 7's daemon
+/// loop) provides the retry by re-firing this function on the next
+/// debounce tick — see [`super::debounce::step`].
 ///
 /// Returns:
 /// - `Ok(true)` if the path does NOT match a partial-marker pattern
@@ -176,6 +190,11 @@ mod tests {
     fn icloud_partial_marker_caught() {
         assert!(matches_partial_pattern(&p("foo.icloud")));
         assert!(matches_partial_pattern(&p("dir/sub/bar.icloud")));
+        // Case-insensitive suffix match — pins the `to_ascii_lowercase`
+        // branch against drift (analogous to dotted_metadata_caught's
+        // DESKTOP.INI coverage of the basename branch).
+        assert!(matches_partial_pattern(&p("Photo.ICLOUD")));
+        assert!(matches_partial_pattern(&p("Photo.iCloud")));
     }
 
     #[test]
@@ -315,6 +334,36 @@ mod tests {
         let missing = dir.path().join("not-there");
         let clock = InstantClock;
         let result = wait_for_ready(&missing, &clock, Duration::ZERO);
+        assert!(result.is_err(), "expected ENOENT, got {result:?}");
+    }
+
+    /// Clock impl that deletes the file at the recorded path the
+    /// instant `sleep` fires — used to exercise the second-`stat()`
+    /// failure branch of [`wait_for_ready`].
+    struct DeleteOnSleep {
+        path: PathBuf,
+    }
+    impl Clock for DeleteOnSleep {
+        fn sleep(&self, _: Duration) {
+            // Ignore the error — if the file is already gone the test
+            // assertion below still pins the second-stat failure.
+            let _ = std::fs::remove_file(&self.path);
+        }
+    }
+
+    #[test]
+    fn wait_for_ready_errors_when_file_disappears_between_stats() {
+        // Pin the second-`stat()` failure path: first stat succeeds
+        // (file present, non-empty), DeleteOnSleep removes the file
+        // during the sleep window, second stat returns ENOENT which
+        // wait_for_ready propagates as io::Error.
+        let dir = tempfile::tempdir().expect("temp dir");
+        let target = dir.path().join("disappearing");
+        std::fs::write(&target, b"non-empty").expect("write");
+        let clock = DeleteOnSleep {
+            path: target.clone(),
+        };
+        let result = wait_for_ready(&target, &clock, Duration::ZERO);
         assert!(result.is_err(), "expected ENOENT, got {result:?}");
     }
 }

--- a/cli/src/watcher/ready.rs
+++ b/cli/src/watcher/ready.rs
@@ -1,0 +1,320 @@
+//! Partial-download readiness — ADR-0003 §"Cloud-folder integration".
+//!
+//! Spec: [`docs/superpowers/specs/2026-05-23-c2-headless-sync-cli-design.md`](../../../docs/superpowers/specs/2026-05-23-c2-headless-sync-cli-design.md)
+//! §D6 — the canonical pattern table lives in the spec; this module
+//! implements that table plus the size-stability probe.
+//!
+//! Design split:
+//!
+//! - [`matches_partial_pattern`] — pure string matcher over the
+//!   path's basename. Table-tested.
+//! - [`is_size_stable`] — pure `(Metadata, Metadata)` comparison.
+//!   Table-tested via real `tempfile` reads.
+//! - [`wait_for_ready`] — the thin I/O orchestrator that does two
+//!   `stat()` reads with a [`Clock::sleep`] in between, then composes
+//!   the two pure predicates above.
+//!
+//! Only [`wait_for_ready`] performs I/O; the inner predicates are
+//! invariant under platform.
+
+use std::fs::Metadata;
+use std::path::Path;
+use std::time::Duration;
+
+/// Suffix patterns that mark a file as not-yet-fully-downloaded.
+///
+/// Sourced from spec §D6 (canonical pattern table). Comparison is
+/// case-insensitive via [`str::to_ascii_lowercase`] in
+/// [`matches_partial_pattern`]; the entries here are pre-lowercased.
+/// Order is recognition-priority only and not semantically significant
+/// — any match wins.
+const PARTIAL_SUFFIXES: &[&str] = &[
+    ".icloud",     // iCloud Drive placeholder for not-yet-downloaded
+    ".tmp",        // generic temp suffix (rsync, rclone, many editors)
+    ".partial",    // generic partial-download suffix
+    ".crdownload", // Chromium-family in-progress download
+    ".download",   // Safari / Firefox-family in-progress download
+    ".swp",        // vim swap file (primary)
+    ".swo",        // vim swap file (secondary)
+];
+
+/// Basename prefixes that mark lock or transient files.
+///
+/// `.~` catches LibreOffice / OpenOffice lockfiles (e.g.
+/// `.~lock.foo.odt#`) and Dropbox dot-prefixed temp files (e.g.
+/// `.~dropbox-abc.tmp`). `~$` catches Microsoft Office lockfiles
+/// (e.g. `~$report.docx`). Both come from spec §D6.
+const PARTIAL_PREFIXES: &[&str] = &[".~", "~$"];
+
+/// Whole-basename markers for OS filesystem-metadata droppings that
+/// must never be treated as vault content.
+///
+/// Comparison is case-insensitive — Windows is case-preserving but
+/// case-insensitive at lookup time, and macOS volumes can be either.
+const PARTIAL_BASENAMES: &[&str] = &["desktop.ini", ".DS_Store"];
+
+/// True if the path's basename matches any known partial-download or
+/// lock-file pattern per spec §D6.
+///
+/// Pure function — table-tested via the in-module `tests` mod.
+///
+/// Returns `false` if the path has no basename (e.g. `/` or `..`),
+/// has a non-UTF-8 basename (extremely unusual on macOS/Linux; the
+/// daemon's path stream is already `String`-typed by `notify`), or
+/// does not match any of the three pattern axes.
+#[must_use]
+pub fn matches_partial_pattern(path: &Path) -> bool {
+    let Some(basename) = path.file_name().and_then(|os| os.to_str()) else {
+        return false;
+    };
+    if PARTIAL_BASENAMES
+        .iter()
+        .any(|b| basename.eq_ignore_ascii_case(b))
+    {
+        return true;
+    }
+    if PARTIAL_PREFIXES.iter().any(|p| basename.starts_with(p)) {
+        return true;
+    }
+    let lowered = basename.to_ascii_lowercase();
+    PARTIAL_SUFFIXES.iter().any(|s| lowered.ends_with(s))
+}
+
+/// True iff two [`Metadata`] snapshots indicate the file is the same
+/// size AND has the same modification timestamp.
+///
+/// Pure comparison. If either snapshot's `modified()` fails (very
+/// unusual on Linux / macOS / Windows where the platform always
+/// reports mtime), conservatively returns `false` — the caller's next
+/// retry will probe again.
+#[must_use]
+pub fn is_size_stable(a: &Metadata, b: &Metadata) -> bool {
+    if a.len() != b.len() {
+        return false;
+    }
+    let (Ok(ma), Ok(mb)) = (a.modified(), b.modified()) else {
+        return false;
+    };
+    ma == mb
+}
+
+/// Sleep abstraction used by [`wait_for_ready`].
+///
+/// Production wires [`RealClock`] (delegating to
+/// [`std::thread::sleep`]); tests wire an instant impl to avoid
+/// adding real wall-clock latency to the test suite.
+pub trait Clock {
+    /// Block the current thread for `dur`.
+    fn sleep(&self, dur: Duration);
+}
+
+/// Real-time clock used by the production daemon loop. Delegates to
+/// [`std::thread::sleep`].
+pub struct RealClock;
+
+impl Clock for RealClock {
+    fn sleep(&self, dur: Duration) {
+        std::thread::sleep(dur);
+    }
+}
+
+/// Wait up to `window` for `path` to become size-stable.
+///
+/// Returns:
+/// - `Ok(true)` if the path does NOT match a partial-marker pattern
+///   AND the two metadata reads (`window` apart) report identical
+///   size + mtime AND the size is non-zero.
+/// - `Ok(false)` if the path matches a partial-marker pattern OR the
+///   file is zero-bytes OR the size/mtime changed during the probe.
+/// - `Err(io::Error)` if either `stat()` call fails (missing file,
+///   permission denied, etc.). Caller (daemon loop) logs + skips.
+///
+/// Pure-function-decomposable per spec §D6: the inner predicates
+/// ([`matches_partial_pattern`] + [`is_size_stable`]) are pure and
+/// table-tested; only this orchestrator does I/O.
+pub fn wait_for_ready<C: Clock>(path: &Path, clock: &C, window: Duration) -> std::io::Result<bool> {
+    if matches_partial_pattern(path) {
+        return Ok(false);
+    }
+    let first = std::fs::metadata(path)?;
+    if first.len() == 0 {
+        return Ok(false);
+    }
+    clock.sleep(window);
+    let second = std::fs::metadata(path)?;
+    Ok(is_size_stable(&first, &second))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+    use std::path::PathBuf;
+
+    /// Smallest sleep granularity reliably observable across mtime
+    /// resolutions on macOS APFS / Linux ext4 (both nanosecond), and
+    /// FAT/exFAT (~1–2 s). The `size_unstable_after_write` test must
+    /// straddle whichever resolution is in play; 50 ms is well below
+    /// 1 s but above the high-res floor.
+    const MTIME_GAP: Duration = Duration::from_millis(50);
+
+    /// `Clock` impl used in tests — never actually sleeps. Avoids
+    /// adding real wall-clock latency to the suite (the predicate
+    /// behaviour, not the sleep duration, is under test).
+    struct InstantClock;
+    impl Clock for InstantClock {
+        fn sleep(&self, _: Duration) {}
+    }
+
+    fn p(s: &str) -> PathBuf {
+        PathBuf::from(s)
+    }
+
+    // ---------- matches_partial_pattern: positive cases (one per spec §D6 row) ----------
+
+    #[test]
+    fn icloud_partial_marker_caught() {
+        assert!(matches_partial_pattern(&p("foo.icloud")));
+        assert!(matches_partial_pattern(&p("dir/sub/bar.icloud")));
+    }
+
+    #[test]
+    fn tmp_partial_marker_caught() {
+        assert!(matches_partial_pattern(&p("write.tmp")));
+        assert!(matches_partial_pattern(&p("a.b.tmp")));
+    }
+
+    #[test]
+    fn partial_suffix_caught() {
+        assert!(matches_partial_pattern(&p("download.partial")));
+    }
+
+    #[test]
+    fn crdownload_suffix_caught() {
+        assert!(matches_partial_pattern(&p("foo.crdownload")));
+    }
+
+    #[test]
+    fn download_suffix_caught() {
+        // Safari / Firefox in-progress download — spec §D6.
+        assert!(matches_partial_pattern(&p("install.download")));
+    }
+
+    #[test]
+    fn dropbox_transient_caught() {
+        // Dropbox `.~foo.tmp` matches BOTH the `.~` prefix branch
+        // AND the `.tmp` suffix branch — pin both routes.
+        assert!(matches_partial_pattern(&p(".~dropbox-abc.tmp")));
+    }
+
+    #[test]
+    fn libreoffice_lockfile_caught() {
+        assert!(matches_partial_pattern(&p(".~lock.foo.odt#")));
+    }
+
+    #[test]
+    fn ms_office_lockfile_caught() {
+        assert!(matches_partial_pattern(&p("~$report.docx")));
+    }
+
+    #[test]
+    fn vim_swap_caught() {
+        assert!(matches_partial_pattern(&p("foo.swp")));
+        assert!(matches_partial_pattern(&p("foo.swo")));
+    }
+
+    #[test]
+    fn dotted_metadata_caught() {
+        assert!(matches_partial_pattern(&p(".DS_Store")));
+        assert!(matches_partial_pattern(&p("desktop.ini")));
+        // Case-insensitive — Windows case-folds, and macOS case-folded
+        // volumes lookup either way.
+        assert!(matches_partial_pattern(&p("DESKTOP.INI")));
+    }
+
+    // ---------- matches_partial_pattern: negative cases (vault content) ----------
+
+    #[test]
+    fn vault_files_not_caught() {
+        // None of the real vault filenames may be filtered as partial.
+        assert!(!matches_partial_pattern(&p("manifest.cbor.enc")));
+        assert!(!matches_partial_pattern(&p(
+            "block_01234567890123456789012345678901.cbor.enc"
+        )));
+        assert!(!matches_partial_pattern(&p("vault.toml")));
+        assert!(!matches_partial_pattern(&p("identity.bundle.enc")));
+    }
+
+    #[test]
+    fn empty_path_not_caught() {
+        // Path with no basename (root) — function returns false rather
+        // than panicking.
+        assert!(!matches_partial_pattern(&p("/")));
+    }
+
+    // ---------- is_size_stable: stable + unstable cases ----------
+
+    #[test]
+    fn size_stable_when_no_writes_between_reads() {
+        let mut f = tempfile::NamedTempFile::new().expect("temp file");
+        writeln!(f, "stable").expect("write");
+        let m1 = std::fs::metadata(f.path()).expect("metadata 1");
+        let m2 = std::fs::metadata(f.path()).expect("metadata 2");
+        assert!(is_size_stable(&m1, &m2));
+    }
+
+    #[test]
+    fn size_unstable_after_write() {
+        let mut f = tempfile::NamedTempFile::new().expect("temp file");
+        writeln!(f, "first").expect("write 1");
+        let m1 = std::fs::metadata(f.path()).expect("metadata 1");
+        // Sleep MTIME_GAP so mtime advances on coarse-resolution
+        // filesystems; the size will also have changed, which is the
+        // primary failure axis we're pinning.
+        std::thread::sleep(MTIME_GAP);
+        writeln!(f, "second").expect("write 2");
+        let m2 = std::fs::metadata(f.path()).expect("metadata 2");
+        assert!(!is_size_stable(&m1, &m2));
+    }
+
+    // ---------- wait_for_ready: orchestrator branches ----------
+
+    #[test]
+    fn wait_for_ready_rejects_partial_marker() {
+        // Use a tempdir so the `.icloud` sidecar is cleaned up
+        // automatically (don't leak files into /tmp).
+        let dir = tempfile::tempdir().expect("temp dir");
+        let icloud_path = dir.path().join("payload.icloud");
+        std::fs::write(&icloud_path, b"x").expect("write");
+        let clock = InstantClock;
+        assert!(!wait_for_ready(&icloud_path, &clock, Duration::ZERO).expect("ready"));
+    }
+
+    #[test]
+    fn wait_for_ready_accepts_stable_file() {
+        let mut f = tempfile::NamedTempFile::new().expect("temp file");
+        writeln!(f, "stable data").expect("write");
+        let clock = InstantClock;
+        assert!(wait_for_ready(f.path(), &clock, Duration::ZERO).expect("ready"));
+    }
+
+    #[test]
+    fn wait_for_ready_rejects_empty_file() {
+        // NamedTempFile::new() creates a zero-byte file; the empty
+        // check fires before the size-stability probe.
+        let f = tempfile::NamedTempFile::new().expect("temp file");
+        let clock = InstantClock;
+        assert!(!wait_for_ready(f.path(), &clock, Duration::ZERO).expect("ready"));
+    }
+
+    #[test]
+    fn wait_for_ready_errors_on_missing_file() {
+        // Path inside a tempdir that we never write — first stat()
+        // returns ENOENT, propagated as io::Error.
+        let dir = tempfile::tempdir().expect("temp dir");
+        let missing = dir.path().join("not-there");
+        let clock = InstantClock;
+        let result = wait_for_ready(&missing, &clock, Duration::ZERO);
+        assert!(result.is_err(), "expected ENOENT, got {result:?}");
+    }
+}

--- a/docs/handoffs/2026-05-25-c2-task-6-watcher-ready-debounce-shipped.md
+++ b/docs/handoffs/2026-05-25-c2-task-6-watcher-ready-debounce-shipped.md
@@ -14,7 +14,7 @@ One commit on `feature/c2-task-6` carrying the sixth code slice of C.2 — the p
 | Debounce (pure state machine) | [`cli/src/watcher/debounce.rs`](../../cli/src/watcher/debounce.rs) | New (~135 LOC). `DebounceDecision` enum (`Schedule` / `Reschedule`); `step(now, pending_since, window) -> (decision, new_pending_since)` is the entire state machine. Trailing-edge semantics: each event in-window resets the deadline; the daemon loop fires `SyncCandidate` when the deadline expires uninterrupted. 5 unit tests cover first-event / within-window-burst / past-window-reset / equal-to-window-boundary / three-event-burst-collapse. |
 | Library surface wiring | [`cli/src/lib.rs`](../../cli/src/lib.rs) | One-line addition: `pub mod watcher;` next to the existing `args`, `exit`, `pipeline`, `state`, `unlock`, `veto` re-exports. Production consumers reach the watcher under `secretary_cli::watcher::*`. |
 
-**Commit:** `C.2 Task 6 — watcher submodule: partial-download ready + pure debounce` (see `git log feature/c2-task-6` for the local pre-merge SHA; the post-squash-merge SHA on `main` will differ). 26 new tests across watcher's three submodules (3 mod + 18 ready + 5 debounce); workspace 877 → 903. No issue closes with this commit; #37 (Sub-project C umbrella) advances by one more C.2 slice.
+**Commit:** `C.2 Task 6 — watcher submodule: partial-download ready + pure debounce` (see `git log feature/c2-task-6` for the local pre-merge SHA; the post-squash-merge SHA on `main` will differ). 27 new tests across watcher's three submodules (3 mod + 19 ready + 5 debounce); workspace 877 → 904. The 19th ready test (`wait_for_ready_errors_when_file_disappears_between_stats`) was added in the PR-review fixup pass to pin the second-`stat()` failure branch. No issue closes with this commit; #37 (Sub-project C umbrella) advances by one more C.2 slice; #120 is a follow-up filed during the same review (low-priority allocation cleanup in `matches_partial_pattern`).
 
 ### Plan ↔ reality reconciliations
 
@@ -25,19 +25,19 @@ Two deliberate deviations from the plan, each documented inline in code comments
 | Plan declared `DebounceDecision::AlreadyPending` as a third enum variant alongside `Schedule` + `Reschedule`. | The plan's `step` function never constructs `AlreadyPending` — every code path returns either `Schedule` (no pending / past window) or `Reschedule` (within window). The variant would be dead code on day one and trip `clippy -D warnings`. | Removed `AlreadyPending` from the enum. Documented the two-variant state machine as **trailing-edge debounce** in `debounce.rs`'s module doc. If a future driver wants a "cap-collapse drop" semantic (cap the total wait time at N windows instead of resetting indefinitely), it'd be a behavioural change requiring its own design — not a leftover variant. Aligns with [[feedback_act_on_issues_dont_mention]] (don't ship dead code) + the recently-closed #113 (cli crate compiles `-D warnings` with zero `#[allow(dead_code)]`). |
 | Plan code's `PARTIAL_PREFIXES` constant declared `[".~", "~$", "."]` but the function body only checked `.~` and `~$` explicitly — the `.` entry was unused. | A literal `.` prefix would also catch ordinary dotfiles (e.g., a contributor accidentally dropping a `.gitignore` into the vault folder would be silently filtered as "partial"). | Reduced the constant to `[".~", "~$"]` and iterated over it in the function body, so the constant is genuinely used (no dead-data warnings) and the semantics match what the spec §D6 table covers. `.DS_Store` is still caught by the `PARTIAL_BASENAMES` whole-name check. |
 
-The plan also estimated 17 new tests (12 ready + 4 debounce + 1 module sanity). Actual: **26 new tests** (3 mod sanity + 18 ready + 5 debounce). The extras came from one positive case per spec §D6 row (the plan compressed `.crdownload` and `.download` into one test; spec §D6 distinguishes Chromium vs Safari/Firefox so I split them), plus a dedicated test for the Dropbox `.~foo.tmp` route (which the plan claims is "caught by both `.~` and `.tmp`" — pinning that with an explicit test), plus a missing-file → `io::Error` test (required by the acceptance criteria's "missing-file branch" but absent from the plan code), plus a `burst_of_three_events_collapses_into_single_reschedule_chain` test (the plan's burst-collapse only had two events).
+The plan also estimated 17 new tests (12 ready + 4 debounce + 1 module sanity). Actual at first push: **26 new tests** (3 mod sanity + 18 ready + 5 debounce). The extras came from one positive case per spec §D6 row (the plan compressed `.crdownload` and `.download` into one test; spec §D6 distinguishes Chromium vs Safari/Firefox so I split them), plus a dedicated test for the Dropbox `.~foo.tmp` route (which the plan claims is "caught by both `.~` and `.tmp`" — pinning that with an explicit test), plus a missing-file → `io::Error` test (required by the acceptance criteria's "missing-file branch" but absent from the plan code), plus a `burst_of_three_events_collapses_into_single_reschedule_chain` test (the plan's burst-collapse only had two events). The PR-review fixup pass added a 19th `ready` test (`wait_for_ready_errors_when_file_disappears_between_stats`) and folded two case-insensitive `.ICLOUD` assertions into the existing `icloud_partial_marker_caught` row, bringing the total to **27 new tests** (3 + 19 + 5).
 
 ### Gauntlet snapshot at session close
 
 ```
-PASSED: 903 FAILED: 0 IGNORED: 10
+PASSED: 904 FAILED: 0 IGNORED: 10
 clippy --release --workspace --tests -- -D warnings   clean
 fmt --all -- --check                                  clean
 uv run core/tests/python/conformance.py               PASS
 uv run core/tests/python/spec_test_name_freshness.py  PASS (96 resolved / 0 unresolved / 2 suppressed)
 ```
 
-(Baseline drift note: the prior baton recorded 868 at Task 5 close. A clean-main checkout from `90334ce` actually shows 877 — the 9-test delta is likely from doctest binaries or `--no-fail-fast` aggregation that the baton's quick `awk` didn't fully account for. Task 6 itself adds exactly 26 new tests (3 + 18 + 5); the post-Task-6 total is 877 + 26 = 903, consistent with the gauntlet output. Future batons should treat 903 as the new baseline.)
+(Baseline drift note: the prior baton recorded 868 at Task 5 close. A clean-main checkout from `90334ce` actually shows 877 — the 9-test delta is likely from doctest binaries or `--no-fail-fast` aggregation that the baton's quick `awk` didn't fully account for. Task 6 itself adds 27 new tests (3 + 19 + 5); the post-Task-6 total is 877 + 27 = 904, consistent with the gauntlet output. Future batons should treat 904 as the new baseline.)
 
 ## (2) What's next — start C.2 Task 7
 
@@ -50,7 +50,7 @@ After this PR merges, the next slice is **C.2 Task 7: `notify` driver + daemon l
 - [ ] New `cli/src/lib.rs` line: `pub mod daemon;` (Task 5 established the `lib.rs` pattern; Task 6 added `watcher`; Task 7 adds `daemon`).
 - [ ] Hook the `run` subcommand's stub in `cli/src/main.rs` to `daemon::run`. (`once` subcommand still stubs through to Task 9's dispatch wiring; Task 7 is daemon-only.)
 - [ ] Unit tests for `notify_driver` cover the platform-event → `WatcherEvent` mapping (using `notify`'s synthetic event constructors); daemon-loop tests cover at least: one-event-end-to-end (synthetic mpsc event → `pipeline::run_one` invoked → state advanced) + shutdown-event-exits-cleanly + debounce-collapses-burst (two synthetic events within the window produce exactly one sync attempt).
-- [ ] Gauntlet target: **PASSED: 903 + N FAILED: 0 IGNORED: 10**. Absolute base is now 903 (bumped from 877 by Task 6's 26 new tests).
+- [ ] Gauntlet target: **PASSED: 904 + N FAILED: 0 IGNORED: 10**. Absolute base is now 904 (bumped from 877 by Task 6's 27 new tests).
 - [ ] Clippy, fmt, conformance, spec freshness all clean.
 
 ### Plan handoff
@@ -93,6 +93,7 @@ Full step-by-step in [`docs/superpowers/plans/2026-05-23-c2-headless-sync-cli.md
 
 - #37 — Sub-project C umbrella. C.2 Tasks 1-5 ✅ in PRs #112, #114, #115, #116, #118; Task 6 pending PR.
 - #117 — `TtyVetoUx` re-prompt loop has no max-attempts cap. Low-priority defensive-coding fix; still queued, not in scope for Task 7.
+- #120 — `matches_partial_pattern` allocates per call via `to_ascii_lowercase`. Filed during PR #119 review; performance-only, no correctness or security impact. Pick up if a profiler ever flags it; not in scope for Task 7.
 - #38, #45, #75, #76, #78, #79, #81, #87, #88, #90, #95, #98 — none block C.2 Task 7.
 
 ### Housekeeping note (stale worktrees on disk)
@@ -131,7 +132,7 @@ git status --short                       # expect: clean (modulo NEXT_SESSION.md
 git checkout main
 git pull --ff-only origin main
 
-# Verify gauntlet on fresh main (expect 903 / 0 / 10 — same as session close):
+# Verify gauntlet on fresh main (expect 904 / 0 / 10 — same as session close):
 cargo test --release --workspace --no-fail-fast 2>&1 | grep -E "^test result:" | awk '{passed+=$4; failed+=$6; ignored+=$8} END {print "PASSED:", passed, "FAILED:", failed, "IGNORED:", ignored}'
 cargo clippy --release --workspace --tests -- -D warnings 2>&1 | tail -3
 cargo fmt --all -- --check
@@ -153,8 +154,8 @@ cd .worktrees/c2-task-7
 
 ## Closing inventory
 
-- **Branch state on close:** `main` at `90334ce` (PR #118 squash-merged). `feature/c2-task-6` carries 1 commit on top (Task 6 code + tests + handoff + symlink).
-- **Workspace tests on `feature/c2-task-6`:** 903 passed + 10 ignored (877 base + 26 new watcher tests: 3 in `watcher::tests` + 18 in `watcher::ready::tests` + 5 in `watcher::debounce::tests`). Clippy + fmt + Python conformance + spec freshness all clean.
+- **Branch state on close:** `main` at `90334ce` (PR #118 squash-merged). `feature/c2-task-6` carries 2 commits on top (Task 6 code + tests + handoff + symlink, then a PR-review fixup that tightened a docstring, added `Copy` to `WatcherEvent`, documented `PARTIAL_PREFIXES` case-folding rationale, and added one ready-module test for the second-`stat()` failure path). Both fold into a single squash-merge at ship time.
+- **Workspace tests on `feature/c2-task-6`:** 904 passed + 10 ignored (877 base + 27 new watcher tests: 3 in `watcher::tests` + 19 in `watcher::ready::tests` + 5 in `watcher::debounce::tests`). Clippy + fmt + Python conformance + spec freshness all clean.
 - **README.md:** unchanged this session — Task 6 ships internal pure-function scaffolding (no operator-visible surface change). The C.2 status line in README still reads "queued"; promoting it to "in progress" is deferred until Task 9 wires the subcommands so `secretary-sync` actually runs.
 - **ROADMAP.md:** unchanged this session — same reason; ROADMAP already calls C.2 "queued" since the C.2 design PR.
 - **CLAUDE.md:** unchanged this session — no new convention; watcher submodule is local to `cli/` and doesn't generalise to repo-wide guidance.

--- a/docs/handoffs/2026-05-25-c2-task-6-watcher-ready-debounce-shipped.md
+++ b/docs/handoffs/2026-05-25-c2-task-6-watcher-ready-debounce-shipped.md
@@ -1,0 +1,166 @@
+# NEXT_SESSION.md — C.2 Task 6 (watcher submodule: ready + debounce) shipped
+
+**Session date:** 2026-05-25 (C.2 Task 6 — `cli/src/watcher/{mod,ready,debounce}.rs`: pure-function pieces of the watcher submodule. No `notify` integration in this slice — that lands in Task 7 alongside the daemon loop).
+**Status:** C.2 Task 6 ✅ on branch `feature/c2-task-6`; PR pending. Tasks 7-10 queued.
+
+## (1) What we shipped this session
+
+One commit on `feature/c2-task-6` carrying the sixth code slice of C.2 — the pure-function pieces of the file-watcher abstraction. Three new files under `cli/src/watcher/` plus the `pub mod watcher;` wiring in `cli/src/lib.rs`. No I/O orchestration beyond the thin [`wait_for_ready`] adapter (two `std::fs::metadata` reads with a [`Clock::sleep`] in between); no `notify::RecommendedWatcher` integration; no daemon loop. Those land in Task 7 once `notify` enters the pipeline.
+
+| Artifact | Path | Notes |
+|---|---|---|
+| Watcher module | [`cli/src/watcher/mod.rs`](../../cli/src/watcher/mod.rs) | New (~60 LOC). Public `WatcherEvent` enum with three variants (`SyncCandidate`, `PollTick`, `ShutdownRequested`). Module-level doc explains the "pure pieces ship first, `notify` driver lands in Task 7" split. 3 unit tests pin variant distinctness + Debug shape + Clone round-trip. |
+| Ready (partial-download + size-stability) | [`cli/src/watcher/ready.rs`](../../cli/src/watcher/ready.rs) | New (~290 LOC). Three pure-function constants (`PARTIAL_SUFFIXES`, `PARTIAL_PREFIXES`, `PARTIAL_BASENAMES`) implement spec §D6's canonical 10-row partial-marker table; `matches_partial_pattern` composes them. `is_size_stable` is a `(Metadata, Metadata)` predicate. `wait_for_ready<C: Clock>` is the thin I/O orchestrator; `Clock` trait + `RealClock` impl ship now so Task 7's `notify_driver` can wire production sleep without re-defining the abstraction. 18 unit tests cover one positive case per spec §D6 row + negative cases for vault filenames + size-stability `(stable, unstable)` + all four `wait_for_ready` branches (partial-marker reject / empty-file reject / stable-file accept / missing-file → `io::Error`). |
+| Debounce (pure state machine) | [`cli/src/watcher/debounce.rs`](../../cli/src/watcher/debounce.rs) | New (~135 LOC). `DebounceDecision` enum (`Schedule` / `Reschedule`); `step(now, pending_since, window) -> (decision, new_pending_since)` is the entire state machine. Trailing-edge semantics: each event in-window resets the deadline; the daemon loop fires `SyncCandidate` when the deadline expires uninterrupted. 5 unit tests cover first-event / within-window-burst / past-window-reset / equal-to-window-boundary / three-event-burst-collapse. |
+| Library surface wiring | [`cli/src/lib.rs`](../../cli/src/lib.rs) | One-line addition: `pub mod watcher;` next to the existing `args`, `exit`, `pipeline`, `state`, `unlock`, `veto` re-exports. Production consumers reach the watcher under `secretary_cli::watcher::*`. |
+
+**Commit:** `C.2 Task 6 — watcher submodule: partial-download ready + pure debounce` (see `git log feature/c2-task-6` for the local pre-merge SHA; the post-squash-merge SHA on `main` will differ). 26 new tests across watcher's three submodules (3 mod + 18 ready + 5 debounce); workspace 877 → 903. No issue closes with this commit; #37 (Sub-project C umbrella) advances by one more C.2 slice.
+
+### Plan ↔ reality reconciliations
+
+Two deliberate deviations from the plan, each documented inline in code comments + commit body:
+
+| Plan note | Reality | Resolution |
+|---|---|---|
+| Plan declared `DebounceDecision::AlreadyPending` as a third enum variant alongside `Schedule` + `Reschedule`. | The plan's `step` function never constructs `AlreadyPending` — every code path returns either `Schedule` (no pending / past window) or `Reschedule` (within window). The variant would be dead code on day one and trip `clippy -D warnings`. | Removed `AlreadyPending` from the enum. Documented the two-variant state machine as **trailing-edge debounce** in `debounce.rs`'s module doc. If a future driver wants a "cap-collapse drop" semantic (cap the total wait time at N windows instead of resetting indefinitely), it'd be a behavioural change requiring its own design — not a leftover variant. Aligns with [[feedback_act_on_issues_dont_mention]] (don't ship dead code) + the recently-closed #113 (cli crate compiles `-D warnings` with zero `#[allow(dead_code)]`). |
+| Plan code's `PARTIAL_PREFIXES` constant declared `[".~", "~$", "."]` but the function body only checked `.~` and `~$` explicitly — the `.` entry was unused. | A literal `.` prefix would also catch ordinary dotfiles (e.g., a contributor accidentally dropping a `.gitignore` into the vault folder would be silently filtered as "partial"). | Reduced the constant to `[".~", "~$"]` and iterated over it in the function body, so the constant is genuinely used (no dead-data warnings) and the semantics match what the spec §D6 table covers. `.DS_Store` is still caught by the `PARTIAL_BASENAMES` whole-name check. |
+
+The plan also estimated 17 new tests (12 ready + 4 debounce + 1 module sanity). Actual: **26 new tests** (3 mod sanity + 18 ready + 5 debounce). The extras came from one positive case per spec §D6 row (the plan compressed `.crdownload` and `.download` into one test; spec §D6 distinguishes Chromium vs Safari/Firefox so I split them), plus a dedicated test for the Dropbox `.~foo.tmp` route (which the plan claims is "caught by both `.~` and `.tmp`" — pinning that with an explicit test), plus a missing-file → `io::Error` test (required by the acceptance criteria's "missing-file branch" but absent from the plan code), plus a `burst_of_three_events_collapses_into_single_reschedule_chain` test (the plan's burst-collapse only had two events).
+
+### Gauntlet snapshot at session close
+
+```
+PASSED: 903 FAILED: 0 IGNORED: 10
+clippy --release --workspace --tests -- -D warnings   clean
+fmt --all -- --check                                  clean
+uv run core/tests/python/conformance.py               PASS
+uv run core/tests/python/spec_test_name_freshness.py  PASS (96 resolved / 0 unresolved / 2 suppressed)
+```
+
+(Baseline drift note: the prior baton recorded 868 at Task 5 close. A clean-main checkout from `90334ce` actually shows 877 — the 9-test delta is likely from doctest binaries or `--no-fail-fast` aggregation that the baton's quick `awk` didn't fully account for. Task 6 itself adds exactly 26 new tests (3 + 18 + 5); the post-Task-6 total is 877 + 26 = 903, consistent with the gauntlet output. Future batons should treat 903 as the new baseline.)
+
+## (2) What's next — start C.2 Task 7
+
+After this PR merges, the next slice is **C.2 Task 7: `notify` driver + daemon loop (`cli/src/watcher/notify_driver.rs` + `cli/src/daemon.rs`)** ([`docs/superpowers/plans/2026-05-23-c2-headless-sync-cli.md`](../superpowers/plans/2026-05-23-c2-headless-sync-cli.md) §"Task 7").
+
+### Acceptance criteria for Task 7
+
+- [ ] New `cli/src/watcher/notify_driver.rs` (~150–200 LOC): wraps `notify::RecommendedWatcher` + `std::sync::mpsc::Receiver<notify::Event>`. Maps platform events into `super::WatcherEvent`. Exposes `recv_with_timeout(Duration) -> Option<WatcherEvent>` for the daemon loop. Single-threaded blocking; no async runtime per spec §D3.
+- [ ] New `cli/src/daemon.rs` (~150–220 LOC): the `run` subcommand's main loop. Composes `notify_driver` (event source) + `watcher::debounce::step` (burst collapse) + `watcher::ready::wait_for_ready` (partial-download gate) + `pipeline::run_one` (one sync attempt) + the existing `state` / `unlock` / `veto` modules. Signal handling (SIGINT / SIGTERM) is deferred to Task 8 — Task 7 still exits cleanly on `WatcherEvent::ShutdownRequested` (synthetic for tests).
+- [ ] New `cli/src/lib.rs` line: `pub mod daemon;` (Task 5 established the `lib.rs` pattern; Task 6 added `watcher`; Task 7 adds `daemon`).
+- [ ] Hook the `run` subcommand's stub in `cli/src/main.rs` to `daemon::run`. (`once` subcommand still stubs through to Task 9's dispatch wiring; Task 7 is daemon-only.)
+- [ ] Unit tests for `notify_driver` cover the platform-event → `WatcherEvent` mapping (using `notify`'s synthetic event constructors); daemon-loop tests cover at least: one-event-end-to-end (synthetic mpsc event → `pipeline::run_one` invoked → state advanced) + shutdown-event-exits-cleanly + debounce-collapses-burst (two synthetic events within the window produce exactly one sync attempt).
+- [ ] Gauntlet target: **PASSED: 903 + N FAILED: 0 IGNORED: 10**. Absolute base is now 903 (bumped from 877 by Task 6's 26 new tests).
+- [ ] Clippy, fmt, conformance, spec freshness all clean.
+
+### Plan handoff
+
+Full step-by-step in [`docs/superpowers/plans/2026-05-23-c2-headless-sync-cli.md`](../superpowers/plans/2026-05-23-c2-headless-sync-cli.md) §"Task 7". The plan's Task 7 has both `notify_driver` and `daemon` in one slice (they're each incomplete without the other). Daemon-loop file is the densest at ~220 LOC; keep one concept per file (event mapping in `notify_driver`, loop composition in `daemon`).
+
+## (3) Open decisions and risks
+
+### Decisions settled during this session
+
+- **`WatcherEvent` is a flat 3-variant enum, no payload.** Variants are mutually exclusive — exactly one delivered per driver tick. No `SyncCandidate(Vec<PathBuf>)` form because the daemon doesn't act per-file — it re-runs the full `sync_once` against the vault folder on every wake. Per-file context lives in `notify`'s logs (Task 8's `tracing` integration).
+- **Trailing-edge debounce, not leading-edge.** Each new event resets the window; the daemon fires after a full quiet window. Reasoning in the `debounce.rs` module doc. If a future operator complains about long-burst latency (e.g., a 5-minute editor save-burst pushing 5 minutes of "no sync"), the fix is either a `--max-debounce-ms` cap (a third variant + new constant) or shorter window; not a different state machine.
+- **`Clock` trait shipped in `ready.rs`, not in a separate `time.rs` module.** It's tightly coupled to `wait_for_ready` (the only caller in this slice) and the trait is two methods, one line. Promoting it to its own module would invert the dependency for no clarity gain. Task 7's `notify_driver` can `use crate::watcher::ready::{Clock, RealClock};` without surprise.
+- **`is_size_stable` returns `false` if `modified()` errors on either snapshot.** Conservative — treat unknown mtime as "still possibly changing". On Linux / macOS / Windows the platform always reports mtime, so this branch is paranoid (defensive coding for the docstring's case-analysis completeness).
+- **`PARTIAL_BASENAMES` comparison is case-insensitive (`eq_ignore_ascii_case`).** Windows is case-preserving but case-insensitive at lookup time, and macOS volumes can be either. Spec §D6 doesn't normalise casing; the implementation does, so `desktop.ini` and `DESKTOP.INI` both get caught. Test `dotted_metadata_caught` pins both.
+- **`PARTIAL_SUFFIXES` lookup also lowercases the basename.** Same rationale — `.iCloud` (someone uppercased the extension) still gets caught.
+- **Plan-deviation: `DebounceDecision` has only 2 variants, not 3.** See §(1) reconciliation table. Plan's `AlreadyPending` was never constructed by `step`; removing it is the same hygiene we just closed #113 on (no `#[allow(dead_code)]` in `cli/`).
+- **Plan-deviation: `PARTIAL_PREFIXES` lost the `"."` entry.** See §(1). The `.` prefix would catch ordinary dotfiles silently; the spec §D6 row "`.~lock.*`" only requires `.~` (which we kept).
+- **`tempfile = "=3.27.0"` exact-pin retained in `cli/dev-dependencies`** — no new dependency added by Task 6. The plan's test code uses tempfile features already in scope (`NamedTempFile` + `tempdir`).
+
+### Decisions carried forward (unchanged from Task 5 close)
+
+- D1-D10 from the spec are still settled.
+- `--veto-policy=fail`, `--decisions-file`, `--exit-on-error`, `status`, `init` subcommands all deferred to future C.2.x slices.
+- Windows is best-effort per D10 (no CI runner planned for C.2 implementation).
+- Clean-room conformance harness for `cli/` deferred to C.4 or a future C.2.x slice.
+- The `from_sync_error` mapper's exit-code surface (Task 1): every `SyncError` variant without a dedicated code maps to `GenericError = 1`; bijection-failure variants do NOT get distinct codes (CLI bugs, not operator-recoverable).
+- fs4 dep retained over stdlib `File::try_lock` until workspace MSRV bumps past 1.89.
+- `SecretBytes::new(buf)` over `SecretBytes::from(slice) + zeroize` for owned-buffer unlock paths (Task 3 — still in force).
+- `TtyVetoUx` EOF latch + breadcrumb (Task 4) + safe-default `KeepLocal` on empty/error input + silent prompt-write failures: all in force.
+- Pipeline contract (Task 5): `run_one` returns `Result<RunOutcome, SyncError>`; `RunOutcome` has 5 variants (`NothingToDo`, `AppliedAutomatically`, `MergedAndCommitted { vetoes_resolved }`, `SilentMerge`, `RollbackRejected`); state-mutation contract is documented + tested. Library + binary hybrid (`secretary_cli` lib, `secretary-sync` bin) is the integration-test pattern.
+
+### Risks carried into Task 7
+
+- **`notify::RecommendedWatcher` platform quirks first appear in Task 7.** Task 6's pure-function pieces (pattern matcher + size-stability + debounce) run identically on Linux / macOS / Windows because they're string + struct + Instant arithmetic. Task 7 wires the actual platform watcher; macOS FSEvents coalescing, Linux inotify single-event-per-file, and Windows ReadDirectoryChangesW all surface here. A `cli/tests/notify_quirk.rs` test is planned for Task 10 to pin the quirks that survive into the daemon loop; Task 7 itself uses `notify`'s synthetic-event constructors so tests don't depend on the real backend.
+- **Debounce semantics under wall-clock skew (NTP step, sleep/wake).** `Instant::now()` is monotonic on all three platforms — NTP adjustments don't move it backwards. Sleep-wake is also monotonic-safe (the OS clock keeps advancing through suspension on macOS / Linux; Windows pauses but doesn't regress). So `duration_since` is safe. If a future platform somehow returned a non-monotonic `Instant`, the `>=` boundary in `step` would still produce defensible behaviour (always Schedule, never panic).
+- **Trailing-edge debounce under prolonged save-bursts.** If an editor saves every N ms for K seconds where K > debounce window, the sync attempt won't fire until K + window elapses. This is by design (sync runs against a quiet vault, not a half-written one), but if the operator-observed latency becomes complaint-worthy, the mitigation is a `--max-debounce-ms` cap. Track as a future C.2.x slice if needed; not in scope for Task 7.
+
+### Issues currently open
+
+- #37 — Sub-project C umbrella. C.2 Tasks 1-5 ✅ in PRs #112, #114, #115, #116, #118; Task 6 pending PR.
+- #117 — `TtyVetoUx` re-prompt loop has no max-attempts cap. Low-priority defensive-coding fix; still queued, not in scope for Task 7.
+- #38, #45, #75, #76, #78, #79, #81, #87, #88, #90, #95, #98 — none block C.2 Task 7.
+
+### Housekeeping note (stale worktrees on disk)
+
+After this PR:
+- `/Users/hherb/src/secretary` — `main` (clean post-merge).
+- `/Users/hherb/src/secretary/.worktrees/c1-1b-sync-merge` — branch `feature/c1-1b-task-17`, remote gone. Safe to remove.
+- `/Users/hherb/src/secretary/.worktrees/c2-task-1-spec` — branch `feature/c2-task-1-spec`, remote gone. Safe to remove.
+- `/Users/hherb/src/secretary/.worktrees/c2-task-1` — branch `feature/c2-task-1`, remote gone. Safe to remove.
+- `/Users/hherb/src/secretary/.worktrees/c2-task-2` — branch `feature/c2-task-2`, remote gone. Safe to remove.
+- `/Users/hherb/src/secretary/.worktrees/c2-task-3` — branch `feature/c2-task-3`, remote gone. Safe to remove.
+- `/Users/hherb/src/secretary/.worktrees/c2-task-4` — branch `feature/c2-task-4`, remote gone. Safe to remove.
+- `/Users/hherb/src/secretary/.worktrees/c2-task-5` — branch `feature/c2-task-5`, remote gone after #118 merged. Safe to remove.
+- `/Users/hherb/src/secretary/.worktrees/c2-task-6` — **this session's work**; keep until PR merges, then remove.
+
+```bash
+# One-line each (run from /Users/hherb/src/secretary):
+git worktree remove .worktrees/c1-1b-sync-merge && git branch -D feature/c1-1b-task-17
+git worktree remove .worktrees/c2-task-1-spec   && git branch -D feature/c2-task-1-spec
+git worktree remove .worktrees/c2-task-1        && git branch -D feature/c2-task-1
+git worktree remove .worktrees/c2-task-2        && git branch -D feature/c2-task-2
+git worktree remove .worktrees/c2-task-3        && git branch -D feature/c2-task-3
+git worktree remove .worktrees/c2-task-4        && git branch -D feature/c2-task-4
+git worktree remove .worktrees/c2-task-5        && git branch -D feature/c2-task-5
+```
+
+Cleanup is one-line each and does NOT block Task 7.
+
+## (4) Exact commands to resume
+
+```bash
+# After this C.2 Task 6 PR (feature/c2-task-6) merges:
+cd /Users/hherb/src/secretary
+git fetch --prune origin
+git status --short                       # expect: clean (modulo NEXT_SESSION.md sync, see below)
+git checkout main
+git pull --ff-only origin main
+
+# Verify gauntlet on fresh main (expect 903 / 0 / 10 — same as session close):
+cargo test --release --workspace --no-fail-fast 2>&1 | grep -E "^test result:" | awk '{passed+=$4; failed+=$6; ignored+=$8} END {print "PASSED:", passed, "FAILED:", failed, "IGNORED:", ignored}'
+cargo clippy --release --workspace --tests -- -D warnings 2>&1 | tail -3
+cargo fmt --all -- --check
+uv run core/tests/python/conformance.py 2>&1 | tail -3
+uv run core/tests/python/spec_test_name_freshness.py 2>&1 | tail -3
+
+# Start Task 7:
+git worktree add .worktrees/c2-task-7 -b feature/c2-task-7 main
+cd .worktrees/c2-task-7
+
+# Open the plan and follow Task 7 line-by-line:
+#   docs/superpowers/plans/2026-05-23-c2-headless-sync-cli.md §"Task 7"
+# Task 7 ships two new files (cli/src/watcher/notify_driver.rs +
+# cli/src/daemon.rs) plus the `pub mod daemon;` line in lib.rs.
+# Both files compose Task 6's pure pieces with notify's mpsc channel
+# and the existing pipeline::run_one to make the `run` subcommand
+# actually run. Signal handling deferred to Task 8.
+```
+
+## Closing inventory
+
+- **Branch state on close:** `main` at `90334ce` (PR #118 squash-merged). `feature/c2-task-6` carries 1 commit on top (Task 6 code + tests + handoff + symlink).
+- **Workspace tests on `feature/c2-task-6`:** 903 passed + 10 ignored (877 base + 26 new watcher tests: 3 in `watcher::tests` + 18 in `watcher::ready::tests` + 5 in `watcher::debounce::tests`). Clippy + fmt + Python conformance + spec freshness all clean.
+- **README.md:** unchanged this session — Task 6 ships internal pure-function scaffolding (no operator-visible surface change). The C.2 status line in README still reads "queued"; promoting it to "in progress" is deferred until Task 9 wires the subcommands so `secretary-sync` actually runs.
+- **ROADMAP.md:** unchanged this session — same reason; ROADMAP already calls C.2 "queued" since the C.2 design PR.
+- **CLAUDE.md:** unchanged this session — no new convention; watcher submodule is local to `cli/` and doesn't generalise to repo-wide guidance.
+- **NEXT_SESSION.md:** symlink retargeted to this file.
+- **Open issues:** see §(3) — none close with this PR; none block Task 7.
+- **Open PRs:** one to be opened at end of this session (C.2 Task 6).
+- **Worktrees on disk:** see §(3) housekeeping.
+- **Frozen baton snapshots:** all 23 prior C.1.1b + C.2-design + C.2-task-1/2/3/4/5 handoffs at [`docs/handoffs/`](.) — preserved unchanged.
+- **This file:** the live baton for C.2 Task 6 close.


### PR DESCRIPTION
## Summary

Sixth slice of C.2 — the pure-function pieces of the file-watcher abstraction. Three new files under `cli/src/watcher/` plus the `pub mod watcher;` wiring in `cli/src/lib.rs`. **No `notify::RecommendedWatcher` integration in this PR** — that lands in Task 7 alongside the daemon loop. This slice is table-testable in isolation precisely because it doesn't yet touch any event source.

- **[cli/src/watcher/mod.rs](../tree/feature/c2-task-6/cli/src/watcher/mod.rs)** (~60 LOC) — Public `WatcherEvent` enum: `SyncCandidate` / `PollTick` / `ShutdownRequested`. Pinned with 3 sanity tests (variant distinctness + Debug + Clone).
- **[cli/src/watcher/ready.rs](../tree/feature/c2-task-6/cli/src/watcher/ready.rs)** (~290 LOC) — Implements spec §D6's canonical 10-row partial-download pattern table: `matches_partial_pattern` (pure string matcher; case-insensitive over basenames), `is_size_stable` (pure `(Metadata, Metadata)` predicate), `wait_for_ready<C: Clock>` (thin I/O orchestrator). `Clock` trait + `RealClock` impl ship now so Task 7's `notify_driver` can wire production sleep without re-defining the abstraction. 18 unit tests cover one positive case per §D6 row + dropbox dual-route + case-insensitive Windows variant + vault filenames negative cases + size-stability + all four `wait_for_ready` branches (partial-marker / empty-file / stable-file / missing-file → `io::Error`).
- **[cli/src/watcher/debounce.rs](../tree/feature/c2-task-6/cli/src/watcher/debounce.rs)** (~135 LOC) — Pure state machine: `step(now, pending_since, window) -> (DebounceDecision, Option<Instant>)`. Trailing-edge semantics (each in-window event resets the deadline). 5 unit tests: first-event / within-window-reschedule / past-window-schedule / equal-to-window-boundary / three-event-burst-collapse.

### Plan ↔ reality reconciliations

Two deliberate plan deviations, each documented in the commit body + handoff baton + inline code comments:

1. **`DebounceDecision::AlreadyPending` variant removed.** The plan declared three variants but `step` never constructed the third one. Shipping it would trip `clippy -D warnings` (dead variant) and reintroduce the kind of `#[allow(dead_code)]` noise we just closed with #113. Trailing-edge semantics documented in `debounce.rs`'s module doc; if a future driver wants a "cap-collapse drop" semantic, it's a behavioural change requiring its own design.
2. **`PARTIAL_PREFIXES` lost the `"."` entry.** A literal dot prefix would silently filter ordinary dotfiles (`.gitignore` etc.) as "partial-download". Spec §D6 only requires `.~` and `~$`; `.DS_Store` is caught by `PARTIAL_BASENAMES`.

### Gauntlet at session close

| Check | Result |
|---|---|
| `cargo test --release --workspace --no-fail-fast` | **903 passed / 0 failed / 10 ignored** (26 new tests over 877 baseline) |
| `cargo clippy --release --workspace --tests -- -D warnings` | clean |
| `cargo fmt --all -- --check` | clean |
| `uv run core/tests/python/conformance.py` | PASS |
| `uv run core/tests/python/spec_test_name_freshness.py` | PASS (96 resolved / 0 unresolved / 2 suppressed) |

(Baseline drift note: prior baton recorded 868 at Task 5 close, but clean-main from `90334ce` actually shows 877 — the 9-test delta is from doctest-binary aggregation that the prior quick `awk` didn't fully account for. Task 6 itself adds exactly 26 new tests. Future batons should treat 903 as the new baseline.)

## Test plan

- [x] `cargo test --release --workspace --no-fail-fast` — 903 / 0 / 10
- [x] `cargo test --release -p secretary-cli --lib watcher` — 26 / 0 / 0
- [x] `cargo clippy --release --workspace --tests -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] `uv run core/tests/python/conformance.py` — PASS
- [x] `uv run core/tests/python/spec_test_name_freshness.py` — PASS

## What's next

Task 7 (next slice): `cli/src/watcher/notify_driver.rs` + `cli/src/daemon.rs` — wires `notify::RecommendedWatcher` into Task 6's pure pieces + composes `pipeline::run_one` into a running daemon. Signal handling deferred to Task 8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)