### PR TITLE
C.2 Task 7 — notify driver + daemon loop

### DIFF
--- a/NEXT_SESSION.md
+++ b/NEXT_SESSION.md
@@ -1,1 +1,1 @@
-docs/handoffs/2026-05-25-c2-task-6-watcher-ready-debounce-shipped.md
+docs/handoffs/2026-05-25-c2-task-7-notify-driver-daemon-shipped.md

--- a/cli/src/daemon.rs
+++ b/cli/src/daemon.rs
@@ -43,15 +43,17 @@ use crate::watcher::notify_driver::NotifyWatcher;
 use crate::watcher::ready::{wait_for_ready, RealClock};
 use crate::watcher::WatcherEvent;
 
-/// Maximum interval the loop will block on `poll` without checking
-/// the shutdown flag.
+/// Default upper bound on how long the loop blocks on `poll` without
+/// checking the shutdown flag.
 ///
-/// Used as the wait when nothing else (debounce window, periodic poll)
-/// is closer. Picked at 1 s as a balance between operator-visible
-/// shutdown latency (Ctrl-C should feel snappy) and per-iteration
-/// overhead (no point spinning the loop every 10 ms in an idle
-/// daemon).
-const SHUTDOWN_POLL_INTERVAL: Duration = Duration::from_millis(1000);
+/// Production daemons leave this at the default. Tests override
+/// [`DaemonConfig::shutdown_poll_interval`] with a shorter value so
+/// flag-flip assertions don't add a full second to the test suite.
+///
+/// Picked at 1 s as a balance between operator-visible shutdown
+/// latency (Ctrl-C should feel snappy) and per-iteration overhead
+/// (no point spinning the loop every 10 ms in an idle daemon).
+pub const DEFAULT_SHUTDOWN_POLL_INTERVAL: Duration = Duration::from_millis(1000);
 
 /// Configuration knobs for the daemon loop.
 #[derive(Debug, Clone)]
@@ -68,9 +70,14 @@ pub struct DaemonConfig {
     /// against backend gaps (FSEvents coalescing, inotify queue
     /// overflow) at a small cost in wasted attempts.
     pub poll_interval: Option<Duration>,
+    /// Upper bound on how long the loop blocks on `poll` without
+    /// re-checking [`Self::shutdown_flag`]. Production wires this to
+    /// [`DEFAULT_SHUTDOWN_POLL_INTERVAL`]; tests use a smaller value to
+    /// keep flag-flip assertions fast.
+    pub shutdown_poll_interval: Duration,
     /// Cancellation flag set by the signal handler (SIGINT/SIGTERM,
     /// landing in Task 8). The loop polls this flag at most every
-    /// [`SHUTDOWN_POLL_INTERVAL`].
+    /// [`Self::shutdown_poll_interval`].
     pub shutdown_flag: Arc<AtomicBool>,
 }
 
@@ -135,7 +142,7 @@ where
             debounce_pending,
             config.debounce,
             config.poll_interval.map(|pi| (pi, last_poll_at)),
-            SHUTDOWN_POLL_INTERVAL,
+            config.shutdown_poll_interval,
         );
 
         match poll(wait) {
@@ -193,6 +200,18 @@ fn compute_wait(
     wait
 }
 
+/// Threshold of consecutive `wait_for_ready` → `Ok(false)` returns that
+/// triggers a single operator-visible warn log. After this many
+/// debounce-fired or periodic-fired cycles in a row where the folder
+/// was still being modified, something external (another process,
+/// stuck cloud sync agent) is likely the cause and the operator
+/// should know — debug-level "skipping sync" lines would otherwise
+/// stay invisible at default verbosity.
+///
+/// Pinned by the [`note_not_ready_and_should_warn`] unit test so the
+/// fire-exactly-once-at-threshold semantic is durable.
+pub const READY_NOT_READY_WARN_THRESHOLD: u32 = 5;
+
 /// Production composition: start a [`NotifyWatcher`] against
 /// `vault_folder`, then run the daemon loop with closures that bridge
 /// to [`wait_for_ready`] + [`run_one`].
@@ -203,7 +222,11 @@ fn compute_wait(
 ///    folder's metadata has stopped changing across a `ready_window`
 ///    probe. The check is best-effort — a stat failure or partial
 ///    marker on the folder itself (impossible in practice) is logged
-///    at debug and skipped, not fatal.
+///    at debug and skipped, not fatal. After
+///    [`READY_NOT_READY_WARN_THRESHOLD`] consecutive `Ok(false)`
+///    returns a warn-level log fires once so operators notice when
+///    something external is continuously modifying the folder and
+///    starving the sync; the counter resets on the next `Ok(true)`.
 /// 2. Calls [`run_one`] for one sync attempt; any [`SyncError`] is
 ///    logged at warn level and the loop continues per spec §"Daemon
 ///    loop sketch" ("on pipeline error: log + continue").
@@ -229,15 +252,36 @@ pub fn run_against_vault(
     config: DaemonConfig,
     ready_window: Duration,
 ) -> Result<(), SyncError> {
+    // Production should always use the default; flag accidental zeros
+    // (would cause the loop to spin without ever blocking) at startup
+    // rather than silently busy-loop in the watcher poll.
+    debug_assert!(
+        !config.shutdown_poll_interval.is_zero(),
+        "DaemonConfig::shutdown_poll_interval must be > 0; use DEFAULT_SHUTDOWN_POLL_INTERVAL in production"
+    );
     let watcher = NotifyWatcher::start(vault_folder).map_err(notify_start_to_sync_error)?;
     let clock = RealClock;
+    let mut consecutive_not_ready: u32 = 0;
     run(
         config,
         |timeout| watcher.poll(timeout),
         || {
             match wait_for_ready(vault_folder, &clock, ready_window) {
-                Ok(true) => {}
+                Ok(true) => {
+                    consecutive_not_ready = 0;
+                }
                 Ok(false) => {
+                    if note_not_ready_and_should_warn(
+                        &mut consecutive_not_ready,
+                        READY_NOT_READY_WARN_THRESHOLD,
+                    ) {
+                        tracing::warn!(
+                            folder = %vault_folder.display(),
+                            consecutive_skips = consecutive_not_ready,
+                            "vault folder has not become size-stable across {} consecutive sync attempts; another process may be continuously modifying it",
+                            READY_NOT_READY_WARN_THRESHOLD,
+                        );
+                    }
                     tracing::debug!("vault folder not size-stable; skipping sync");
                     return;
                 }
@@ -252,6 +296,22 @@ pub fn run_against_vault(
         },
     );
     Ok(())
+}
+
+/// Increments `consecutive` (saturating) and returns `true` exactly
+/// when the new value equals `threshold` — i.e. on the
+/// `threshold`-th consecutive `wait_for_ready → Ok(false)`. Subsequent
+/// returns over the threshold do NOT re-fire (the warn was already
+/// emitted; further iterations stay at debug level until the counter
+/// resets).
+///
+/// Pure helper extracted from [`run_against_vault`]'s `on_sync`
+/// closure so the fire-once-at-threshold semantic is unit-testable
+/// without spinning up a real watcher + vault fixture.
+#[must_use]
+fn note_not_ready_and_should_warn(consecutive: &mut u32, threshold: u32) -> bool {
+    *consecutive = consecutive.saturating_add(1);
+    *consecutive == threshold
 }
 
 /// Wall-clock milliseconds since the UNIX epoch, saturating on
@@ -304,6 +364,15 @@ mod tests {
     /// cleanly: one debounce window of "did nothing" then one poll
     /// fire.
     const TEST_POLL_INTERVAL: Duration = Duration::from_millis(100);
+
+    /// Short shutdown-poll interval for tests. Keeps
+    /// [`run_exits_when_shutdown_flag_flips_mid_loop`] under ~400 ms
+    /// instead of paying [`DEFAULT_SHUTDOWN_POLL_INTERVAL`] (1 s) per
+    /// iteration. Deliberately set ≥ [`TEST_POLL_INTERVAL`] so the
+    /// shutdown interval never fragments a scripted `None` slot that
+    /// is meant to elapse the full periodic-poll interval — see the
+    /// scripting model in [`ScriptedPoller`].
+    const TEST_SHUTDOWN_INTERVAL: Duration = Duration::from_millis(200);
 
     /// Sentinel that ends scripts in tests. The poller exhausting
     /// its script returns this so the loop exits deterministically.
@@ -361,11 +430,13 @@ mod tests {
     }
 
     /// Build a default test config with the given debounce window,
-    /// no periodic poll, and a fresh shutdown_flag.
+    /// no periodic poll, a fresh shutdown_flag, and the short
+    /// [`TEST_SHUTDOWN_INTERVAL`].
     fn test_config(debounce: Duration) -> DaemonConfig {
         DaemonConfig {
             debounce,
             poll_interval: None,
+            shutdown_poll_interval: TEST_SHUTDOWN_INTERVAL,
             shutdown_flag: Arc::new(AtomicBool::new(false)),
         }
     }
@@ -376,8 +447,14 @@ mod tests {
     #[test]
     fn compute_wait_returns_shutdown_interval_with_no_constraints() {
         let now = Instant::now();
-        let wait = compute_wait(now, None, TEST_DEBOUNCE, None, SHUTDOWN_POLL_INTERVAL);
-        assert_eq!(wait, SHUTDOWN_POLL_INTERVAL);
+        let wait = compute_wait(
+            now,
+            None,
+            TEST_DEBOUNCE,
+            None,
+            DEFAULT_SHUTDOWN_POLL_INTERVAL,
+        );
+        assert_eq!(wait, DEFAULT_SHUTDOWN_POLL_INTERVAL);
     }
 
     /// `compute_wait` caps at the remaining debounce window when a
@@ -393,7 +470,7 @@ mod tests {
             Some(pending),
             TEST_DEBOUNCE,
             None,
-            SHUTDOWN_POLL_INTERVAL,
+            DEFAULT_SHUTDOWN_POLL_INTERVAL,
         );
         // Allow a small tolerance for clock granularity.
         assert!(
@@ -416,7 +493,7 @@ mod tests {
             Some(pending),
             TEST_DEBOUNCE,
             None,
-            SHUTDOWN_POLL_INTERVAL,
+            DEFAULT_SHUTDOWN_POLL_INTERVAL,
         );
         assert_eq!(wait, Duration::ZERO);
     }
@@ -434,7 +511,7 @@ mod tests {
             None,
             TEST_DEBOUNCE,
             Some((TEST_POLL_INTERVAL, last_poll)),
-            SHUTDOWN_POLL_INTERVAL,
+            DEFAULT_SHUTDOWN_POLL_INTERVAL,
         );
         assert!(
             wait <= Duration::from_millis(60) && wait >= Duration::from_millis(59),
@@ -455,7 +532,7 @@ mod tests {
             Some(pending),
             TEST_DEBOUNCE,
             Some((TEST_POLL_INTERVAL, last_poll)),
-            SHUTDOWN_POLL_INTERVAL,
+            DEFAULT_SHUTDOWN_POLL_INTERVAL,
         );
         assert!(
             wait <= Duration::from_millis(10) && wait >= Duration::from_millis(9),
@@ -473,6 +550,7 @@ mod tests {
         let config = DaemonConfig {
             debounce: TEST_DEBOUNCE,
             poll_interval: None,
+            shutdown_poll_interval: TEST_SHUTDOWN_INTERVAL,
             shutdown_flag: flag,
         };
         run(config, |t| poller.poll(t), || counter.record());
@@ -561,6 +639,7 @@ mod tests {
         let config = DaemonConfig {
             debounce: TEST_DEBOUNCE,
             poll_interval: Some(TEST_POLL_INTERVAL),
+            shutdown_poll_interval: TEST_SHUTDOWN_INTERVAL,
             shutdown_flag: Arc::new(AtomicBool::new(false)),
         };
         run(config, |t| poller.poll(t), || counter.record());
@@ -576,13 +655,16 @@ mod tests {
         let flag_clone = flag.clone();
         let mut counter = SyncCounter::new();
         // Script is two Nones so the poller sleeps for two
-        // SHUTDOWN_POLL_INTERVAL-bounded waits; the side thread flips
+        // TEST_SHUTDOWN_INTERVAL-bounded waits; the side thread flips
         // the flag during the first sleep. The loop catches it at the
-        // top of the next iteration.
+        // top of the next iteration. Total wall-clock is bounded by
+        // 2× TEST_SHUTDOWN_INTERVAL (≈400 ms) — without the test
+        // override this would be 2 s.
         let mut poller = ScriptedPoller::new([None, None]);
         let config = DaemonConfig {
             debounce: TEST_DEBOUNCE,
             poll_interval: None,
+            shutdown_poll_interval: TEST_SHUTDOWN_INTERVAL,
             shutdown_flag: flag,
         };
         let handle = std::thread::spawn(move || {
@@ -621,6 +703,60 @@ mod tests {
         const CEILING_MS: u64 = 32_503_680_000_000;
         assert!(ms >= FLOOR_MS, "now_ms below floor: {ms}");
         assert!(ms <= CEILING_MS, "now_ms above ceiling: {ms}");
+    }
+
+    /// `note_not_ready_and_should_warn` fires `true` exactly once on
+    /// the threshold-th consecutive call and stays `false` afterwards
+    /// until the caller resets the counter. Pins the
+    /// fire-once-at-threshold semantic for the
+    /// [`READY_NOT_READY_WARN_THRESHOLD`] policy.
+    #[test]
+    fn note_not_ready_fires_warn_exactly_once_at_threshold() {
+        let mut counter: u32 = 0;
+        let threshold: u32 = 3;
+        assert!(!note_not_ready_and_should_warn(&mut counter, threshold));
+        assert_eq!(counter, 1);
+        assert!(!note_not_ready_and_should_warn(&mut counter, threshold));
+        assert_eq!(counter, 2);
+        assert!(
+            note_not_ready_and_should_warn(&mut counter, threshold),
+            "third call hits the threshold"
+        );
+        assert_eq!(counter, 3);
+        assert!(
+            !note_not_ready_and_should_warn(&mut counter, threshold),
+            "fourth call is past the threshold and must NOT re-fire"
+        );
+        assert_eq!(counter, 4);
+    }
+
+    /// Resetting `counter` to 0 (as `run_against_vault` does on
+    /// `wait_for_ready → Ok(true)`) restores fire-at-threshold
+    /// behavior for the next streak. Pins that the warn would re-fire
+    /// after a transient stable period followed by another stuck
+    /// stretch — the operator should hear about each streak.
+    #[test]
+    fn note_not_ready_refires_after_counter_reset() {
+        let mut counter: u32 = 0;
+        let threshold: u32 = 2;
+        let _ = note_not_ready_and_should_warn(&mut counter, threshold);
+        assert!(note_not_ready_and_should_warn(&mut counter, threshold));
+        // Folder became stable for one cycle.
+        counter = 0;
+        // Second streak — must fire again on its own threshold-th hit.
+        assert!(!note_not_ready_and_should_warn(&mut counter, threshold));
+        assert!(note_not_ready_and_should_warn(&mut counter, threshold));
+    }
+
+    /// `note_not_ready_and_should_warn` uses saturating arithmetic so
+    /// a pathological never-ending stuck stretch can't panic on
+    /// counter overflow. Caller can rely on counter staying at
+    /// `u32::MAX` indefinitely after reaching it.
+    #[test]
+    fn note_not_ready_saturates_at_u32_max() {
+        let mut counter: u32 = u32::MAX;
+        let _ = note_not_ready_and_should_warn(&mut counter, 1);
+        assert_eq!(counter, u32::MAX);
     }
 
     /// `notify_start_to_sync_error` wraps a notify error in

--- a/cli/src/daemon.rs
+++ b/cli/src/daemon.rs
@@ -1,0 +1,641 @@
+//! `run` subcommand event loop. Composes the watcher submodule's pure
+//! pieces ([`watcher::debounce::step`], [`watcher::notify_driver`]) +
+//! the existing [`pipeline::run_one`] into a single-threaded blocking
+//! daemon.
+//!
+//! Spec: [`docs/superpowers/specs/2026-05-23-c2-headless-sync-cli-design.md`](../../docs/superpowers/specs/2026-05-23-c2-headless-sync-cli-design.md)
+//! §"Daemon loop sketch".
+//!
+//! The loop is **pure orchestration** — it takes a `poll` closure as
+//! the event source and an `on_sync` closure as the sync action. This
+//! lets the unit tests drive the loop with a scripted event source +
+//! a counter, while the production wire-up (see
+//! [`run_against_vault`]) plugs in [`watcher::notify_driver::NotifyWatcher`]
+//! and a [`pipeline::run_one`] call.
+//!
+//! ## Trailing-edge debounce
+//!
+//! The loop honours the trailing-edge debounce semantic that
+//! [`watcher::debounce`] documents: every fresh
+//! [`watcher::WatcherEvent::SyncCandidate`] *resets* the deadline. The
+//! sync only fires once an entire debounce window has elapsed without
+//! a new event. The previous design (see C.2 Task 7 plan §"Plan
+//! deviation" in the handoff) used a blocking `std::thread::sleep` in
+//! the match arm and effectively degraded to *leading-edge with burst
+//! coalescing* — that contradicted the semantic Task 6's debounce
+//! module + its 5 unit tests pin. The closure-shaped loop here uses
+//! the `poll` timeout itself as the debounce timer, which is the
+//! straightforward implementation of trailing-edge semantics.
+
+use std::path::Path;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use secretary_core::crypto::secret::SecretBytes;
+use secretary_core::sync::{SyncError, SyncState};
+use secretary_core::unlock::UnlockedIdentity;
+
+use crate::pipeline::run_one;
+use crate::veto::VetoUx;
+use crate::watcher::debounce::step as debounce_step;
+use crate::watcher::notify_driver::NotifyWatcher;
+use crate::watcher::ready::{wait_for_ready, RealClock};
+use crate::watcher::WatcherEvent;
+
+/// Maximum interval the loop will block on `poll` without checking
+/// the shutdown flag.
+///
+/// Used as the wait when nothing else (debounce window, periodic poll)
+/// is closer. Picked at 1 s as a balance between operator-visible
+/// shutdown latency (Ctrl-C should feel snappy) and per-iteration
+/// overhead (no point spinning the loop every 10 ms in an idle
+/// daemon).
+const SHUTDOWN_POLL_INTERVAL: Duration = Duration::from_millis(1000);
+
+/// Configuration knobs for the daemon loop.
+#[derive(Debug, Clone)]
+pub struct DaemonConfig {
+    /// Trailing-edge debounce window (typically `--debounce-ms`). A
+    /// burst of [`WatcherEvent::SyncCandidate`] within `debounce` of
+    /// the previous one extends the deadline; the sync fires once
+    /// `debounce` has elapsed uninterrupted.
+    pub debounce: Duration,
+    /// Optional periodic safety-net poll. `None` disables it.
+    ///
+    /// When `Some(d)`, the loop runs an unconditional sync every `d`
+    /// regardless of whether `notify` has surfaced events — defends
+    /// against backend gaps (FSEvents coalescing, inotify queue
+    /// overflow) at a small cost in wasted attempts.
+    pub poll_interval: Option<Duration>,
+    /// Cancellation flag set by the signal handler (SIGINT/SIGTERM,
+    /// landing in Task 8). The loop polls this flag at most every
+    /// [`SHUTDOWN_POLL_INTERVAL`].
+    pub shutdown_flag: Arc<AtomicBool>,
+}
+
+/// Run the daemon loop.
+///
+/// `poll` is the event source — typically `|t| watcher.poll(t)` for
+/// a [`NotifyWatcher`]. It MUST block up to its `Duration` argument
+/// then return either a `WatcherEvent` or `None` (timeout).
+///
+/// `on_sync` is invoked exactly once per fired sync (post-debounce or
+/// post-periodic-poll). The production callsite passes a closure that
+/// calls [`run_one`] + handles its result; tests pass a counter-bump.
+///
+/// The function returns when:
+/// - `config.shutdown_flag` becomes `true`, or
+/// - `poll` returns `Some(WatcherEvent::ShutdownRequested)`.
+///
+/// Pipeline-level errors are the caller's responsibility (the
+/// closure logs + continues per spec; this function never sees a
+/// [`SyncError`] directly).
+pub fn run<P, S>(config: DaemonConfig, mut poll: P, mut on_sync: S)
+where
+    P: FnMut(Duration) -> Option<WatcherEvent>,
+    S: FnMut(),
+{
+    let mut debounce_pending: Option<Instant> = None;
+    let mut last_poll_at = Instant::now();
+
+    loop {
+        if config.shutdown_flag.load(Ordering::SeqCst) {
+            tracing::debug!("daemon shutdown_flag set; exiting loop");
+            return;
+        }
+
+        let now = Instant::now();
+
+        // (1) Trailing-edge debounce: window has elapsed uninterrupted
+        //     since the last event → fire sync.
+        if let Some(pending_since) = debounce_pending {
+            if now.duration_since(pending_since) >= config.debounce {
+                debounce_pending = None;
+                on_sync();
+                continue;
+            }
+        }
+
+        // (2) Periodic safety-net poll due → fire sync regardless of
+        //     event activity.
+        if let Some(poll_interval) = config.poll_interval {
+            if now.duration_since(last_poll_at) >= poll_interval {
+                last_poll_at = now;
+                on_sync();
+                continue;
+            }
+        }
+
+        // (3) Block on the next event up to whichever deadline comes
+        //     first (debounce expiry, next periodic poll, or the
+        //     shutdown polling interval).
+        let wait = compute_wait(
+            now,
+            debounce_pending,
+            config.debounce,
+            config.poll_interval.map(|pi| (pi, last_poll_at)),
+            SHUTDOWN_POLL_INTERVAL,
+        );
+
+        match poll(wait) {
+            Some(WatcherEvent::SyncCandidate) => {
+                // `_decision` distinguishes Schedule vs Reschedule
+                // for telemetry; here the only thing we need is the
+                // updated `pending_since`.
+                let (_decision, new_pending) =
+                    debounce_step(Instant::now(), debounce_pending, config.debounce);
+                debounce_pending = new_pending;
+            }
+            Some(WatcherEvent::ShutdownRequested) => {
+                tracing::debug!("daemon received ShutdownRequested; exiting loop");
+                return;
+            }
+            Some(WatcherEvent::PollTick) | None => {
+                // PollTick is delivered by the synthetic test source
+                // only — production never emits it (the periodic-poll
+                // check at the top of the loop handles real
+                // backups). None = timeout; loop back.
+            }
+        }
+    }
+}
+
+/// Pure helper: smallest of (remaining debounce window, remaining
+/// poll interval, shutdown poll interval).
+///
+/// Pulled out as a free function for the unit tests + for clarity.
+/// Saturating arithmetic everywhere so an "already elapsed" deadline
+/// yields `Duration::ZERO`, which makes `poll` return immediately on
+/// the next call — the top-of-loop checks then fire the appropriate
+/// sync.
+#[must_use]
+fn compute_wait(
+    now: Instant,
+    debounce_pending: Option<Instant>,
+    debounce_window: Duration,
+    poll_state: Option<(Duration, Instant)>,
+    shutdown_interval: Duration,
+) -> Duration {
+    let mut wait = shutdown_interval;
+    if let Some(pending) = debounce_pending {
+        let remaining = debounce_window.saturating_sub(now.duration_since(pending));
+        if remaining < wait {
+            wait = remaining;
+        }
+    }
+    if let Some((interval, last)) = poll_state {
+        let remaining = interval.saturating_sub(now.duration_since(last));
+        if remaining < wait {
+            wait = remaining;
+        }
+    }
+    wait
+}
+
+/// Production composition: start a [`NotifyWatcher`] against
+/// `vault_folder`, then run the daemon loop with closures that bridge
+/// to [`wait_for_ready`] + [`run_one`].
+///
+/// The loop's `on_sync` closure:
+///
+/// 1. Calls [`wait_for_ready`] against `vault_folder` to confirm the
+///    folder's metadata has stopped changing across a `ready_window`
+///    probe. The check is best-effort — a stat failure or partial
+///    marker on the folder itself (impossible in practice) is logged
+///    at debug and skipped, not fatal.
+/// 2. Calls [`run_one`] for one sync attempt; any [`SyncError`] is
+///    logged at warn level and the loop continues per spec §"Daemon
+///    loop sketch" ("on pipeline error: log + continue").
+///
+/// # Errors
+///
+/// Returns [`SyncError`] only if [`NotifyWatcher::start`] fails (i.e.
+/// the OS refused to set up the file-watch). All in-loop pipeline
+/// errors are caught + logged + continued, never propagated.
+///
+/// This helper is the production seam; it is **not** independently
+/// unit-tested because its only logic is the closure composition —
+/// the integration test suite (Task 10) will exercise it end-to-end
+/// against `golden_vault_001`. Each individual piece (`NotifyWatcher`,
+/// `debounce_step`, `wait_for_ready`, `run_one`) is unit-tested in
+/// place.
+pub fn run_against_vault(
+    vault_folder: &Path,
+    identity: &UnlockedIdentity,
+    password: &SecretBytes,
+    state: &mut SyncState,
+    veto_ux: &mut dyn VetoUx,
+    config: DaemonConfig,
+    ready_window: Duration,
+) -> Result<(), SyncError> {
+    let watcher = NotifyWatcher::start(vault_folder).map_err(notify_start_to_sync_error)?;
+    let clock = RealClock;
+    run(
+        config,
+        |timeout| watcher.poll(timeout),
+        || {
+            match wait_for_ready(vault_folder, &clock, ready_window) {
+                Ok(true) => {}
+                Ok(false) => {
+                    tracing::debug!("vault folder not size-stable; skipping sync");
+                    return;
+                }
+                Err(e) => {
+                    tracing::debug!("ready probe failed: {e}; skipping sync");
+                    return;
+                }
+            }
+            if let Err(e) = run_one(vault_folder, identity, password, state, veto_ux, now_ms()) {
+                tracing::warn!("pipeline error (continuing): {e}");
+            }
+        },
+    );
+    Ok(())
+}
+
+/// Wall-clock milliseconds since the UNIX epoch, saturating on
+/// overflow (the year 584,556,000 is not our problem).
+fn now_ms() -> u64 {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| u64::try_from(d.as_millis()).unwrap_or(u64::MAX))
+        .unwrap_or(0)
+}
+
+/// Map a [`notify::Error`] from [`NotifyWatcher::start`] into a
+/// [`SyncError`] the daemon caller can surface through its existing
+/// exit-code mapping.
+fn notify_start_to_sync_error(err: notify::Error) -> SyncError {
+    SyncError::Vault(secretary_core::vault::VaultError::Io {
+        context: "notify watcher start failed",
+        source: std::io::Error::other(err.to_string()),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    //! Daemon-loop unit tests.
+    //!
+    //! Each test composes:
+    //! - a [`ScriptedPoller`] (drives the loop with a fixed sequence
+    //!   of `Option<WatcherEvent>` values; sleeps the timeout when the
+    //!   scripted slot is `None`, so the daemon's debounce / periodic
+    //!   poll deadlines elapse against real wall-clock time);
+    //! - a [`SyncCounter`] (records how many times the loop fired
+    //!   `on_sync`).
+    //!
+    //! Debounce windows are kept short (~50 ms) so the suite stays
+    //! under a second of real time.
+
+    use super::*;
+    use std::collections::VecDeque;
+    use std::sync::atomic::AtomicBool;
+    use std::sync::Arc;
+
+    /// Short debounce window used across daemon tests. Tuned to be
+    /// comfortably larger than typical iteration overhead (sub-ms)
+    /// while keeping the whole suite well under a second.
+    const TEST_DEBOUNCE: Duration = Duration::from_millis(50);
+
+    /// Short periodic-poll interval for the periodic-poll test.
+    /// Picked at 2× `TEST_DEBOUNCE` so the test scenario reads
+    /// cleanly: one debounce window of "did nothing" then one poll
+    /// fire.
+    const TEST_POLL_INTERVAL: Duration = Duration::from_millis(100);
+
+    /// Sentinel that ends scripts in tests. The poller exhausting
+    /// its script returns this so the loop exits deterministically.
+    const SCRIPT_END: WatcherEvent = WatcherEvent::ShutdownRequested;
+
+    /// Scripted event source. Each call to [`Self::poll`] pops the
+    /// next slot from `script`:
+    ///
+    /// - `Some(event)` → return immediately (no sleep).
+    /// - `None` → sleep the supplied `timeout` then return `None`,
+    ///   which is how the daemon's deadline-based debounce / periodic
+    ///   poll actually fire (the next loop iteration sees the
+    ///   wall-clock has advanced past the deadline).
+    ///
+    /// Once exhausted, the poller emits [`SCRIPT_END`] forever so the
+    /// daemon loop exits cleanly without the test needing to set the
+    /// shutdown flag.
+    struct ScriptedPoller {
+        script: VecDeque<Option<WatcherEvent>>,
+    }
+
+    impl ScriptedPoller {
+        fn new(script: impl IntoIterator<Item = Option<WatcherEvent>>) -> Self {
+            Self {
+                script: script.into_iter().collect(),
+            }
+        }
+
+        fn poll(&mut self, timeout: Duration) -> Option<WatcherEvent> {
+            match self.script.pop_front() {
+                Some(Some(event)) => Some(event),
+                Some(None) => {
+                    std::thread::sleep(timeout);
+                    None
+                }
+                None => Some(SCRIPT_END),
+            }
+        }
+    }
+
+    /// Records each `on_sync` invocation; the tests assert on its
+    /// final `count`.
+    struct SyncCounter {
+        count: u32,
+    }
+
+    impl SyncCounter {
+        fn new() -> Self {
+            Self { count: 0 }
+        }
+
+        fn record(&mut self) {
+            self.count += 1;
+        }
+    }
+
+    /// Build a default test config with the given debounce window,
+    /// no periodic poll, and a fresh shutdown_flag.
+    fn test_config(debounce: Duration) -> DaemonConfig {
+        DaemonConfig {
+            debounce,
+            poll_interval: None,
+            shutdown_flag: Arc::new(AtomicBool::new(false)),
+        }
+    }
+
+    /// `compute_wait` with no debounce + no poll returns the shutdown
+    /// interval verbatim — the loop should fall back to the slowest
+    /// safe deadline when nothing tighter applies.
+    #[test]
+    fn compute_wait_returns_shutdown_interval_with_no_constraints() {
+        let now = Instant::now();
+        let wait = compute_wait(now, None, TEST_DEBOUNCE, None, SHUTDOWN_POLL_INTERVAL);
+        assert_eq!(wait, SHUTDOWN_POLL_INTERVAL);
+    }
+
+    /// `compute_wait` caps at the remaining debounce window when a
+    /// debounce timer is pending and its deadline is closer than the
+    /// shutdown interval.
+    #[test]
+    fn compute_wait_caps_at_remaining_debounce_window() {
+        let now = Instant::now();
+        // pending started 20ms ago, window is 50ms → 30ms remaining.
+        let pending = now - Duration::from_millis(20);
+        let wait = compute_wait(
+            now,
+            Some(pending),
+            TEST_DEBOUNCE,
+            None,
+            SHUTDOWN_POLL_INTERVAL,
+        );
+        // Allow a small tolerance for clock granularity.
+        assert!(
+            wait <= Duration::from_millis(30) && wait >= Duration::from_millis(29),
+            "expected ~30ms remaining, got {wait:?}"
+        );
+    }
+
+    /// `compute_wait` returns `Duration::ZERO` when the debounce
+    /// window has already elapsed. The top-of-loop check will then
+    /// fire `on_sync` on the next iteration, but we want `poll` not
+    /// to block in the meantime.
+    #[test]
+    fn compute_wait_returns_zero_when_debounce_elapsed() {
+        let now = Instant::now();
+        // pending started 100ms ago, window is 50ms → elapsed.
+        let pending = now - Duration::from_millis(100);
+        let wait = compute_wait(
+            now,
+            Some(pending),
+            TEST_DEBOUNCE,
+            None,
+            SHUTDOWN_POLL_INTERVAL,
+        );
+        assert_eq!(wait, Duration::ZERO);
+    }
+
+    /// `compute_wait` caps at the remaining poll interval when a
+    /// periodic poll is configured and closer than the shutdown
+    /// interval.
+    #[test]
+    fn compute_wait_caps_at_remaining_poll_interval() {
+        let now = Instant::now();
+        // last poll 40ms ago, interval is 100ms → 60ms remaining.
+        let last_poll = now - Duration::from_millis(40);
+        let wait = compute_wait(
+            now,
+            None,
+            TEST_DEBOUNCE,
+            Some((TEST_POLL_INTERVAL, last_poll)),
+            SHUTDOWN_POLL_INTERVAL,
+        );
+        assert!(
+            wait <= Duration::from_millis(60) && wait >= Duration::from_millis(59),
+            "expected ~60ms remaining, got {wait:?}"
+        );
+    }
+
+    /// `compute_wait` picks the smallest deadline among all sources —
+    /// here debounce remaining (10ms) beats poll remaining (50ms) and
+    /// shutdown_interval (1000ms).
+    #[test]
+    fn compute_wait_picks_smallest_constraint() {
+        let now = Instant::now();
+        let pending = now - Duration::from_millis(40); // 10ms remaining
+        let last_poll = now - Duration::from_millis(50); // 50ms remaining
+        let wait = compute_wait(
+            now,
+            Some(pending),
+            TEST_DEBOUNCE,
+            Some((TEST_POLL_INTERVAL, last_poll)),
+            SHUTDOWN_POLL_INTERVAL,
+        );
+        assert!(
+            wait <= Duration::from_millis(10) && wait >= Duration::from_millis(9),
+            "expected ~10ms (debounce remaining), got {wait:?}"
+        );
+    }
+
+    /// A pre-set shutdown_flag causes [`run`] to exit on the very
+    /// first iteration without ever calling `poll` or `on_sync`.
+    #[test]
+    fn run_exits_immediately_when_shutdown_flag_already_set() {
+        let flag = Arc::new(AtomicBool::new(true));
+        let mut counter = SyncCounter::new();
+        let mut poller = ScriptedPoller::new([Some(WatcherEvent::SyncCandidate)]);
+        let config = DaemonConfig {
+            debounce: TEST_DEBOUNCE,
+            poll_interval: None,
+            shutdown_flag: flag,
+        };
+        run(config, |t| poller.poll(t), || counter.record());
+        assert_eq!(counter.count, 0);
+    }
+
+    /// Mid-loop: a `ShutdownRequested` event causes [`run`] to exit
+    /// without firing the sync that the SyncCandidate before it had
+    /// queued. (Test models the case where shutdown beats the
+    /// debounce window.)
+    #[test]
+    fn run_exits_on_shutdown_event_before_window_expires() {
+        let mut counter = SyncCounter::new();
+        let mut poller = ScriptedPoller::new([
+            Some(WatcherEvent::SyncCandidate),
+            Some(WatcherEvent::ShutdownRequested),
+        ]);
+        let config = test_config(TEST_DEBOUNCE);
+        run(config, |t| poller.poll(t), || counter.record());
+        assert_eq!(counter.count, 0, "shutdown beat the debounce window");
+    }
+
+    /// A single SyncCandidate followed by a None (which makes the
+    /// poller sleep the debounce window) → exactly one sync fires
+    /// once the window elapses uninterrupted.
+    #[test]
+    fn run_fires_one_sync_after_single_event_when_window_elapses() {
+        let mut counter = SyncCounter::new();
+        let mut poller = ScriptedPoller::new([
+            Some(WatcherEvent::SyncCandidate),
+            None, // sleeps `wait` (~ debounce window) — daemon then fires
+        ]);
+        let config = test_config(TEST_DEBOUNCE);
+        run(config, |t| poller.poll(t), || counter.record());
+        assert_eq!(counter.count, 1);
+    }
+
+    /// A burst of three SyncCandidates (delivered back-to-back, all
+    /// within one debounce window) followed by a None must collapse
+    /// into a single sync. Trailing-edge semantic: each event extends
+    /// the window; the window only fires after a full uninterrupted
+    /// quiet stretch.
+    #[test]
+    fn run_collapses_burst_into_single_sync() {
+        let mut counter = SyncCounter::new();
+        let mut poller = ScriptedPoller::new([
+            Some(WatcherEvent::SyncCandidate),
+            Some(WatcherEvent::SyncCandidate),
+            Some(WatcherEvent::SyncCandidate),
+            None,
+        ]);
+        let config = test_config(TEST_DEBOUNCE);
+        run(config, |t| poller.poll(t), || counter.record());
+        assert_eq!(counter.count, 1, "burst must collapse into one sync");
+    }
+
+    /// Two bursts separated by a None (which makes the poller sleep
+    /// the full debounce window between them, so the first burst
+    /// fires before the second starts) → exactly two syncs.
+    #[test]
+    fn run_separate_bursts_fire_separate_syncs() {
+        let mut counter = SyncCounter::new();
+        let mut poller = ScriptedPoller::new([
+            Some(WatcherEvent::SyncCandidate),
+            None, // sleep debounce, fire sync #1
+            Some(WatcherEvent::SyncCandidate),
+            None, // sleep debounce, fire sync #2
+        ]);
+        let config = test_config(TEST_DEBOUNCE);
+        run(config, |t| poller.poll(t), || counter.record());
+        assert_eq!(counter.count, 2);
+    }
+
+    /// Periodic-poll-only: no events ever delivered, but a periodic
+    /// poll interval is configured. After the interval elapses the
+    /// safety-net poll fires `on_sync`. Pins the periodic-poll path
+    /// independent of the debounce path.
+    #[test]
+    fn run_fires_periodic_poll_when_interval_elapses_without_events() {
+        let mut counter = SyncCounter::new();
+        // One None to advance wall-clock past the poll interval, then
+        // SCRIPT_END terminates the loop. The None's sleep is bounded
+        // by `compute_wait`, which here returns at most
+        // TEST_POLL_INTERVAL (since shutdown_interval is much larger).
+        let mut poller = ScriptedPoller::new([None]);
+        let config = DaemonConfig {
+            debounce: TEST_DEBOUNCE,
+            poll_interval: Some(TEST_POLL_INTERVAL),
+            shutdown_flag: Arc::new(AtomicBool::new(false)),
+        };
+        run(config, |t| poller.poll(t), || counter.record());
+        assert_eq!(counter.count, 1, "periodic poll must fire once");
+    }
+
+    /// Setting the shutdown flag from a side-thread mid-loop causes
+    /// [`run`] to exit on its next iteration. Models the SIGINT path
+    /// (Task 8) without depending on signal-hook.
+    #[test]
+    fn run_exits_when_shutdown_flag_flips_mid_loop() {
+        let flag = Arc::new(AtomicBool::new(false));
+        let flag_clone = flag.clone();
+        let mut counter = SyncCounter::new();
+        // Script is two Nones so the poller sleeps for two
+        // SHUTDOWN_POLL_INTERVAL-bounded waits; the side thread flips
+        // the flag during the first sleep. The loop catches it at the
+        // top of the next iteration.
+        let mut poller = ScriptedPoller::new([None, None]);
+        let config = DaemonConfig {
+            debounce: TEST_DEBOUNCE,
+            poll_interval: None,
+            shutdown_flag: flag,
+        };
+        let handle = std::thread::spawn(move || {
+            std::thread::sleep(Duration::from_millis(20));
+            flag_clone.store(true, Ordering::SeqCst);
+        });
+        run(config, |t| poller.poll(t), || counter.record());
+        handle.join().expect("flag-setter joined");
+        assert_eq!(counter.count, 0);
+    }
+
+    /// A bare `PollTick` event is delivered (some test sources might
+    /// inject it) — the loop ignores it (handled via the periodic
+    /// poll check, not via the `poll` return). Pins that the variant
+    /// match doesn't accidentally trigger a sync.
+    #[test]
+    fn run_ignores_polltick_event_from_poll() {
+        let mut counter = SyncCounter::new();
+        let mut poller = ScriptedPoller::new([Some(WatcherEvent::PollTick)]);
+        let config = test_config(TEST_DEBOUNCE);
+        run(config, |t| poller.poll(t), || counter.record());
+        assert_eq!(counter.count, 0);
+    }
+
+    /// `now_ms` returns a plausible UNIX-epoch millisecond value —
+    /// must be ≥ 2024-01-01 in ms (1_700_000_000_000) and ≤ year-3000
+    /// upper bound. Sanity check that the helper isn't off by orders
+    /// of magnitude.
+    #[test]
+    fn now_ms_returns_plausible_unix_timestamp() {
+        let ms = now_ms();
+        // 2024-01-01 UTC in ms.
+        const FLOOR_MS: u64 = 1_700_000_000_000;
+        // Year 3000 in ms — wildly future, but rules out u64::MAX
+        // saturation or seconds-vs-ms unit confusion.
+        const CEILING_MS: u64 = 32_503_680_000_000;
+        assert!(ms >= FLOOR_MS, "now_ms below floor: {ms}");
+        assert!(ms <= CEILING_MS, "now_ms above ceiling: {ms}");
+    }
+
+    /// `notify_start_to_sync_error` wraps a notify error in
+    /// `SyncError::Vault(VaultError::Io)` with the documented
+    /// context string. Pins the mapping so callers can rely on the
+    /// `context` value for log-grepping.
+    #[test]
+    fn notify_start_to_sync_error_maps_to_vault_io_with_context() {
+        let notify_err = notify::Error::path_not_found();
+        let err = notify_start_to_sync_error(notify_err);
+        match err {
+            SyncError::Vault(secretary_core::vault::VaultError::Io { context, .. }) => {
+                assert_eq!(context, "notify watcher start failed");
+            }
+            other => panic!("expected SyncError::Vault(VaultError::Io {{..}}), got {other:?}"),
+        }
+    }
+}

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -9,6 +9,7 @@
 //! Spec: [`docs/superpowers/specs/2026-05-23-c2-headless-sync-cli-design.md`](../../docs/superpowers/specs/2026-05-23-c2-headless-sync-cli-design.md).
 
 pub mod args;
+pub mod daemon;
 pub mod exit;
 pub mod pipeline;
 pub mod state;

--- a/cli/src/watcher/mod.rs
+++ b/cli/src/watcher/mod.rs
@@ -13,11 +13,12 @@
 //!   into one scheduled `SyncCandidate` per `--debounce-ms` window.
 //!
 //! The [`notify::RecommendedWatcher`](https://docs.rs/notify) integration
-//! that produces the actual event stream lives in
-//! `cli/src/watcher/notify_driver.rs` (Task 7) and consumes both pure
-//! pieces through a [`WatcherEvent`]-emitting driver.
+//! that produces the actual event stream lives in [`notify_driver`]
+//! (Task 7) and consumes both pure pieces through a
+//! [`WatcherEvent`]-emitting driver.
 
 pub mod debounce;
+pub mod notify_driver;
 pub mod ready;
 
 /// What the watcher dispatcher tells the [`crate::pipeline::run_one`]

--- a/cli/src/watcher/notify_driver.rs
+++ b/cli/src/watcher/notify_driver.rs
@@ -1,0 +1,291 @@
+//! [`notify::RecommendedWatcher`] wrapper that surfaces filesystem
+//! activity to the daemon loop as [`super::WatcherEvent`] values.
+//!
+//! Spec: [`docs/superpowers/specs/2026-05-23-c2-headless-sync-cli-design.md`](../../../docs/superpowers/specs/2026-05-23-c2-headless-sync-cli-design.md)
+//! §D3 (events + debounce + optional poll).
+//!
+//! The driver is intentionally thin:
+//!
+//! - It owns the underlying `notify` watcher (so its OS resources stay
+//!   alive for the daemon's lifetime).
+//! - [`NotifyWatcher::poll`] blocks the calling thread for at most
+//!   `timeout`. On a sync-relevant filesystem event it returns
+//!   [`WatcherEvent::SyncCandidate`]; on timeout (or an event we filter
+//!   out) it returns `None`.
+//! - Burst coalescing is a single drain pass on the channel after the
+//!   first relevant event — the daemon loop's trailing-edge debounce
+//!   (see [`super::debounce::step`]) does the heavy lifting of
+//!   collapsing repeated events into a single sync attempt.
+//!
+//! [`super::WatcherEvent::PollTick`] and
+//! [`super::WatcherEvent::ShutdownRequested`] are **not** produced by
+//! this driver — both are state-driven concerns handled by the daemon
+//! loop directly (a periodic-poll timer and an [`std::sync::atomic`]
+//! shutdown flag, respectively). The daemon's tests inject synthetic
+//! `ShutdownRequested` events through a closure-shaped poller; the
+//! production driver never emits them.
+
+use std::path::Path;
+use std::sync::mpsc::{channel, Receiver, RecvTimeoutError, TryRecvError};
+use std::time::Duration;
+
+use notify::{Event, EventKind, RecommendedWatcher, RecursiveMode, Watcher};
+
+use super::ready::matches_partial_pattern;
+use super::WatcherEvent;
+
+/// Owns the [`RecommendedWatcher`] and its event receiver. Dropping a
+/// [`NotifyWatcher`] tears down the OS-level subscription via
+/// `notify`'s `Drop` impl.
+pub struct NotifyWatcher {
+    /// Held to keep the OS subscription alive; never read after
+    /// construction. The leading underscore silences the unused-field
+    /// lint while documenting intent.
+    _watcher: RecommendedWatcher,
+    rx: Receiver<notify::Result<Event>>,
+}
+
+impl NotifyWatcher {
+    /// Begin watching `folder` recursively. Subsequent calls to
+    /// [`Self::poll`] surface any filesystem activity that
+    /// [`is_sync_relevant`] accepts.
+    ///
+    /// # Errors
+    ///
+    /// Bubbles up [`notify::Error`] from the underlying
+    /// [`notify::recommended_watcher`] / [`Watcher::watch`] calls.
+    /// Typical causes: missing directory, permission denied, inotify
+    /// limits exhausted on Linux.
+    pub fn start(folder: &Path) -> notify::Result<Self> {
+        let (tx, rx) = channel();
+        let mut watcher = notify::recommended_watcher(move |res| {
+            // `mpsc::Sender::send` errors only when the receiver has
+            // been dropped — which only happens after the daemon loop
+            // exits and `NotifyWatcher` is being dropped. At that point
+            // event delivery is irrelevant; silently discard.
+            let _ = tx.send(res);
+        })?;
+        watcher.watch(folder, RecursiveMode::Recursive)?;
+        Ok(Self {
+            _watcher: watcher,
+            rx,
+        })
+    }
+
+    /// Block up to `timeout`, then return:
+    ///
+    /// - `Some(WatcherEvent::SyncCandidate)` if at least one
+    ///   sync-relevant event arrived before the deadline.
+    /// - `None` on timeout, channel disconnect, a `notify`-level error,
+    ///   or a stream of exclusively non-relevant events (e.g. file
+    ///   accesses).
+    ///
+    /// On a relevant first event, the method drains any
+    /// immediately-pending events from the channel before returning,
+    /// collapsing a burst into a single signal. This is **not** a
+    /// debounce — that lives in [`super::debounce::step`], driven by
+    /// the daemon loop. The drain just spares the daemon the cost of
+    /// looping once per queued event for a burst that the platform
+    /// has already coalesced into the channel.
+    pub fn poll(&self, timeout: Duration) -> Option<WatcherEvent> {
+        // Wait up to `timeout` for the FIRST event. Treat any of
+        // timeout / disconnect / notify-level error as "no event".
+        let first = match self.rx.recv_timeout(timeout) {
+            Ok(Ok(event)) => event,
+            Ok(Err(_notify_err)) => return None,
+            Err(RecvTimeoutError::Timeout | RecvTimeoutError::Disconnected) => return None,
+        };
+
+        let mut any_relevant = is_sync_relevant(&first);
+
+        // Drain whatever else is already queued. Each one updates
+        // `any_relevant` so a relevant event later in the burst still
+        // surfaces even if the first one was filtered out.
+        loop {
+            match self.rx.try_recv() {
+                Ok(Ok(event)) => {
+                    if is_sync_relevant(&event) {
+                        any_relevant = true;
+                    }
+                }
+                Ok(Err(_notify_err)) => continue,
+                Err(TryRecvError::Empty | TryRecvError::Disconnected) => break,
+            }
+        }
+
+        if any_relevant {
+            Some(WatcherEvent::SyncCandidate)
+        } else {
+            None
+        }
+    }
+}
+
+/// Pure predicate: does this `notify` event represent a content change
+/// that might warrant a sync attempt?
+///
+/// Returns `false` when:
+///
+/// - The event kind is [`EventKind::Access`] (file read — not a change).
+/// - Every path in the event matches the canonical partial-download
+///   filename table (see [`matches_partial_pattern`]). This is the
+///   spec §D6 partial-download gate at the watcher layer — a
+///   `*.icloud` write should never trigger a debounce window.
+///
+/// Returns `true` otherwise. [`EventKind::Any`] and
+/// [`EventKind::Other`] are conservatively treated as relevant — Any
+/// is notify's catch-all when it couldn't classify the underlying OS
+/// event, and Other is a platform-specific signal we don't model in
+/// detail. False positives here cost a wasted sync attempt; false
+/// negatives risk silently missing a real change.
+///
+/// Events with no paths attached are also conservatively relevant —
+/// some platforms surface change notifications without specific paths.
+fn is_sync_relevant(event: &Event) -> bool {
+    if matches!(event.kind, EventKind::Access(_)) {
+        return false;
+    }
+    if event.paths.is_empty() {
+        return true;
+    }
+    !event.paths.iter().all(|p| matches_partial_pattern(p))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use std::time::Duration;
+    use tempfile::TempDir;
+
+    /// Maximum time we wait for `notify` to surface an event in tests.
+    /// 2 s comfortably covers macOS FSEvents' typical ~1 s coalescing
+    /// window plus inotify queue drains on Linux under load.
+    const TEST_POLL_TIMEOUT: Duration = Duration::from_secs(2);
+
+    /// Brief settle before writing into a freshly-started watcher.
+    /// Without this delay, the OS watch registration races the first
+    /// write and notify may not surface that initial event on macOS.
+    const WATCHER_SETTLE: Duration = Duration::from_millis(100);
+
+    /// Smoke test: a write into a freshly-watched folder produces a
+    /// [`WatcherEvent::SyncCandidate`] on the next poll.
+    ///
+    /// This is the cross-platform sanity check that the
+    /// `notify`-backed driver is wired correctly. A more elaborate
+    /// per-OS quirk suite (FSEvents coalescing, inotify queue
+    /// overflow) lives in `cli/tests/notify_quirk.rs` (Task 10).
+    #[test]
+    fn writing_a_file_surfaces_a_sync_candidate() {
+        let dir = TempDir::new().expect("tempdir");
+        let watcher = NotifyWatcher::start(dir.path()).expect("watcher start");
+        std::thread::sleep(WATCHER_SETTLE);
+        fs::write(dir.path().join("vault.cbor.enc"), b"hello").expect("write");
+        assert_eq!(
+            watcher.poll(TEST_POLL_TIMEOUT),
+            Some(WatcherEvent::SyncCandidate)
+        );
+    }
+
+    /// `poll` with no events queued returns `None` after the timeout.
+    /// Pinning this guarantees the daemon loop's "did the debounce
+    /// window expire?" check fires reliably — if `poll` ever blocked
+    /// past its timeout under no-event load, the trailing-edge
+    /// debounce semantic would break.
+    #[test]
+    fn poll_returns_none_on_timeout() {
+        let dir = TempDir::new().expect("tempdir");
+        let watcher = NotifyWatcher::start(dir.path()).expect("watcher start");
+        // Some platforms (macOS FSEvents) emit setup events as the
+        // watch is registered against the freshly-created tempdir.
+        // Drain everything that arrives in the first settle window so
+        // the assertion exercises the timeout path, not the
+        // startup-noise path.
+        std::thread::sleep(WATCHER_SETTLE);
+        let _ = watcher.poll(Duration::from_millis(10));
+        // Quiet folder + short timeout — must come back as None.
+        assert_eq!(watcher.poll(Duration::from_millis(50)), None);
+    }
+
+    /// Access-only events (file reads) are filtered out — only
+    /// changes surface as sync candidates.
+    ///
+    /// We construct a synthetic [`Event`] with [`EventKind::Access`]
+    /// and check the predicate directly; building a real Access event
+    /// through notify is platform-dependent and noisy.
+    #[test]
+    fn access_events_are_filtered_by_relevance_predicate() {
+        use notify::event::{AccessKind, Event, EventKind};
+        let access = Event {
+            kind: EventKind::Access(AccessKind::Read),
+            paths: Vec::new(),
+            attrs: Default::default(),
+        };
+        assert!(!is_sync_relevant(&access));
+    }
+
+    /// `Modify` events are treated as sync-relevant — the most
+    /// common kind from text-editor saves. Companion test to
+    /// `access_events_are_filtered_by_relevance_predicate`: pins
+    /// the inverse direction of the predicate.
+    #[test]
+    fn modify_events_are_relevant() {
+        use notify::event::{Event, EventKind, ModifyKind};
+        let modify = Event {
+            kind: EventKind::Modify(ModifyKind::Any),
+            paths: Vec::new(),
+            attrs: Default::default(),
+        };
+        assert!(is_sync_relevant(&modify));
+    }
+
+    /// An event whose paths all match the partial-download pattern
+    /// table (`.icloud`, `.tmp`, etc.) is filtered as not-sync-relevant.
+    /// This is the spec §D6 partial-download gate at the watcher
+    /// layer — touching a partial file should not trip the debounce
+    /// window.
+    #[test]
+    fn partial_marker_paths_are_filtered() {
+        use notify::event::{Event, EventKind, ModifyKind};
+        use std::path::PathBuf;
+        let partial = Event {
+            kind: EventKind::Modify(ModifyKind::Any),
+            paths: vec![PathBuf::from("/vault/.foo.icloud")],
+            attrs: Default::default(),
+        };
+        assert!(!is_sync_relevant(&partial));
+    }
+
+    /// An event with a mix of partial + real paths is still relevant —
+    /// the real path warrants a sync attempt. Pins the "all paths
+    /// must match" semantic of the filter.
+    #[test]
+    fn mixed_partial_and_real_paths_are_relevant() {
+        use notify::event::{Event, EventKind, ModifyKind};
+        use std::path::PathBuf;
+        let mixed = Event {
+            kind: EventKind::Modify(ModifyKind::Any),
+            paths: vec![
+                PathBuf::from("/vault/.foo.icloud"),
+                PathBuf::from("/vault/manifest.toml"),
+            ],
+            attrs: Default::default(),
+        };
+        assert!(is_sync_relevant(&mixed));
+    }
+
+    /// An event with no paths attached is conservatively relevant —
+    /// some platforms surface change notifications without specific
+    /// paths and we'd rather sync on a false positive than miss a
+    /// real change.
+    #[test]
+    fn pathless_events_are_relevant() {
+        use notify::event::{Event, EventKind, ModifyKind};
+        let pathless = Event {
+            kind: EventKind::Modify(ModifyKind::Any),
+            paths: Vec::new(),
+            attrs: Default::default(),
+        };
+        assert!(is_sync_relevant(&pathless));
+    }
+}

--- a/cli/src/watcher/notify_driver.rs
+++ b/cli/src/watcher/notify_driver.rs
@@ -87,13 +87,24 @@ impl NotifyWatcher {
     /// the daemon loop. The drain just spares the daemon the cost of
     /// looping once per queued event for a burst that the platform
     /// has already coalesced into the channel.
+    ///
+    /// A `Disconnected` channel is logged at error level — it should
+    /// be impossible (the `_watcher` field holds the sender alive for
+    /// our entire lifetime) but if it ever fires, the daemon would
+    /// silently stop receiving events. The error log makes that
+    /// detectable in operator logs.
     pub fn poll(&self, timeout: Duration) -> Option<WatcherEvent> {
-        // Wait up to `timeout` for the FIRST event. Treat any of
-        // timeout / disconnect / notify-level error as "no event".
+        // Wait up to `timeout` for the FIRST event.
         let first = match self.rx.recv_timeout(timeout) {
             Ok(Ok(event)) => event,
             Ok(Err(_notify_err)) => return None,
-            Err(RecvTimeoutError::Timeout | RecvTimeoutError::Disconnected) => return None,
+            Err(RecvTimeoutError::Timeout) => return None,
+            Err(RecvTimeoutError::Disconnected) => {
+                tracing::error!(
+                    "notify watcher channel disconnected; daemon will receive no further filesystem events"
+                );
+                return None;
+            }
         };
 
         let mut any_relevant = is_sync_relevant(&first);
@@ -109,7 +120,13 @@ impl NotifyWatcher {
                     }
                 }
                 Ok(Err(_notify_err)) => continue,
-                Err(TryRecvError::Empty | TryRecvError::Disconnected) => break,
+                Err(TryRecvError::Empty) => break,
+                Err(TryRecvError::Disconnected) => {
+                    tracing::error!(
+                        "notify watcher channel disconnected mid-drain; daemon will receive no further filesystem events"
+                    );
+                    break;
+                }
             }
         }
 
@@ -145,6 +162,10 @@ fn is_sync_relevant(event: &Event) -> bool {
     if matches!(event.kind, EventKind::Access(_)) {
         return false;
     }
+    // Explicit early return for the empty-paths case: `iter().all(_)`
+    // is vacuously `true` on an empty iterator, which would invert to
+    // `false` below — opposite of the documented "pathless events are
+    // conservatively relevant" semantic. Don't fold this check away.
     if event.paths.is_empty() {
         return true;
     }

--- a/docs/handoffs/2026-05-25-c2-task-7-notify-driver-daemon-shipped.md
+++ b/docs/handoffs/2026-05-25-c2-task-7-notify-driver-daemon-shipped.md
@@ -1,6 +1,6 @@
 # NEXT_SESSION.md — C.2 Task 7 (`notify_driver` + `daemon` loop) shipped
 
-**Session date:** 2026-05-25 (C.2 Task 7 — `cli/src/watcher/notify_driver.rs` + `cli/src/daemon.rs`: the `notify::RecommendedWatcher` event source plus the closure-shaped daemon orchestration loop. Pure-orchestration core + production composition helper. No `main.rs` hook — that lands in Task 9 once signal handling (Task 8) is wired.).
+**Session date:** 2026-05-25 (C.2 Task 7 — `cli/src/watcher/notify_driver.rs` + `cli/src/daemon.rs`: the `notify::RecommendedWatcher` event source plus the closure-shaped daemon orchestration loop. Pure-orchestration core + production composition helper. No `main.rs` hook — that lands in Task 9 once signal handling (Task 8) is wired.). **Updated 2026-05-26** to absorb PR-review fixup pass (5 issues addressed in-place, 2 deferred to GitHub issues #122 + #123).
 **Status:** C.2 Task 7 ✅ on branch `feature/c2-task-7`; PR pending. Tasks 8-10 queued.
 
 ## (1) What we shipped this session
@@ -14,7 +14,22 @@ One commit on `feature/c2-task-7` carrying the seventh code slice of C.2 — the
 | Watcher submodule wiring | [`cli/src/watcher/mod.rs`](../../cli/src/watcher/mod.rs) | One-line addition (`pub mod notify_driver;`) next to the existing `debounce` and `ready` re-exports. The submodule's doc comment cross-reference to "Task 7" now resolves intra-crate. |
 | Library surface wiring | [`cli/src/lib.rs`](../../cli/src/lib.rs) | One-line addition (`pub mod daemon;`) next to the existing `args`, `exit`, `pipeline`, `state`, `unlock`, `veto`, `watcher` re-exports. Production consumers reach the daemon under `secretary_cli::daemon::*`. |
 
-**Commit:** `C.2 Task 7 — notify driver + daemon event loop` (see `git log feature/c2-task-7` for the local pre-merge SHA; the post-squash-merge SHA on `main` will differ). 22 new tests across the two new modules (7 notify_driver + 15 daemon); workspace 904 → 926. No issue closes with this commit; #37 (Sub-project C umbrella) advances by one more C.2 slice.
+**Commit:** `C.2 Task 7 — notify driver + daemon event loop` (see `git log feature/c2-task-7` for the local pre-merge SHA; the post-squash-merge SHA on `main` will differ). A follow-up review-fixup commit lands on the same branch (see §"Review fixup pass" below). 25 new tests across the two new modules after the fixup (7 notify_driver + 18 daemon); workspace 904 → 929. No issue closes with this commit; #37 (Sub-project C umbrella) advances by one more C.2 slice. Two follow-up issues filed: #122 (daemon.rs ~770 LOC — consider directory module split) and #123 (test timing-flake mitigation).
+
+### Review fixup pass (2026-05-26)
+
+Code review surfaced six observations on the initial commit; five were addressed in-place on `feature/c2-task-7` as a follow-up fixup commit, two filed as deferred GitHub issues. All five in-place fixes are self-contained, do not change the public API beyond the documented `DaemonConfig` additions, and ship with new unit tests where applicable.
+
+| Review issue | Resolution | Where |
+|---|---|---|
+| `is_sync_relevant` — `paths.is_empty()` early return relies on vacuous-truth gotcha that a "simplifying" reader might fold away. | Added a four-line comment explaining the inverted vacuous-`all()` semantic and that the explicit early return must stay. | [`cli/src/watcher/notify_driver.rs`](../../cli/src/watcher/notify_driver.rs) `is_sync_relevant`. |
+| `NotifyWatcher::poll` swallows `RecvTimeoutError::Disconnected` and `TryRecvError::Disconnected` silently — should be impossible (the `_watcher` sender stays alive) but if it ever fires, the daemon would stop receiving events with no signal. | Both Disconnected arms now emit `tracing::error!` before returning. Different message text per call site so the operator can tell which path tripped. | [`cli/src/watcher/notify_driver.rs`](../../cli/src/watcher/notify_driver.rs) `NotifyWatcher::poll`. |
+| `SHUTDOWN_POLL_INTERVAL` was a module-private const; tests had to pay the full 1 s per loop iteration, which slowed `run_exits_when_shutdown_flag_flips_mid_loop` to ~2 s. Future signal-handler work might also want to tune it. | Renamed to `pub const DEFAULT_SHUTDOWN_POLL_INTERVAL` and added `DaemonConfig::shutdown_poll_interval: Duration` field. Tests override to `TEST_SHUTDOWN_INTERVAL = 200 ms` (constrained `≥ TEST_POLL_INTERVAL` so it never fragments scripted `None` slots). A `debug_assert!` in `run_against_vault` rejects zero to flag misconfiguration that would otherwise busy-spin the watcher. | [`cli/src/daemon.rs`](../../cli/src/daemon.rs) `DaemonConfig`, `run_against_vault`. |
+| `run_against_vault`'s `wait_for_ready → Ok(false)` path logged at debug-only — a continuously-modified vault folder would silently never sync. | Added a saturating-counter `consecutive_not_ready: u32` captured in the `on_sync` closure; resets on `Ok(true)`. New `pub const READY_NOT_READY_WARN_THRESHOLD: u32 = 5` and a pure helper `note_not_ready_and_should_warn` extracted for unit-testability. A single `tracing::warn!` fires exactly once at the threshold and stays silent on subsequent skips until the next successful `Ok(true)` resets the counter. 3 new unit tests pin the fire-once-at-threshold + reset + u32::MAX-saturation semantics. | [`cli/src/daemon.rs`](../../cli/src/daemon.rs) `READY_NOT_READY_WARN_THRESHOLD`, `note_not_ready_and_should_warn`, `run_against_vault::on_sync`. |
+| `daemon.rs` at 641 LOC was already over the 500-LOC threshold; the fixup pass adds another ~130 LOC, taking it to ~770. Splitting requires non-trivial restructure. | Filed as [#122](https://github.com/hherb/secretary/issues/122) for follow-up — directory-module candidate shape proposed but no immediate action. Inline-tests pattern matches the rest of the `cli/` crate, so the threshold is a soft signal rather than a blocker. | Tracked, not in-scope. |
+| Behavioural daemon tests use 50–200 ms wall-clock windows — could flake under loaded CI runners. | Filed as [#123](https://github.com/hherb/secretary/issues/123) with the symptom signature + mitigation (bump constants 2–4×). No flake observed; speculative. | Tracked, not in-scope. |
+
+Gauntlet on close-of-fixup: **PASSED: 929 FAILED: 0 IGNORED: 10**, clippy + fmt + conformance + spec-freshness all clean.
 
 ### Plan ↔ reality reconciliations
 
@@ -28,21 +43,21 @@ Three deliberate deviations from the plan, all validated up-front via a brainsto
 
 Plan also said "Hook the `run` subcommand's stub in `cli/src/main.rs` to `daemon::run`" — deferred to Task 9 (subcommand dispatch wiring). `main.rs` still stubs through to `eprintln!("secretary-sync run: not yet implemented")` because the full wire-up requires `unlock` + `state::load` + `state::acquire_lockfile` orchestration that Task 9 is scoped to assemble. Without signal handling (Task 8) the daemon also can't be cleanly Ctrl-C'd from `main.rs`, so hooking it now would ship a non-Ctrl-C-stoppable binary. The handoff acceptance criterion was aspirational; the plan's literal Steps 1-3 don't include `main.rs` changes either. Task 8 + Task 9 together do the real wire-up.
 
-The plan estimated 2 new tests (1 notify_driver smoke + 1 daemon compile-shape) for a workspace bump of 854 → 856. The 854 baseline was stale (drifted from the actual 904 in Task 6 close), and the 2-test estimate was tied to the now-rejected compile-only stub. Actual: **22 new tests** (7 notify_driver + 15 daemon); workspace **904 → 926**.
+The plan estimated 2 new tests (1 notify_driver smoke + 1 daemon compile-shape) for a workspace bump of 854 → 856. The 854 baseline was stale (drifted from the actual 904 in Task 6 close), and the 2-test estimate was tied to the now-rejected compile-only stub. Actual after the 2026-05-26 fixup pass: **25 new tests** (7 notify_driver + 18 daemon); workspace **904 → 929**.
 
 ### Gauntlet snapshot at session close
 
 ```
-PASSED: 926 FAILED: 0 IGNORED: 10
+PASSED: 929 FAILED: 0 IGNORED: 10
 clippy --release --workspace --tests -- -D warnings   clean
 fmt --all -- --check                                  clean
 uv run core/tests/python/conformance.py               PASS
 uv run core/tests/python/spec_test_name_freshness.py  PASS (96 resolved / 0 unresolved / 2 suppressed)
 ```
 
-Baseline 904 came from Task 6 close. Task 7 added 22 new tests:
+Baseline 904 came from Task 6 close. Task 7 added 25 new tests (after the 2026-05-26 review-fixup pass):
 - `watcher::notify_driver::tests::*` — 7 tests (5 predicate-level + 2 against a real `notify` watcher).
-- `daemon::tests::*` — 15 tests (5 `compute_wait` pure-function + 8 `run` behavioural + 1 `now_ms` plausibility + 1 `notify_start_to_sync_error` mapping pin).
+- `daemon::tests::*` — 18 tests (5 `compute_wait` pure-function + 8 `run` behavioural + 3 `note_not_ready_and_should_warn` semantic pins added in the fixup pass + 1 `now_ms` plausibility + 1 `notify_start_to_sync_error` mapping pin).
 
 ## (2) What's next — start C.2 Task 8
 
@@ -54,7 +69,7 @@ After this PR merges, the next slice is **C.2 Task 8: logging + signal handling 
 - [ ] New `cli/src/signal.rs` (~60–100 LOC): exposes `install_shutdown_handler() -> Arc<AtomicBool>` using `signal-hook` (already in `cli/Cargo.toml`). Hooks SIGINT + SIGTERM; flips the flag the daemon already polls (`DaemonConfig::shutdown_flag`).
 - [ ] New `cli/src/lib.rs` lines: `pub mod logging;` + `pub mod signal;` (Task 5 established the lib.rs pattern; Tasks 6 + 7 added `watcher` + `daemon`; Task 8 adds two more).
 - [ ] Unit tests: logging — at minimum, EnvFilter parses from `--verbose=N` correctly; signal — register / un-register without leaking the handler, and the flag flips on a synthetic signal raise (test-only). The signal harness is the trickier bit because Rust's test runner already installs its own signal handlers; gate signal-handler tests behind `cfg(test)` + a one-test-at-a-time discipline (no `#[test(parallel = false)]` available, but `signal-hook` itself supports installing-and-uninstalling cleanly so tests can be careful).
-- [ ] Gauntlet target: **PASSED: 926 + N FAILED: 0 IGNORED: 10**. Absolute base is now 926 (bumped from 904 by Task 7's 22 new tests).
+- [ ] Gauntlet target: **PASSED: 929 + N FAILED: 0 IGNORED: 10**. Absolute base is now 929 (bumped from 904 by Task 7's 22 original new tests + 3 added in the 2026-05-26 fixup pass).
 - [ ] Clippy, fmt, conformance, spec freshness all clean.
 
 ### Plan handoff
@@ -68,7 +83,8 @@ Full step-by-step in [`docs/superpowers/plans/2026-05-23-c2-headless-sync-cli.md
 - **`daemon::run` is closure-shaped (`P: FnMut(Duration) → Option<WatcherEvent>`, `S: FnMut()`), not trait-driven.** Pure functions in reusable modules per project preference. The closure shape lets tests inject a `ScriptedPoller` + a `SyncCounter` without `Box<dyn ...>` overhead or a `MockEventSource` struct, and lets the production composition (`run_against_vault`) inline the `NotifyWatcher::poll` and `wait_for_ready` + `run_one` calls without an indirection.
 - **Trailing-edge debounce in the daemon honours Task 6's documented semantic.** The redesign uses `poll`'s timeout as the debounce timer; the previous plan's `std::thread::sleep` degraded to leading-edge-with-burst-coalescing and would have rendered Task 6's 5 trailing-edge unit tests semantically misleading.
 - **`compute_wait` is a pure free function pulled out of the loop body.** Smallest-of three deadlines (remaining debounce, remaining poll interval, shutdown poll interval). Five pure unit tests pin it against drift — independently of the harder-to-test loop body.
-- **`SHUTDOWN_POLL_INTERVAL = 1 s` is the loop's worst-case cancellation latency.** Balances operator-visible Ctrl-C responsiveness against per-iteration overhead. The flag is checked at every loop iteration, and `poll` blocks at most this long when nothing else (debounce / periodic poll) is closer.
+- **`DEFAULT_SHUTDOWN_POLL_INTERVAL = 1 s` is the loop's default worst-case cancellation latency.** Balances operator-visible Ctrl-C responsiveness against per-iteration overhead. The flag is checked at every loop iteration, and `poll` blocks at most this long when nothing else (debounce / periodic poll) is closer. **Per-instance override** lives on `DaemonConfig::shutdown_poll_interval: Duration` (introduced by the 2026-05-26 fixup pass); tests set it to 200 ms so flag-flip assertions complete in well under a second. A `debug_assert!` in `run_against_vault` rejects zero to flag misconfiguration that would busy-spin the watcher.
+- **`READY_NOT_READY_WARN_THRESHOLD = 5` consecutive `wait_for_ready → Ok(false)` returns trigger a single warn-level log.** Added by the 2026-05-26 fixup pass to surface stuck-folder conditions that would otherwise stay invisible at debug verbosity. The counter resets on the next `Ok(true)`, so a transient stable window followed by another stuck stretch re-fires the warn — one signal per stuck streak. The `note_not_ready_and_should_warn` helper is unit-tested in three places (fire-exactly-once-at-threshold, refire-after-reset, saturate-at-u32::MAX).
 - **`is_sync_relevant` in `notify_driver` filters partial-download patterns at the watcher layer.** `*.icloud` / `*.crdownload` writes never cross into the debounce window. Pairs with Task 6's `ready::matches_partial_pattern` table — same canonical filename list, applied earlier in the pipeline. The handoff acceptance criterion called for "partial-download gate"; this is one half of it (the other half — folder-level size-stability via `wait_for_ready` — runs in `run_against_vault`'s `on_sync` closure).
 - **`run_against_vault` calls `wait_for_ready(vault_folder, &RealClock, ready_window)` before each sync.** Treats the folder's metadata stability as a coarse-grained post-debounce safety check; on macOS / Linux the folder mtime changes with every contents change inside, so a still-changing folder yields `Ok(false)` and the sync is skipped that round. The default `ready_window` is 2000 ms (`RunArgs::ready_window_ms`), which adds latency to each sync attempt — acceptable for v1; if operator complaints surface, `--ready-window-ms 0` is the documented mitigation.
 - **`WatcherEvent::PollTick` is never emitted by the production `NotifyWatcher`.** Only synthetic test event sources produce it. The periodic-poll path is driven by `compute_wait`'s `poll_interval` arm + the top-of-loop `last_poll_at` check, not by a notify-side event. The variant stays in the enum because tests use it to verify the `match` arm is wired correctly.
@@ -96,9 +112,11 @@ Full step-by-step in [`docs/superpowers/plans/2026-05-23-c2-headless-sync-cli.md
 
 ### Issues currently open
 
-- #37 — Sub-project C umbrella. C.2 Tasks 1-6 ✅ in PRs #112, #114, #115, #116, #118, #119; Task 7 pending PR.
+- #37 — Sub-project C umbrella. C.2 Tasks 1-6 ✅ in PRs #112, #114, #115, #116, #118, #119; Task 7 pending PR (#121).
 - #117 — `TtyVetoUx` re-prompt loop has no max-attempts cap. Low-priority defensive-coding fix; still queued, not in scope for Task 8.
 - #120 — `matches_partial_pattern` allocates per call via `to_ascii_lowercase`. Filed during PR #119 review; performance-only, no correctness or security impact. Pick up if a profiler ever flags it; not in scope for Task 8.
+- **#122** — *new* — `cli/src/daemon.rs` at ~770 LOC (post-fixup) is over the 500-LOC threshold. Candidate directory-module shape captured in the issue. Pick up as a standalone cleanup PR or when Task 8/9 add more daemon code.
+- **#123** — *new* — daemon behavioural tests use 50–200 ms wall-clock windows. Speculative CI-flake risk; mitigation (2–4× constant bump) documented. No observed flake yet.
 - #38, #45, #75, #76, #78, #79, #81, #87, #88, #90, #95, #98 — none block C.2 Task 8.
 
 ### Housekeeping note (stale worktrees on disk)
@@ -139,7 +157,7 @@ git status --short                       # expect: clean (modulo NEXT_SESSION.md
 git checkout main
 git pull --ff-only origin main
 
-# Verify gauntlet on fresh main (expect 926 / 0 / 10 — same as session close):
+# Verify gauntlet on fresh main (expect 929 / 0 / 10 — same as session close after the 2026-05-26 fixup pass):
 cargo test --release --workspace --no-fail-fast 2>&1 | grep -E "^test result:" | awk '{passed+=$4; failed+=$6; ignored+=$8} END {print "PASSED:", passed, "FAILED:", failed, "IGNORED:", ignored}'
 cargo clippy --release --workspace --tests -- -D warnings 2>&1 | tail -3
 cargo fmt --all -- --check
@@ -161,7 +179,7 @@ cd .worktrees/c2-task-8
 ## Closing inventory
 
 - **Branch state on close:** `main` at `132e15f` (PR #119 squash-merged). `feature/c2-task-7` carries one commit on top (Task 7 code + tests + handoff + symlink).
-- **Workspace tests on `feature/c2-task-7`:** 926 passed + 10 ignored (904 base + 22 new tests: 7 in `watcher::notify_driver::tests` + 15 in `daemon::tests`). Clippy + fmt + Python conformance + spec freshness all clean.
+- **Workspace tests on `feature/c2-task-7`:** 929 passed + 10 ignored (904 base + 25 new tests: 7 in `watcher::notify_driver::tests` + 18 in `daemon::tests`, including the 3 added in the 2026-05-26 fixup pass). Clippy + fmt + Python conformance + spec freshness all clean.
 - **README.md:** unchanged this session — Task 7 ships internal pure-function scaffolding (no operator-visible surface change yet). The C.2 status line in README still implies "queued"; promoting it to "in progress" is deferred until Task 9 wires the subcommands so `secretary-sync` actually runs.
 - **ROADMAP.md:** unchanged this session — same reason; ROADMAP's progress bar still calls C.2 "queued". Bump deferred to Task 9 close.
 - **CLAUDE.md:** unchanged this session — no new convention; daemon submodule is local to `cli/` and doesn't generalise to repo-wide guidance. (The "trailing-edge debounce" semantic was already captured in Task 6's `cli/src/watcher/debounce.rs` module-level doc.)

--- a/docs/handoffs/2026-05-25-c2-task-7-notify-driver-daemon-shipped.md
+++ b/docs/handoffs/2026-05-25-c2-task-7-notify-driver-daemon-shipped.md
@@ -1,0 +1,173 @@
+# NEXT_SESSION.md — C.2 Task 7 (`notify_driver` + `daemon` loop) shipped
+
+**Session date:** 2026-05-25 (C.2 Task 7 — `cli/src/watcher/notify_driver.rs` + `cli/src/daemon.rs`: the `notify::RecommendedWatcher` event source plus the closure-shaped daemon orchestration loop. Pure-orchestration core + production composition helper. No `main.rs` hook — that lands in Task 9 once signal handling (Task 8) is wired.).
+**Status:** C.2 Task 7 ✅ on branch `feature/c2-task-7`; PR pending. Tasks 8-10 queued.
+
+## (1) What we shipped this session
+
+One commit on `feature/c2-task-7` carrying the seventh code slice of C.2 — the `notify` integration plus the daemon event loop. Two new files under `cli/src/` (one under `cli/src/watcher/`, one at the crate root), plus the wiring lines in [`cli/src/watcher/mod.rs`](../../cli/src/watcher/mod.rs) and [`cli/src/lib.rs`](../../cli/src/lib.rs). The daemon is a single-threaded blocking loop per spec §D3 — no async runtime.
+
+| Artifact | Path | Notes |
+|---|---|---|
+| Notify driver | [`cli/src/watcher/notify_driver.rs`](../../cli/src/watcher/notify_driver.rs) | New (~200 LOC). `NotifyWatcher::start(folder)` wraps `notify::RecommendedWatcher` + `std::sync::mpsc::Receiver`. `NotifyWatcher::poll(timeout) → Option<WatcherEvent>` blocks up to `timeout`, drains an in-channel burst on first relevant event, returns `Some(SyncCandidate)` or `None`. Pure `is_sync_relevant` predicate filters `EventKind::Access` (file reads — not a change) AND events whose paths all match the canonical partial-download table (spec §D6 partial-download gate at the watcher layer). 7 unit tests: 2 against a real watcher (smoke write surfaces SyncCandidate; quiet folder times out as None) + 5 against the predicate (Access filtered; Modify relevant; all-partial filtered; mixed partial+real relevant; pathless events relevant). |
+| Daemon loop | [`cli/src/daemon.rs`](../../cli/src/daemon.rs) | New (~460 LOC including tests; ~210 LOC of code + ~250 LOC of tests). `run<P, S>(config, poll, on_sync)` is pure orchestration — `P: FnMut(Duration) -> Option<WatcherEvent>` is the event source, `S: FnMut()` is the sync action. Unit tests drive the loop with a `ScriptedPoller` (scripts events; sleeps the timeout when the slot is `None` so real wall-clock advances the deadlines) and a `SyncCounter` (records fires). `run_against_vault(...)` is the production composition helper: starts a `NotifyWatcher`, then calls `run` with closures that do `wait_for_ready` → `run_one` per fire. `compute_wait` is a pure free function picking the smallest of (remaining debounce window, remaining poll interval, shutdown poll interval). 15 unit tests: 5 for `compute_wait`, 8 for `run` (immediate-shutdown / shutdown-event / single-event / burst-collapse / separate-bursts / periodic-poll / mid-loop-flag-flip / polltick-ignored), 1 for `now_ms`, 1 for `notify_start_to_sync_error`. |
+| Watcher submodule wiring | [`cli/src/watcher/mod.rs`](../../cli/src/watcher/mod.rs) | One-line addition (`pub mod notify_driver;`) next to the existing `debounce` and `ready` re-exports. The submodule's doc comment cross-reference to "Task 7" now resolves intra-crate. |
+| Library surface wiring | [`cli/src/lib.rs`](../../cli/src/lib.rs) | One-line addition (`pub mod daemon;`) next to the existing `args`, `exit`, `pipeline`, `state`, `unlock`, `veto`, `watcher` re-exports. Production consumers reach the daemon under `secretary_cli::daemon::*`. |
+
+**Commit:** `C.2 Task 7 — notify driver + daemon event loop` (see `git log feature/c2-task-7` for the local pre-merge SHA; the post-squash-merge SHA on `main` will differ). 22 new tests across the two new modules (7 notify_driver + 15 daemon); workspace 904 → 926. No issue closes with this commit; #37 (Sub-project C umbrella) advances by one more C.2 slice.
+
+### Plan ↔ reality reconciliations
+
+Three deliberate deviations from the plan, all validated up-front via a brainstorming question to the user before code went in (selected option: **"Redesign the loop"**):
+
+| Plan note | Reality | Resolution |
+|---|---|---|
+| Plan code's daemon match had `DebounceDecision::AlreadyPending => continue,`. | That variant was removed in Task 6's PR-review fixup pass (see Task-6 handoff §"Plan-deviation"). The plan's arm would have produced a compile error. | Removed the dead arm. Daemon's match now covers only the two real variants (`Schedule`/`Reschedule`) and folds both into "update `debounce_pending`, no immediate fire". |
+| Plan code's daemon did `std::thread::sleep(delay)` inside the `match decision { Schedule \| Reschedule => ... }` arm to wait the debounce window. | This blocks the loop for the full window (~500 ms by default), so (a) new events during the sleep can't extend the window, (b) `shutdown_flag` can't be checked, (c) the semantic degrades to **leading-edge-with-burst-coalescing**, contradicting Task 6's debounce module doc + its 5 unit tests that pin **trailing-edge** semantics. | Replaced the sleep with **`poll`'s own timeout as the debounce timer**. The loop computes `wait = min(remaining_debounce, remaining_poll, shutdown_poll_interval)` and calls `poll(wait)`. Returning before the deadline = new event → extend window; returning at the deadline (None) = window elapsed → top of next iteration sees `now - pending >= window` → fire. Exactly the trailing-edge semantic the debounce module documents. The redesign also let the daemon support cancellation latency ≤ `SHUTDOWN_POLL_INTERVAL` (1 s) regardless of debounce window length. |
+| Plan code's daemon test was a compile-only stub that bound two unused values and returned without exercising the loop. | A compile-only test violates the project's "proper inline documentation and unit tests mandatory" principle. The handoff acceptance criterion also called for "one-event-end-to-end + shutdown-event-exits-cleanly + debounce-collapses-burst" tests. | Restructured the daemon to be **closure-shaped** (`run<P, S>` takes a poll closure + an on_sync closure) so unit tests can inject a `ScriptedPoller` + a `SyncCounter` without spinning up a real watcher or a real vault. Shipped 8 `run` behavioural tests covering all three handoff scenarios plus 5 corner cases (immediate-shutdown / mid-loop-flag-flip / periodic-poll-only / etc.). The production composition (`run_against_vault`) is the only thing that calls `wait_for_ready` + `run_one`, and its tests are deferred to Task 10's golden-vault-backed integration suite — the same split the plan calls out. |
+
+Plan also said "Hook the `run` subcommand's stub in `cli/src/main.rs` to `daemon::run`" — deferred to Task 9 (subcommand dispatch wiring). `main.rs` still stubs through to `eprintln!("secretary-sync run: not yet implemented")` because the full wire-up requires `unlock` + `state::load` + `state::acquire_lockfile` orchestration that Task 9 is scoped to assemble. Without signal handling (Task 8) the daemon also can't be cleanly Ctrl-C'd from `main.rs`, so hooking it now would ship a non-Ctrl-C-stoppable binary. The handoff acceptance criterion was aspirational; the plan's literal Steps 1-3 don't include `main.rs` changes either. Task 8 + Task 9 together do the real wire-up.
+
+The plan estimated 2 new tests (1 notify_driver smoke + 1 daemon compile-shape) for a workspace bump of 854 → 856. The 854 baseline was stale (drifted from the actual 904 in Task 6 close), and the 2-test estimate was tied to the now-rejected compile-only stub. Actual: **22 new tests** (7 notify_driver + 15 daemon); workspace **904 → 926**.
+
+### Gauntlet snapshot at session close
+
+```
+PASSED: 926 FAILED: 0 IGNORED: 10
+clippy --release --workspace --tests -- -D warnings   clean
+fmt --all -- --check                                  clean
+uv run core/tests/python/conformance.py               PASS
+uv run core/tests/python/spec_test_name_freshness.py  PASS (96 resolved / 0 unresolved / 2 suppressed)
+```
+
+Baseline 904 came from Task 6 close. Task 7 added 22 new tests:
+- `watcher::notify_driver::tests::*` — 7 tests (5 predicate-level + 2 against a real `notify` watcher).
+- `daemon::tests::*` — 15 tests (5 `compute_wait` pure-function + 8 `run` behavioural + 1 `now_ms` plausibility + 1 `notify_start_to_sync_error` mapping pin).
+
+## (2) What's next — start C.2 Task 8
+
+After this PR merges, the next slice is **C.2 Task 8: logging + signal handling (`cli/src/logging.rs` + `cli/src/signal.rs`)** ([`docs/superpowers/plans/2026-05-23-c2-headless-sync-cli.md`](../superpowers/plans/2026-05-23-c2-headless-sync-cli.md) §"Task 8").
+
+### Acceptance criteria for Task 8
+
+- [ ] New `cli/src/logging.rs` (~80–120 LOC): initialises `tracing-subscriber` with `EnvFilter` + human / json formats keyed off `CommonArgs::log_format` and `--verbose`. Pure init function plus a small builder; no global state beyond what `tracing-subscriber` itself owns.
+- [ ] New `cli/src/signal.rs` (~60–100 LOC): exposes `install_shutdown_handler() -> Arc<AtomicBool>` using `signal-hook` (already in `cli/Cargo.toml`). Hooks SIGINT + SIGTERM; flips the flag the daemon already polls (`DaemonConfig::shutdown_flag`).
+- [ ] New `cli/src/lib.rs` lines: `pub mod logging;` + `pub mod signal;` (Task 5 established the lib.rs pattern; Tasks 6 + 7 added `watcher` + `daemon`; Task 8 adds two more).
+- [ ] Unit tests: logging — at minimum, EnvFilter parses from `--verbose=N` correctly; signal — register / un-register without leaking the handler, and the flag flips on a synthetic signal raise (test-only). The signal harness is the trickier bit because Rust's test runner already installs its own signal handlers; gate signal-handler tests behind `cfg(test)` + a one-test-at-a-time discipline (no `#[test(parallel = false)]` available, but `signal-hook` itself supports installing-and-uninstalling cleanly so tests can be careful).
+- [ ] Gauntlet target: **PASSED: 926 + N FAILED: 0 IGNORED: 10**. Absolute base is now 926 (bumped from 904 by Task 7's 22 new tests).
+- [ ] Clippy, fmt, conformance, spec freshness all clean.
+
+### Plan handoff
+
+Full step-by-step in [`docs/superpowers/plans/2026-05-23-c2-headless-sync-cli.md`](../superpowers/plans/2026-05-23-c2-headless-sync-cli.md) §"Task 8". The plan's Task 8 bundles logging + signal as initialisation-time concerns. Both are small + small — keep each as a single file under the 500-LOC threshold.
+
+## (3) Open decisions and risks
+
+### Decisions settled during this session
+
+- **`daemon::run` is closure-shaped (`P: FnMut(Duration) → Option<WatcherEvent>`, `S: FnMut()`), not trait-driven.** Pure functions in reusable modules per project preference. The closure shape lets tests inject a `ScriptedPoller` + a `SyncCounter` without `Box<dyn ...>` overhead or a `MockEventSource` struct, and lets the production composition (`run_against_vault`) inline the `NotifyWatcher::poll` and `wait_for_ready` + `run_one` calls without an indirection.
+- **Trailing-edge debounce in the daemon honours Task 6's documented semantic.** The redesign uses `poll`'s timeout as the debounce timer; the previous plan's `std::thread::sleep` degraded to leading-edge-with-burst-coalescing and would have rendered Task 6's 5 trailing-edge unit tests semantically misleading.
+- **`compute_wait` is a pure free function pulled out of the loop body.** Smallest-of three deadlines (remaining debounce, remaining poll interval, shutdown poll interval). Five pure unit tests pin it against drift — independently of the harder-to-test loop body.
+- **`SHUTDOWN_POLL_INTERVAL = 1 s` is the loop's worst-case cancellation latency.** Balances operator-visible Ctrl-C responsiveness against per-iteration overhead. The flag is checked at every loop iteration, and `poll` blocks at most this long when nothing else (debounce / periodic poll) is closer.
+- **`is_sync_relevant` in `notify_driver` filters partial-download patterns at the watcher layer.** `*.icloud` / `*.crdownload` writes never cross into the debounce window. Pairs with Task 6's `ready::matches_partial_pattern` table — same canonical filename list, applied earlier in the pipeline. The handoff acceptance criterion called for "partial-download gate"; this is one half of it (the other half — folder-level size-stability via `wait_for_ready` — runs in `run_against_vault`'s `on_sync` closure).
+- **`run_against_vault` calls `wait_for_ready(vault_folder, &RealClock, ready_window)` before each sync.** Treats the folder's metadata stability as a coarse-grained post-debounce safety check; on macOS / Linux the folder mtime changes with every contents change inside, so a still-changing folder yields `Ok(false)` and the sync is skipped that round. The default `ready_window` is 2000 ms (`RunArgs::ready_window_ms`), which adds latency to each sync attempt — acceptable for v1; if operator complaints surface, `--ready-window-ms 0` is the documented mitigation.
+- **`WatcherEvent::PollTick` is never emitted by the production `NotifyWatcher`.** Only synthetic test event sources produce it. The periodic-poll path is driven by `compute_wait`'s `poll_interval` arm + the top-of-loop `last_poll_at` check, not by a notify-side event. The variant stays in the enum because tests use it to verify the `match` arm is wired correctly.
+- **`SyncError::Vault(VaultError::Io { context: "notify watcher start failed", source: ... })` is the mapping for `NotifyWatcher::start` failure.** Pins the `context` value so the caller's exit-code mapper (Task 1) gets a deterministic surface to grep against. One unit test in `daemon::tests` pins this mapping.
+- **`now_ms` saturates on overflow** (the year 584,556,000 ad infinitum is not the user's problem). Pinned by a unit test that floors at 2024-01-01 and ceilings at year 3000.
+- **`main.rs` hook DEFERRED to Task 9.** Without signal handling (Task 8) the daemon can't be cleanly Ctrl-C'd; without `unlock` + `state::load` + `state::acquire_lockfile` orchestration (Task 9 composition), `daemon::run_against_vault` doesn't have its inputs. Shipping a `main.rs` hook in Task 7 would either duplicate Task 8's work or land a daemon that hangs forever on SIGINT.
+
+### Decisions carried forward (unchanged from Task 6 close)
+
+- D1-D10 from the spec are still settled.
+- `--veto-policy=fail`, `--decisions-file`, `--exit-on-error`, `status`, `init` subcommands all deferred to future C.2.x slices.
+- Windows is best-effort per D10 (no CI runner planned for C.2 implementation).
+- Clean-room conformance harness for `cli/` deferred to C.4 or a future C.2.x slice.
+- The `from_sync_error` mapper's exit-code surface (Task 1): every `SyncError` variant without a dedicated code maps to `GenericError = 1`; bijection-failure variants do NOT get distinct codes (CLI bugs, not operator-recoverable).
+- fs4 dep retained over stdlib `File::try_lock` until workspace MSRV bumps past 1.89.
+- `SecretBytes::new(buf)` over `SecretBytes::from(slice) + zeroize` for owned-buffer unlock paths (Task 3 — still in force).
+- `TtyVetoUx` EOF latch + breadcrumb (Task 4) + safe-default `KeepLocal` on empty/error input + silent prompt-write failures: all in force.
+- Pipeline contract (Task 5): `run_one` returns `Result<RunOutcome, SyncError>`; `RunOutcome` has 5 variants; state-mutation contract is documented + tested.
+- Watcher pure pieces (Task 6): `WatcherEvent` is a 3-variant payload-less enum (`SyncCandidate` / `PollTick` / `ShutdownRequested`); `DebounceDecision` is 2 variants (`Schedule` / `Reschedule`), no `AlreadyPending`; `Clock` trait + `RealClock` live in `ready.rs`; `PARTIAL_BASENAMES` comparison is `eq_ignore_ascii_case`; `PARTIAL_SUFFIXES` lookup lowercases the basename; `PARTIAL_PREFIXES = [".~", "~$"]` only (no `"."`).
+
+### Risks carried into Task 8
+
+- **`signal-hook` ↔ Rust test runner interaction.** Rust's `#[test]` harness installs its own signal handlers (for `--test-threads=1` cancellation, etc.). Installing/uninstalling SIGINT/SIGTERM handlers inside a test must not leave the harness in a broken state. The Task 8 plan calls out using `signal-hook::flag::register` (which is non-replacing — it chains to any prior handler) and an RAII guard for cleanup. Tests will need to be careful about parallel execution; gating one signal test behind a `serial_test::serial` annotation (or equivalent) is the standard mitigation if `cargo test` parallelism turns out to interfere. The dep is already in `cli/Cargo.toml` as of Task 1.
+- **`tracing-subscriber` global state.** `tracing-subscriber::registry()` and its `set_global_default` are process-global; calling them more than once panics. Tests that exercise the logging init must either run in isolation (subprocess per test) or hold a `OnceLock` guard so the second init is a no-op. The plan suggests a `try_init` helper that returns `Result<(), TryInitError>` so the production callsite can fail-fast at startup while tests tolerate "already initialised".
+
+### Issues currently open
+
+- #37 — Sub-project C umbrella. C.2 Tasks 1-6 ✅ in PRs #112, #114, #115, #116, #118, #119; Task 7 pending PR.
+- #117 — `TtyVetoUx` re-prompt loop has no max-attempts cap. Low-priority defensive-coding fix; still queued, not in scope for Task 8.
+- #120 — `matches_partial_pattern` allocates per call via `to_ascii_lowercase`. Filed during PR #119 review; performance-only, no correctness or security impact. Pick up if a profiler ever flags it; not in scope for Task 8.
+- #38, #45, #75, #76, #78, #79, #81, #87, #88, #90, #95, #98 — none block C.2 Task 8.
+
+### Housekeeping note (stale worktrees on disk)
+
+After this PR:
+- `/Users/hherb/src/secretary` — `main` (clean post-merge).
+- `/Users/hherb/src/secretary/.worktrees/c1-1b-sync-merge` — branch `feature/c1-1b-task-17`, remote gone. Safe to remove.
+- `/Users/hherb/src/secretary/.worktrees/c2-task-1-spec` — branch `feature/c2-task-1-spec`, remote gone. Safe to remove.
+- `/Users/hherb/src/secretary/.worktrees/c2-task-1` — branch `feature/c2-task-1`, remote gone. Safe to remove.
+- `/Users/hherb/src/secretary/.worktrees/c2-task-2` — branch `feature/c2-task-2`, remote gone. Safe to remove.
+- `/Users/hherb/src/secretary/.worktrees/c2-task-3` — branch `feature/c2-task-3`, remote gone. Safe to remove.
+- `/Users/hherb/src/secretary/.worktrees/c2-task-4` — branch `feature/c2-task-4`, remote gone. Safe to remove.
+- `/Users/hherb/src/secretary/.worktrees/c2-task-5` — branch `feature/c2-task-5`, remote gone. Safe to remove.
+- `/Users/hherb/src/secretary/.worktrees/c2-task-6` — branch `feature/c2-task-6`, remote gone after #119 merged. Safe to remove.
+- `/Users/hherb/src/secretary/.worktrees/c2-task-7` — **this session's work**; keep until PR merges, then remove.
+
+```bash
+# One-line each (run from /Users/hherb/src/secretary):
+git worktree remove .worktrees/c1-1b-sync-merge && git branch -D feature/c1-1b-task-17
+git worktree remove .worktrees/c2-task-1-spec   && git branch -D feature/c2-task-1-spec
+git worktree remove .worktrees/c2-task-1        && git branch -D feature/c2-task-1
+git worktree remove .worktrees/c2-task-2        && git branch -D feature/c2-task-2
+git worktree remove .worktrees/c2-task-3        && git branch -D feature/c2-task-3
+git worktree remove .worktrees/c2-task-4        && git branch -D feature/c2-task-4
+git worktree remove .worktrees/c2-task-5        && git branch -D feature/c2-task-5
+git worktree remove .worktrees/c2-task-6        && git branch -D feature/c2-task-6
+```
+
+Cleanup is one-line each and does NOT block Task 8.
+
+## (4) Exact commands to resume
+
+```bash
+# After this C.2 Task 7 PR (feature/c2-task-7) merges:
+cd /Users/hherb/src/secretary
+git fetch --prune origin
+git status --short                       # expect: clean (modulo NEXT_SESSION.md sync, see below)
+git checkout main
+git pull --ff-only origin main
+
+# Verify gauntlet on fresh main (expect 926 / 0 / 10 — same as session close):
+cargo test --release --workspace --no-fail-fast 2>&1 | grep -E "^test result:" | awk '{passed+=$4; failed+=$6; ignored+=$8} END {print "PASSED:", passed, "FAILED:", failed, "IGNORED:", ignored}'
+cargo clippy --release --workspace --tests -- -D warnings 2>&1 | tail -3
+cargo fmt --all -- --check
+uv run core/tests/python/conformance.py 2>&1 | tail -3
+uv run core/tests/python/spec_test_name_freshness.py 2>&1 | tail -3
+
+# Start Task 8:
+git worktree add .worktrees/c2-task-8 -b feature/c2-task-8 main
+cd .worktrees/c2-task-8
+
+# Open the plan and follow Task 8 line-by-line:
+#   docs/superpowers/plans/2026-05-23-c2-headless-sync-cli.md §"Task 8"
+# Task 8 ships two new files (cli/src/logging.rs + cli/src/signal.rs)
+# plus the `pub mod logging;` + `pub mod signal;` lines in lib.rs.
+# Signal hooks SIGINT + SIGTERM and returns an Arc<AtomicBool> the
+# daemon already polls (DaemonConfig::shutdown_flag).
+```
+
+## Closing inventory
+
+- **Branch state on close:** `main` at `132e15f` (PR #119 squash-merged). `feature/c2-task-7` carries one commit on top (Task 7 code + tests + handoff + symlink).
+- **Workspace tests on `feature/c2-task-7`:** 926 passed + 10 ignored (904 base + 22 new tests: 7 in `watcher::notify_driver::tests` + 15 in `daemon::tests`). Clippy + fmt + Python conformance + spec freshness all clean.
+- **README.md:** unchanged this session — Task 7 ships internal pure-function scaffolding (no operator-visible surface change yet). The C.2 status line in README still implies "queued"; promoting it to "in progress" is deferred until Task 9 wires the subcommands so `secretary-sync` actually runs.
+- **ROADMAP.md:** unchanged this session — same reason; ROADMAP's progress bar still calls C.2 "queued". Bump deferred to Task 9 close.
+- **CLAUDE.md:** unchanged this session — no new convention; daemon submodule is local to `cli/` and doesn't generalise to repo-wide guidance. (The "trailing-edge debounce" semantic was already captured in Task 6's `cli/src/watcher/debounce.rs` module-level doc.)
+- **NEXT_SESSION.md:** symlink retargeted to this file.
+- **Open issues:** see §(3) — none close with this PR; none block Task 8.
+- **Open PRs:** one to be opened at end of this session (C.2 Task 7).
+- **Worktrees on disk:** see §(3) housekeeping.
+- **Frozen baton snapshots:** all 24 prior C.1.1b + C.2-design + C.2-task-1/2/3/4/5/6 handoffs at [`docs/handoffs/`](.) — preserved unchanged.
+- **This file:** the live baton for C.2 Task 7 close.


### PR DESCRIPTION
## Summary

C.2 Task 7 wires the `notify` crate into a `WatcherEvent` stream and composes Task 6's pure pieces (`debounce::step`, `ready::wait_for_ready`) plus Task 5's `pipeline::run_one` into the `run`-subcommand event loop.

- New `cli/src/watcher/notify_driver.rs` (~200 LOC). `NotifyWatcher::start(folder)` wraps `notify::RecommendedWatcher`; `poll(timeout)` blocks up to the supplied duration and returns `Some(SyncCandidate)` or `None`. `is_sync_relevant()` filters `EventKind::Access` (file reads) and events whose paths are all partial-download markers — the spec §D6 partial-download gate at the watcher layer.
- New `cli/src/daemon.rs` (~460 LOC including tests). `run<P, S>(config, poll, on_sync)` is **pure orchestration** over closures so unit tests can drive the loop with a scripted event source + a counter, no vault fixture needed. `run_against_vault(...)` is the production composition helper. `compute_wait` is a pure free helper.
- Three deliberate plan deviations, validated up-front with the user (see handoff §"Plan ↔ reality reconciliations"):
  - Plan's `DebounceDecision::AlreadyPending` arm removed (variant doesn't exist after Task 6's PR-review fixup).
  - Plan's `std::thread::sleep(delay)` inside the debounce match arm replaced with **`poll`'s own timeout as the debounce timer** — restores trailing-edge debounce (matches Task 6's `debounce.rs` module doc + its 5 unit tests). The plan's sleep degraded to leading-edge-with-burst-coalescing.
  - Plan's compile-only daemon test replaced with 15 real unit tests over an injectable closure surface.
- `main.rs` hook deferred to Task 9 (subcommand dispatch wiring); the handoff was aspirational on that point. Without Task 8's signal handler the daemon can't be cleanly Ctrl-C'd, so hooking it now would ship a non-stoppable binary.
- 22 new tests (7 notify_driver + 15 daemon); workspace **904 → 926**.

## Test plan

- [x] `cargo test --release --workspace --no-fail-fast` — `PASSED: 926 FAILED: 0 IGNORED: 10` (= 904 baseline + 22 new).
- [x] `cargo clippy --release --workspace --tests -- -D warnings` — clean.
- [x] `cargo fmt --all -- --check` — clean.
- [x] `uv run core/tests/python/conformance.py` — PASS.
- [x] `uv run core/tests/python/spec_test_name_freshness.py` — PASS (96 resolved / 0 unresolved / 2 suppressed).
- [x] Behavioural daemon tests cover: immediate-shutdown / shutdown-event / single-event / burst-collapse / separate-bursts / periodic-poll / mid-loop-flag-flip / polltick-ignored.
- [x] Tested real `notify::RecommendedWatcher` smoke (writing into a fresh tempdir surfaces SyncCandidate within 2 s on macOS).
- [ ] `cli/tests/run_subcommand_integration.rs` — deferred to Task 10 (needs the `golden_vault_001` fixture + Task 9's `main.rs` dispatch wiring).

🤖 Generated with [Claude Code](https://claude.com/claude-code)