### PR TITLE
feat(d11): Task 2 — backend pure modules (constants, errors, auto_lock, settings parse/serialize)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3735,8 +3735,15 @@ dependencies = [
 name = "secretary-desktop"
 version = "0.1.0"
 dependencies = [
+ "hex",
+ "secretary-ffi-bridge",
+ "serde",
+ "serde_json",
+ "sha2",
  "tauri",
  "tauri-build",
+ "thiserror 2.0.18",
+ "tracing",
 ]
 
 [[package]]

--- a/NEXT_SESSION.md
+++ b/NEXT_SESSION.md
@@ -1,1 +1,1 @@
-docs/handoffs/2026-05-27-d11-task-1-shipped.md
+docs/handoffs/2026-05-27-d11-task-2-shipped.md

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -18,15 +18,30 @@ tauri-build = { version = "2", features = [] }
 # tray icon / no auto-updater / no clipboard / no shell — D.1.1 doesn't
 # need any of those. Add features per-slice as D.1.x grows.
 #
-# Other crates the later D.1.x tasks need (`secretary-ffi-bridge`, `serde`,
-# `serde_json`, `thiserror`, `tracing` / `tracing-subscriber`, `sha2`, `hex`,
-# `rand`, `dirs`, `tempfile`) are intentionally NOT pre-pulled here — each
-# task adds the dep it actually introduces, so reviewers can see "this PR
-# pulled in X" without cross-referencing the plan. `tempfile` (when added
-# for atomic writes in Task 2/3) MUST be exact-pinned (`=3.27.0`) to match
-# `core/Cargo.toml` / `cli/Cargo.toml` per CLAUDE.md "exact pins on
-# security-critical paths".
+# Per CLAUDE.md "exact pins on security-critical paths": when `tempfile` is
+# pulled in for atomic writes in Task 3, it MUST be exact-pinned (`=3.27.0`)
+# to match `core/Cargo.toml` / `cli/Cargo.toml`.
 tauri = { version = "2", features = [] }
+
+# Task 2 pure modules:
+# - `secretary-ffi-bridge` is consumed for `FfiVaultError` (typed mapping
+#   surface in `errors.rs`). Workspace path dep — not an FFI hop.
+# - `serde` / `serde_json` for the serde-tagged `AppError` / `AppWarning`
+#   discriminated unions that cross the Tauri IPC seam.
+# - `thiserror` for derive-based `Error` impls.
+# - `tracing` for structured logs on the Rust side (developer-facing
+#   `detail` fields are logged here but stripped before IPC serialization).
+# - `sha2` + `hex` for the deterministic SHA-256-derived UUID helper and
+#   the frozen-UUID tripwire tests in `constants::tests`.
+# Versions track the workspace conventions already used by `core/` and
+# `ffi/secretary-ffi-bridge/`.
+secretary-ffi-bridge = { path = "../../ffi/secretary-ffi-bridge" }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+thiserror = "2"
+tracing = "0.1"
+sha2 = "0.10"
+hex = "0.4"
 
 [lints]
 workspace = true

--- a/desktop/src-tauri/src/auto_lock.rs
+++ b/desktop/src-tauri/src/auto_lock.rs
@@ -11,6 +11,11 @@ use std::time::{SystemTime, UNIX_EPOCH};
 /// and the timer thread to compute "now". Pulled out as a free function so
 /// tests can inject a fixed value via the `is_expired` argument rather than
 /// monkey-patching the clock.
+///
+/// `Duration::as_millis()` returns `u128`; we truncate to `u64`. `u64::MAX`
+/// milliseconds from the UNIX epoch is ≈ year 584_556_020 — past any horizon
+/// where this code will run — so the truncation is safe and not worth a
+/// runtime check.
 pub fn now_ms() -> u64 {
     SystemTime::now()
         .duration_since(UNIX_EPOCH)

--- a/desktop/src-tauri/src/auto_lock.rs
+++ b/desktop/src-tauri/src/auto_lock.rs
@@ -101,9 +101,10 @@ mod tests {
 
     #[test]
     fn tick_interval_constant_is_usable() {
-        // Smoke: ensure tick interval is strictly positive at runtime.
-        // (Compile-time fit in u64 is enforced by the constant's type.)
-        assert!(AUTO_LOCK_TICK_MS > 0);
+        // Smoke: ensure tick interval is strictly positive. Compile-time
+        // known, so use a const block — clippy correctly flags `assert!`
+        // on compile-time constants as not a runtime test.
+        const _: () = assert!(AUTO_LOCK_TICK_MS > 0);
     }
 
     #[test]

--- a/desktop/src-tauri/src/auto_lock.rs
+++ b/desktop/src-tauri/src/auto_lock.rs
@@ -1,0 +1,117 @@
+//! Pure idle tracker for the auto-lock timer. The actual timer thread and
+//! the lock action live in `session.rs` / `main.rs`; this module is pure
+//! data + truth-table functions, unit-testable without spinning up Tauri
+//! or threads.
+//!
+//! See spec §6 (vault session lifecycle, auto-lock subsection).
+
+use std::time::{SystemTime, UNIX_EPOCH};
+
+/// Wall-clock milliseconds since the UNIX epoch. Used by both `IdleTracker`
+/// and the timer thread to compute "now". Pulled out as a free function so
+/// tests can inject a fixed value via the `is_expired` argument rather than
+/// monkey-patching the clock.
+pub fn now_ms() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system clock before UNIX epoch")
+        .as_millis() as u64
+}
+
+/// Records the wall-clock time of the most recent UI activity. The auto-lock
+/// timer thread checks `is_expired(threshold_ms, now_ms())` each tick.
+#[derive(Debug, Clone, Copy)]
+pub struct IdleTracker {
+    pub last_activity_ms: u64,
+}
+
+impl IdleTracker {
+    /// Construct fresh — `last_activity_ms` initialized to "now".
+    pub fn new(now_ms: u64) -> Self {
+        Self {
+            last_activity_ms: now_ms,
+        }
+    }
+
+    /// Mark activity at the given wall-clock time.
+    ///
+    /// Only advances forward — protects against clock skew that could
+    /// make `last_activity_ms` jump into the past, which would cause a
+    /// spurious auto-lock on the next tick.
+    pub fn notify(&mut self, now_ms: u64) {
+        if now_ms > self.last_activity_ms {
+            self.last_activity_ms = now_ms;
+        }
+    }
+
+    /// Returns true if `now_ms - last_activity_ms >= threshold_ms`.
+    ///
+    /// Underflow-safe: if the clock has gone backwards (rare; resume from
+    /// suspend on some systems), returns false rather than panicking.
+    pub fn is_expired(&self, threshold_ms: u64, now_ms: u64) -> bool {
+        now_ms.saturating_sub(self.last_activity_ms) >= threshold_ms
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::constants::{AUTO_LOCK_DEFAULT_MS, AUTO_LOCK_TICK_MS};
+
+    #[test]
+    fn fresh_tracker_is_not_expired() {
+        let t = IdleTracker::new(1_000);
+        assert!(!t.is_expired(AUTO_LOCK_DEFAULT_MS, 1_000));
+    }
+
+    #[test]
+    fn expired_after_threshold() {
+        let t = IdleTracker::new(0);
+        // Exactly at the threshold counts as expired (>= comparison).
+        assert!(t.is_expired(AUTO_LOCK_DEFAULT_MS, AUTO_LOCK_DEFAULT_MS));
+    }
+
+    #[test]
+    fn not_expired_just_before_threshold() {
+        let t = IdleTracker::new(0);
+        assert!(!t.is_expired(AUTO_LOCK_DEFAULT_MS, AUTO_LOCK_DEFAULT_MS - 1));
+    }
+
+    #[test]
+    fn notify_advances_forward() {
+        let mut t = IdleTracker::new(1_000);
+        t.notify(5_000);
+        assert_eq!(t.last_activity_ms, 5_000);
+    }
+
+    #[test]
+    fn notify_ignores_backward_clock() {
+        let mut t = IdleTracker::new(5_000);
+        t.notify(1_000); // backward — clock skew or test fixture mistake
+        assert_eq!(t.last_activity_ms, 5_000, "must not advance backward");
+    }
+
+    #[test]
+    fn underflow_safe_on_backward_clock() {
+        let t = IdleTracker::new(10_000);
+        // "now" before "last_activity" — saturating_sub returns 0,
+        // 0 < threshold, so not expired.
+        assert!(!t.is_expired(AUTO_LOCK_DEFAULT_MS, 5_000));
+    }
+
+    #[test]
+    fn tick_interval_constant_is_usable() {
+        // Smoke: ensure tick interval is strictly positive at runtime.
+        // (Compile-time fit in u64 is enforced by the constant's type.)
+        assert!(AUTO_LOCK_TICK_MS > 0);
+    }
+
+    #[test]
+    fn now_ms_is_after_2020() {
+        // Sanity: this code is being written in 2026; if `now_ms` returns
+        // something before 2020 the system clock is broken (or we accidentally
+        // started returning seconds instead of milliseconds).
+        const JAN_1_2020_MS: u64 = 1_577_836_800_000;
+        assert!(now_ms() > JAN_1_2020_MS);
+    }
+}

--- a/desktop/src-tauri/src/constants.rs
+++ b/desktop/src-tauri/src/constants.rs
@@ -1,0 +1,153 @@
+//! Canonical constants for the desktop app. Every value is documented with
+//! its rationale; the spec §8 "Constants" table is the canonical source —
+//! this file mirrors it verbatim.
+//!
+//! NO MAGIC NUMBERS POLICY: every value the desktop app uses that isn't
+//! self-explanatory (e.g. 0, 1, 2 for indexing) lives here with a name.
+//!
+//! See: docs/superpowers/specs/2026-05-27-d11-tauri-walking-skeleton-design.md §8
+
+use sha2::{Digest, Sha256};
+
+// =============================================================================
+// Auto-lock timing
+// =============================================================================
+
+/// Default auto-lock timeout in milliseconds. Used when no settings record
+/// exists in the vault (first-unlock or default-only users).
+///
+/// **Value:** 600_000 (10 minutes).
+/// **Rationale:** Matches 1Password (10 min default), Bitwarden (15 min).
+/// Long enough to not annoy; short enough that "I walked away for lunch"
+/// leaves the vault locked.
+pub const AUTO_LOCK_DEFAULT_MS: u64 = 600_000;
+
+/// Lower bound for `auto_lock_timeout_ms` settings validation.
+///
+/// **Value:** 60_000 (1 minute).
+/// **Rationale:** Below this, re-prompts become tedious for the user with no
+/// security gain — a 30-second adversary window vs 60-second isn't materially
+/// different in a physical-access threat model.
+pub const AUTO_LOCK_MIN_MS: u64 = 60_000;
+
+/// Upper bound for `auto_lock_timeout_ms` settings validation.
+///
+/// **Value:** 86_400_000 (24 hours).
+/// **Rationale:** Anything longer is effectively "never auto-lock" —
+/// security antipattern we won't ship as configurable.
+pub const AUTO_LOCK_MAX_MS: u64 = 86_400_000;
+
+/// Tick interval for the auto-lock timer thread.
+///
+/// **Value:** 5_000 (5 seconds).
+/// **Rationale:** Coarse enough to be free of measurable CPU cost; fine
+/// enough that auto-lock fires within 5s of the threshold expiring
+/// (acceptable jitter vs the 1-minute minimum threshold).
+pub const AUTO_LOCK_TICK_MS: u64 = 5_000;
+
+/// Minimum interval between frontend `notify_activity` IPC calls (debounce).
+///
+/// **Value:** 2_000 (2 seconds).
+/// **Rationale:** Each mousemove during typing shouldn't issue an IPC; 2s
+/// is well below any plausible threshold so the timer never spuriously fires
+/// while the user is active.
+pub const ACTIVITY_NOTIFY_MIN_INTERVAL_MS: u64 = 2_000;
+
+// =============================================================================
+// Settings record schema
+// =============================================================================
+
+/// Reserved block name for the secretary-app settings record.
+///
+/// **Value:** `"__secretary_app_settings__"`.
+/// **Rationale:** Double-underscore prefix/suffix marks "internal"; unlikely
+/// to collide with user-created block names.
+pub const SETTINGS_BLOCK_NAME: &str = "__secretary_app_settings__";
+
+/// Versioned record_type string for the settings record.
+///
+/// **Value:** `"secretary.settings.v1"`.
+/// **Rationale:** Versioned. Future schema migrations get `v2`. Forward-compat:
+/// unknown version on load falls back to `Settings::default()` + warning.
+pub const SETTINGS_RECORD_TYPE: &str = "secretary.settings.v1";
+
+/// Field name for the auto-lock timeout setting.
+///
+/// **Value:** `"auto_lock_timeout_ms"`.
+/// **Rationale:** Snake-case matches Rust convention; matches the constant
+/// name `AUTO_LOCK_DEFAULT_MS` for grep-ability.
+pub const SETTINGS_FIELD_AUTO_LOCK_TIMEOUT_MS: &str = "auto_lock_timeout_ms";
+
+// =============================================================================
+// Deterministic UUID derivation (for the settings block and record)
+// =============================================================================
+
+/// Number of bytes consumed from the front of a SHA-256 digest to form the
+/// deterministic 16-byte UUID. The vault format uses 128-bit UUIDs; SHA-256
+/// produces 256 bits so we discard the high half.
+const UUID_BYTE_LEN: usize = 16;
+
+/// Compute the deterministic 16-byte UUID for a vault-internal block name
+/// or record_type string, via `SHA-256(input)[0..16]`.
+///
+/// Used for the settings block and the settings record so that two devices
+/// creating the same block independently produce identical UUIDs — the CRDT
+/// merge layer then treats their writes as concurrent updates of one block
+/// rather than two separate blocks. See spec §8 for the full rationale.
+pub fn deterministic_uuid_16(input: &str) -> [u8; UUID_BYTE_LEN] {
+    let hash = Sha256::digest(input.as_bytes());
+    let mut out = [0u8; UUID_BYTE_LEN];
+    out.copy_from_slice(&hash[0..UUID_BYTE_LEN]);
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Frozen hex prefix of `SHA-256("__secretary_app_settings__")`.
+    /// Drift = vault-format break risk; see `settings_block_uuid_is_deterministic_and_frozen`.
+    const FROZEN_SETTINGS_BLOCK_UUID_HEX: &str = "04fcc7aa05345f631e7f1ce2db78ba9a";
+
+    /// Frozen hex prefix of `SHA-256("secretary.settings.v1")`.
+    /// Drift = vault-format break risk; see `settings_record_uuid_is_deterministic_and_frozen`.
+    const FROZEN_SETTINGS_RECORD_UUID_HEX: &str = "4145cb7a4531f1ac41af6717e205e1a9";
+
+    // Sanity: ensure no two constants accidentally hold the same value
+    // (would mask a refactor bug).
+    #[test]
+    fn auto_lock_bounds_are_ordered() {
+        assert!(AUTO_LOCK_MIN_MS < AUTO_LOCK_DEFAULT_MS);
+        assert!(AUTO_LOCK_DEFAULT_MS < AUTO_LOCK_MAX_MS);
+    }
+
+    #[test]
+    fn tick_interval_smaller_than_min_threshold() {
+        // Otherwise auto-lock can never fire within the user's chosen
+        // threshold — spec §6 invariant.
+        assert!(AUTO_LOCK_TICK_MS < AUTO_LOCK_MIN_MS);
+    }
+
+    #[test]
+    fn settings_block_uuid_is_deterministic_and_frozen() {
+        // Frozen-string test: if this assertion ever fails, the on-disk
+        // settings-block UUID has drifted from what shipped clients expect.
+        // That's a vault-format break — investigate before changing.
+        let uuid = deterministic_uuid_16(SETTINGS_BLOCK_NAME);
+        assert_eq!(
+            hex::encode(uuid),
+            FROZEN_SETTINGS_BLOCK_UUID_HEX,
+            "settings block UUID drift — vault-format break risk"
+        );
+    }
+
+    #[test]
+    fn settings_record_uuid_is_deterministic_and_frozen() {
+        let uuid = deterministic_uuid_16(SETTINGS_RECORD_TYPE);
+        assert_eq!(
+            hex::encode(uuid),
+            FROZEN_SETTINGS_RECORD_UUID_HEX,
+            "settings record UUID drift — vault-format break risk"
+        );
+    }
+}

--- a/desktop/src-tauri/src/constants.rs
+++ b/desktop/src-tauri/src/constants.rs
@@ -51,6 +51,11 @@ pub const AUTO_LOCK_TICK_MS: u64 = 5_000;
 /// **Rationale:** Each mousemove during typing shouldn't issue an IPC; 2s
 /// is well below any plausible threshold so the timer never spuriously fires
 /// while the user is active.
+///
+// Consumer lands in Task 5 (auto-lock timer thread) / Task 6 (frontend
+// debounce). Allowed dead at this Task-2 checkpoint by design — the
+// constants module ships ahead of its consumers per the plan.
+#[allow(dead_code)]
 pub const ACTIVITY_NOTIFY_MIN_INTERVAL_MS: u64 = 2_000;
 
 // =============================================================================
@@ -113,19 +118,22 @@ mod tests {
     /// Drift = vault-format break risk; see `settings_record_uuid_is_deterministic_and_frozen`.
     const FROZEN_SETTINGS_RECORD_UUID_HEX: &str = "4145cb7a4531f1ac41af6717e205e1a9";
 
-    // Sanity: ensure no two constants accidentally hold the same value
-    // (would mask a refactor bug).
+    // Sanity: ensure constant relationships hold. These are
+    // compile-time-known so we use const blocks — clippy correctly
+    // flags `assert!` on compile-time constants as not a runtime test.
+    // The const-block form upgrades the check to a compile error if the
+    // relationship is ever violated.
     #[test]
     fn auto_lock_bounds_are_ordered() {
-        assert!(AUTO_LOCK_MIN_MS < AUTO_LOCK_DEFAULT_MS);
-        assert!(AUTO_LOCK_DEFAULT_MS < AUTO_LOCK_MAX_MS);
+        const _: () = assert!(AUTO_LOCK_MIN_MS < AUTO_LOCK_DEFAULT_MS);
+        const _: () = assert!(AUTO_LOCK_DEFAULT_MS < AUTO_LOCK_MAX_MS);
     }
 
     #[test]
     fn tick_interval_smaller_than_min_threshold() {
         // Otherwise auto-lock can never fire within the user's chosen
         // threshold — spec §6 invariant.
-        assert!(AUTO_LOCK_TICK_MS < AUTO_LOCK_MIN_MS);
+        const _: () = assert!(AUTO_LOCK_TICK_MS < AUTO_LOCK_MIN_MS);
     }
 
     #[test]

--- a/desktop/src-tauri/src/errors.rs
+++ b/desktop/src-tauri/src/errors.rs
@@ -29,6 +29,19 @@
 
 use secretary_ffi_bridge::error::FfiVaultError;
 
+// `AppError` variants `VaultPathNotFound` / `VaultPathNotAVault` /
+// `VaultPathLocked` / `AlreadyUnlocked` / `NotUnlocked` are constructed by
+// the Task 4 command handlers (which have access to the user-picked path
+// and the session-state mutex) rather than by the `From<FfiVaultError>`
+// impl. They appear in the wire-format schema from day one so the
+// frontend's TS discriminated union (Task 6) mirrors the full surface,
+// but the Rust producers land in Task 4.
+//
+// `AppWarning::SettingsCorrupt` is constructed by the Task 3 vault-load
+// path when the settings record decodes but its field shapes don't match
+// the schema (vs `SettingsClamped` which fires on out-of-range numeric
+// values, already produced by `settings::parse_settings_field`).
+#[allow(dead_code)]
 #[derive(thiserror::Error, Debug, serde::Serialize)]
 #[serde(tag = "code", rename_all = "snake_case")]
 pub enum AppError {
@@ -87,6 +100,14 @@ pub enum AppError {
     },
 }
 
+// All three variants are part of the IPC wire-format schema; renaming to
+// drop the `Settings` prefix would change the on-wire `code` discriminator
+// strings (e.g. `"settings_clamped"` → `"clamped"`) which would be a
+// frontend-visible contract break. The shared prefix is intentional —
+// these are the settings-domain warnings, and future non-settings
+// warnings would NOT share the prefix.
+#[allow(clippy::enum_variant_names)]
+#[allow(dead_code)]
 #[derive(Debug, serde::Serialize)]
 #[serde(tag = "code", rename_all = "snake_case")]
 pub enum AppWarning {

--- a/desktop/src-tauri/src/errors.rs
+++ b/desktop/src-tauri/src/errors.rs
@@ -154,8 +154,9 @@ impl From<FfiVaultError> for AppError {
             // Both bridge variants conflate "wrong credential" and "corruption"
             // per the anti-oracle property; we preserve the conflation at the
             // UI boundary too.
-            FfiVaultError::WrongPasswordOrCorrupt
-            | FfiVaultError::WrongMnemonicOrCorrupt => AppError::WrongPassword,
+            FfiVaultError::WrongPasswordOrCorrupt | FfiVaultError::WrongMnemonicOrCorrupt => {
+                AppError::WrongPassword
+            }
 
             // Genuine cryptographic / integrity failures → VaultCorrupt.
             FfiVaultError::CorruptVault { detail }
@@ -167,8 +168,7 @@ impl From<FfiVaultError> for AppError {
             // inconsistent and they need to re-pair from backups. We synthesise
             // a detail string (this variant carries no payload).
             FfiVaultError::VaultMismatch => AppError::VaultCorrupt {
-                detail: "vault.toml and identity.bundle.enc reference different vaults"
-                    .to_string(),
+                detail: "vault.toml and identity.bundle.enc reference different vaults".to_string(),
             },
 
             // Pre-decryption mnemonic validation failure. Unreachable from

--- a/desktop/src-tauri/src/errors.rs
+++ b/desktop/src-tauri/src/errors.rs
@@ -6,8 +6,10 @@
 //!   the wire format is `{ "code": "wrong_password", ... }`.
 //! - Developer-facing `detail` fields are `#[serde(skip_serializing)]` — they're
 //!   logged via `tracing` on the Rust side but NEVER cross the IPC seam.
-//! - `From<FfiVaultError>` is an explicit `match` so we choose the user-facing
-//!   variant per case; no fall-through wrap-in-`Internal`.
+//! - The mapping from `FfiVaultError` is split into a pure [`map_ffi_error`]
+//!   function (no side effects, exhaustive match) and an `impl From` that
+//!   logs at `warn` before delegating. The side effect is visible at the
+//!   call site rather than buried inside the `From` body.
 //! - `WrongPassword` collapse rule: anything decryption-failure-shaped becomes
 //!   `WrongPassword` (info-leak prevention per `docs/threat-model.md` §13).
 //!
@@ -124,87 +126,100 @@ pub enum AppWarning {
     },
 }
 
-impl From<FfiVaultError> for AppError {
-    /// Explicit per-variant mapping. Adding a new `FfiVaultError` variant
-    /// in the bridge crate will surface here as a compile error (the match
-    /// must be exhaustive), forcing a deliberate UI-mapping choice.
-    ///
-    /// The bridge's `WrongPasswordOrCorrupt` / `WrongMnemonicOrCorrupt`
-    /// variants are deliberately conflated per `docs/threat-model.md` §13's
-    /// anti-oracle property; both fold to `WrongPassword` here (the user's
-    /// affordance is "retry credential" in both cases). Bridge variants
-    /// that cannot reach D.1.1's code paths (block-share authorisation,
-    /// trash/restore preconditions, recovery-phrase pre-validation) fold
-    /// to `Internal { detail }` so a regression that lets them fire
-    /// surfaces as a clear bug-report path.
-    ///
-    /// `FolderInvalid` folds to `Io { detail }` here because the bridge
-    /// surfaces the underlying IO context but not the caller's chosen path.
-    /// Task 4's command handlers, which DO know the user-picked path, will
-    /// construct `VaultPathNotFound` / `VaultPathNotAVault` directly at the
-    /// boundary so the UI can render the path-specific affordance.
-    fn from(e: FfiVaultError) -> Self {
-        // Log developer-facing detail before stripping. tracing::warn so
-        // it appears in stderr in dev mode and in any production log sink
-        // without requiring DEBUG verbosity.
-        tracing::warn!(?e, "FfiVaultError surfacing to AppError");
-
-        match e {
-            // Decryption-failure-shaped → WrongPassword (info-leak prevention).
-            // Both bridge variants conflate "wrong credential" and "corruption"
-            // per the anti-oracle property; we preserve the conflation at the
-            // UI boundary too.
-            FfiVaultError::WrongPasswordOrCorrupt | FfiVaultError::WrongMnemonicOrCorrupt => {
-                AppError::WrongPassword
-            }
-
-            // Genuine cryptographic / integrity failures → VaultCorrupt.
-            FfiVaultError::CorruptVault { detail }
-            | FfiVaultError::SaveCryptoFailure { detail }
-            | FfiVaultError::CardDecodeFailure { detail } => AppError::VaultCorrupt { detail },
-
-            // vault.toml ↔ identity.bundle.enc mismatch is a corruption-class
-            // failure from the user's perspective: the on-disk state is
-            // inconsistent and they need to re-pair from backups. We synthesise
-            // a detail string (this variant carries no payload).
-            FfiVaultError::VaultMismatch => AppError::VaultCorrupt {
-                detail: "vault.toml and identity.bundle.enc reference different vaults".to_string(),
-            },
-
-            // Pre-decryption mnemonic validation failure. Unreachable from
-            // D.1.1's password-only unlock path; if it ever fires here, it's
-            // a bug — surface as Internal with detail for the bug report.
-            FfiVaultError::InvalidMnemonic { detail } => AppError::Internal {
-                detail: format!("invalid mnemonic on password-only unlock path: {detail}"),
-            },
-
-            // Pre-unlock filesystem failure. Task 4's command handlers replace
-            // this with the path-aware VaultPathNotFound / VaultPathNotAVault
-            // construction at the boundary; here we fold to the generic Io
-            // bucket so any pre-Task-4 code path surfaces something coherent.
-            FfiVaultError::FolderInvalid { detail } => AppError::Io { detail },
-
-            // Block-lookup miss. Reachable in D.1.1 if a caller passes a
-            // stale block UUID to read_block (e.g. between a settings-block
-            // creation and the subsequent manifest refresh). Surface as
-            // Internal — D.1.1's settings flow never asks for an unknown
-            // UUID, so this firing means a bug.
-            FfiVaultError::BlockNotFound { uuid_hex } => AppError::Internal {
-                detail: format!("block not found in manifest: {uuid_hex}"),
-            },
-
-            // Block-share authorization failures, recipient table mismatches,
-            // and trash/restore preconditions: unreachable in D.1.1 (no
-            // share / no trash UI). Map to Internal so an accidental
-            // wiring of a share/trash command surfaces clearly.
-            other @ (FfiVaultError::NotAuthor { .. }
-            | FfiVaultError::RecipientAlreadyPresent
-            | FfiVaultError::MissingRecipientCard { .. }
-            | FfiVaultError::BlockUuidAlreadyLive { .. }
-            | FfiVaultError::BlockNotInTrash { .. }) => AppError::Internal {
-                detail: format!("{other:?}"),
-            },
+/// Pure mapping from `FfiVaultError` to `AppError`. No side effects — the
+/// `tracing::warn!` that records the developer-facing detail before it's
+/// stripped at the IPC seam lives in `impl From<FfiVaultError> for AppError`
+/// so the side effect is visible at the call site.
+///
+/// Exposed as a function (not just an `impl From` body) so callers that
+/// want the mapping without the log line — e.g. unit tests checking variant
+/// routing, or future call sites that have already logged the source error
+/// at a different level — can use it directly.
+///
+/// Adding a new `FfiVaultError` variant in the bridge crate will surface
+/// here as a compile error (the match must be exhaustive), forcing a
+/// deliberate UI-mapping choice.
+///
+/// The bridge's `WrongPasswordOrCorrupt` / `WrongMnemonicOrCorrupt`
+/// variants are deliberately conflated per `docs/threat-model.md` §13's
+/// anti-oracle property; both fold to `WrongPassword` here (the user's
+/// affordance is "retry credential" in both cases). Bridge variants
+/// that cannot reach D.1.1's code paths (block-share authorisation,
+/// trash/restore preconditions, recovery-phrase pre-validation) fold
+/// to `Internal { detail }` so a regression that lets them fire
+/// surfaces as a clear bug-report path.
+///
+/// `FolderInvalid` folds to `Io { detail }` here because the bridge
+/// surfaces the underlying IO context but not the caller's chosen path.
+/// Task 4's command handlers, which DO know the user-picked path, will
+/// construct `VaultPathNotFound` / `VaultPathNotAVault` directly at the
+/// boundary so the UI can render the path-specific affordance.
+pub fn map_ffi_error(e: FfiVaultError) -> AppError {
+    match e {
+        // Decryption-failure-shaped → WrongPassword (info-leak prevention).
+        // Both bridge variants conflate "wrong credential" and "corruption"
+        // per the anti-oracle property; we preserve the conflation at the
+        // UI boundary too.
+        FfiVaultError::WrongPasswordOrCorrupt | FfiVaultError::WrongMnemonicOrCorrupt => {
+            AppError::WrongPassword
         }
+
+        // Genuine cryptographic / integrity failures → VaultCorrupt.
+        FfiVaultError::CorruptVault { detail }
+        | FfiVaultError::SaveCryptoFailure { detail }
+        | FfiVaultError::CardDecodeFailure { detail } => AppError::VaultCorrupt { detail },
+
+        // vault.toml ↔ identity.bundle.enc mismatch is a corruption-class
+        // failure from the user's perspective: the on-disk state is
+        // inconsistent and they need to re-pair from backups. We synthesise
+        // a detail string (this variant carries no payload).
+        FfiVaultError::VaultMismatch => AppError::VaultCorrupt {
+            detail: "vault.toml and identity.bundle.enc reference different vaults".to_string(),
+        },
+
+        // Pre-decryption mnemonic validation failure. Unreachable from
+        // D.1.1's password-only unlock path; if it ever fires here, it's
+        // a bug — surface as Internal with detail for the bug report.
+        FfiVaultError::InvalidMnemonic { detail } => AppError::Internal {
+            detail: format!("invalid mnemonic on password-only unlock path: {detail}"),
+        },
+
+        // Pre-unlock filesystem failure. Task 4's command handlers replace
+        // this with the path-aware VaultPathNotFound / VaultPathNotAVault
+        // construction at the boundary; here we fold to the generic Io
+        // bucket so any pre-Task-4 code path surfaces something coherent.
+        FfiVaultError::FolderInvalid { detail } => AppError::Io { detail },
+
+        // Block-lookup miss. Reachable in D.1.1 if a caller passes a
+        // stale block UUID to read_block (e.g. between a settings-block
+        // creation and the subsequent manifest refresh). Surface as
+        // Internal — D.1.1's settings flow never asks for an unknown
+        // UUID, so this firing means a bug.
+        FfiVaultError::BlockNotFound { uuid_hex } => AppError::Internal {
+            detail: format!("block not found in manifest: {uuid_hex}"),
+        },
+
+        // Block-share authorization failures, recipient table mismatches,
+        // and trash/restore preconditions: unreachable in D.1.1 (no
+        // share / no trash UI). Map to Internal so an accidental
+        // wiring of a share/trash command surfaces clearly.
+        other @ (FfiVaultError::NotAuthor { .. }
+        | FfiVaultError::RecipientAlreadyPresent
+        | FfiVaultError::MissingRecipientCard { .. }
+        | FfiVaultError::BlockUuidAlreadyLive { .. }
+        | FfiVaultError::BlockNotInTrash { .. }) => AppError::Internal {
+            detail: format!("{other:?}"),
+        },
+    }
+}
+
+impl From<FfiVaultError> for AppError {
+    /// Logs the source error at `warn` level (developer-facing detail goes
+    /// to stderr / log sink before being stripped at the IPC seam), then
+    /// delegates to the pure mapping in [`map_ffi_error`].
+    fn from(e: FfiVaultError) -> Self {
+        tracing::warn!(?e, "FfiVaultError surfacing to AppError");
+        map_ffi_error(e)
     }
 }
 
@@ -292,6 +307,17 @@ mod tests {
             v["code"], "wrong_password",
             "anti-oracle: WrongPasswordOrCorrupt must collapse to WrongPassword"
         );
+    }
+
+    #[test]
+    fn map_ffi_error_is_pure_no_log_side_effect_required() {
+        // Calling the pure helper directly (not via `.into()` / `From`) must
+        // produce the same routing as the `From` impl. Documents the public
+        // API of the side-effect-free path so future callers that already
+        // logged the source at a different level can reuse it.
+        let mapped = map_ffi_error(FfiVaultError::WrongMnemonicOrCorrupt);
+        let v = round_trip(&mapped);
+        assert_eq!(v["code"], "wrong_password");
     }
 
     #[test]

--- a/desktop/src-tauri/src/errors.rs
+++ b/desktop/src-tauri/src/errors.rs
@@ -1,0 +1,289 @@
+//! `AppError` + `AppWarning` types crossing the Tauri IPC boundary.
+//!
+//! See spec §9 for the full mapping rules. Key disciplines:
+//!
+//! - Every variant `#[serde(tag = "code", rename_all = "snake_case")]` so
+//!   the wire format is `{ "code": "wrong_password", ... }`.
+//! - Developer-facing `detail` fields are `#[serde(skip_serializing)]` — they're
+//!   logged via `tracing` on the Rust side but NEVER cross the IPC seam.
+//! - `From<FfiVaultError>` is an explicit `match` so we choose the user-facing
+//!   variant per case; no fall-through wrap-in-`Internal`.
+//! - `WrongPassword` collapse rule: anything decryption-failure-shaped becomes
+//!   `WrongPassword` (info-leak prevention per `docs/threat-model.md` §13).
+//!
+//! # Variant coverage versus FfiVaultError
+//!
+//! D.1.1 only exercises the password-unlock + read-block + save-block paths
+//! (no recovery-phrase unlock, no block-share, no trash/restore). The
+//! `From<FfiVaultError>` match is nonetheless exhaustive because new bridge
+//! variants must force a deliberate UI-mapping choice rather than silently
+//! folding to `Internal`. Variants that cannot fire in D.1.1's code paths
+//! fold to `Internal { detail }` so a regression surfaces as a clear
+//! "this is a bug" rather than a silent miscategorisation.
+//!
+//! Note: the bridge already collapses `WeakKdfParams` into `CorruptVault`
+//! (post-unlock detail string). `AppError::KdfTooWeak` therefore has no
+//! producer in this `From` impl — it survives as a typed variant for the
+//! future where the bridge exposes the parameter pair structurally, and
+//! its serialization shape is pinned by `kdf_too_weak_carries_payload`.
+
+use secretary_ffi_bridge::error::FfiVaultError;
+
+#[derive(thiserror::Error, Debug, serde::Serialize)]
+#[serde(tag = "code", rename_all = "snake_case")]
+pub enum AppError {
+    #[error("Vault folder does not exist or is not readable")]
+    VaultPathNotFound { path: String },
+
+    #[error("Folder exists but doesn't contain a vault")]
+    VaultPathNotAVault { path: String },
+
+    #[error("Vault is currently locked by another process")]
+    VaultPathLocked { path: String },
+
+    #[error("Wrong password")]
+    WrongPassword,
+
+    #[error("Vault uses KDF parameters below the minimum")]
+    KdfTooWeak {
+        current_memory_kib: u32,
+        min_memory_kib: u32,
+    },
+
+    #[error("Vault is corrupted; consider restoring from a backup")]
+    VaultCorrupt {
+        #[serde(skip_serializing)]
+        detail: String,
+    },
+
+    #[error("Vault already unlocked")]
+    AlreadyUnlocked,
+
+    #[error("No vault currently unlocked")]
+    NotUnlocked,
+
+    #[error("Settings record is malformed; using defaults")]
+    SettingsCorrupt {
+        #[serde(skip_serializing)]
+        detail: String,
+    },
+
+    #[error("Settings record uses an unknown schema version")]
+    SettingsUnknownVersion { version: String },
+
+    #[error("Auto-lock timeout must be between {min} and {max} ms")]
+    SettingsOutOfRange { min: u64, max: u64 },
+
+    #[error("Filesystem error")]
+    Io {
+        #[serde(skip_serializing)]
+        detail: String,
+    },
+
+    #[error("Internal error — this is a bug")]
+    Internal {
+        #[serde(skip_serializing)]
+        detail: String,
+    },
+}
+
+#[derive(Debug, serde::Serialize)]
+#[serde(tag = "code", rename_all = "snake_case")]
+pub enum AppWarning {
+    SettingsCorrupt {
+        #[serde(skip_serializing)]
+        detail: String,
+    },
+    SettingsClamped {
+        original_ms: u64,
+        clamped_ms: u64,
+    },
+    SettingsUnknownVersion {
+        version: String,
+    },
+}
+
+impl From<FfiVaultError> for AppError {
+    /// Explicit per-variant mapping. Adding a new `FfiVaultError` variant
+    /// in the bridge crate will surface here as a compile error (the match
+    /// must be exhaustive), forcing a deliberate UI-mapping choice.
+    ///
+    /// The bridge's `WrongPasswordOrCorrupt` / `WrongMnemonicOrCorrupt`
+    /// variants are deliberately conflated per `docs/threat-model.md` §13's
+    /// anti-oracle property; both fold to `WrongPassword` here (the user's
+    /// affordance is "retry credential" in both cases). Bridge variants
+    /// that cannot reach D.1.1's code paths (block-share authorisation,
+    /// trash/restore preconditions, recovery-phrase pre-validation) fold
+    /// to `Internal { detail }` so a regression that lets them fire
+    /// surfaces as a clear bug-report path.
+    ///
+    /// `FolderInvalid` folds to `Io { detail }` here because the bridge
+    /// surfaces the underlying IO context but not the caller's chosen path.
+    /// Task 4's command handlers, which DO know the user-picked path, will
+    /// construct `VaultPathNotFound` / `VaultPathNotAVault` directly at the
+    /// boundary so the UI can render the path-specific affordance.
+    fn from(e: FfiVaultError) -> Self {
+        // Log developer-facing detail before stripping. tracing::warn so
+        // it appears in stderr in dev mode and in any production log sink
+        // without requiring DEBUG verbosity.
+        tracing::warn!(?e, "FfiVaultError surfacing to AppError");
+
+        match e {
+            // Decryption-failure-shaped → WrongPassword (info-leak prevention).
+            // Both bridge variants conflate "wrong credential" and "corruption"
+            // per the anti-oracle property; we preserve the conflation at the
+            // UI boundary too.
+            FfiVaultError::WrongPasswordOrCorrupt
+            | FfiVaultError::WrongMnemonicOrCorrupt => AppError::WrongPassword,
+
+            // Genuine cryptographic / integrity failures → VaultCorrupt.
+            FfiVaultError::CorruptVault { detail }
+            | FfiVaultError::SaveCryptoFailure { detail }
+            | FfiVaultError::CardDecodeFailure { detail } => AppError::VaultCorrupt { detail },
+
+            // vault.toml ↔ identity.bundle.enc mismatch is a corruption-class
+            // failure from the user's perspective: the on-disk state is
+            // inconsistent and they need to re-pair from backups. We synthesise
+            // a detail string (this variant carries no payload).
+            FfiVaultError::VaultMismatch => AppError::VaultCorrupt {
+                detail: "vault.toml and identity.bundle.enc reference different vaults"
+                    .to_string(),
+            },
+
+            // Pre-decryption mnemonic validation failure. Unreachable from
+            // D.1.1's password-only unlock path; if it ever fires here, it's
+            // a bug — surface as Internal with detail for the bug report.
+            FfiVaultError::InvalidMnemonic { detail } => AppError::Internal {
+                detail: format!("invalid mnemonic on password-only unlock path: {detail}"),
+            },
+
+            // Pre-unlock filesystem failure. Task 4's command handlers replace
+            // this with the path-aware VaultPathNotFound / VaultPathNotAVault
+            // construction at the boundary; here we fold to the generic Io
+            // bucket so any pre-Task-4 code path surfaces something coherent.
+            FfiVaultError::FolderInvalid { detail } => AppError::Io { detail },
+
+            // Block-lookup miss. Reachable in D.1.1 if a caller passes a
+            // stale block UUID to read_block (e.g. between a settings-block
+            // creation and the subsequent manifest refresh). Surface as
+            // Internal — D.1.1's settings flow never asks for an unknown
+            // UUID, so this firing means a bug.
+            FfiVaultError::BlockNotFound { uuid_hex } => AppError::Internal {
+                detail: format!("block not found in manifest: {uuid_hex}"),
+            },
+
+            // Block-share authorization failures, recipient table mismatches,
+            // and trash/restore preconditions: unreachable in D.1.1 (no
+            // share / no trash UI). Map to Internal so an accidental
+            // wiring of a share/trash command surfaces clearly.
+            other @ (FfiVaultError::NotAuthor { .. }
+            | FfiVaultError::RecipientAlreadyPresent
+            | FfiVaultError::MissingRecipientCard { .. }
+            | FfiVaultError::BlockUuidAlreadyLive { .. }
+            | FfiVaultError::BlockNotInTrash { .. }) => AppError::Internal {
+                detail: format!("{other:?}"),
+            },
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::Value;
+
+    fn round_trip(err: &AppError) -> Value {
+        serde_json::from_str(&serde_json::to_string(err).expect("serialize")).expect("parse")
+    }
+
+    #[test]
+    fn wrong_password_has_code_only() {
+        let v = round_trip(&AppError::WrongPassword);
+        assert_eq!(v["code"], "wrong_password");
+        assert_eq!(v.as_object().expect("object").len(), 1);
+    }
+
+    #[test]
+    fn kdf_too_weak_carries_payload() {
+        let v = round_trip(&AppError::KdfTooWeak {
+            current_memory_kib: 32_768,
+            min_memory_kib: 65_536,
+        });
+        assert_eq!(v["code"], "kdf_too_weak");
+        assert_eq!(v["current_memory_kib"], 32_768);
+        assert_eq!(v["min_memory_kib"], 65_536);
+    }
+
+    #[test]
+    fn vault_corrupt_detail_is_stripped() {
+        let v = round_trip(&AppError::VaultCorrupt {
+            detail: "sensitive dev info".to_string(),
+        });
+        assert_eq!(v["code"], "vault_corrupt");
+        assert!(v.get("detail").is_none(), "detail must NOT cross IPC");
+    }
+
+    #[test]
+    fn settings_out_of_range_carries_bounds() {
+        let v = round_trip(&AppError::SettingsOutOfRange {
+            min: 60_000,
+            max: 86_400_000,
+        });
+        assert_eq!(v["code"], "settings_out_of_range");
+        assert_eq!(v["min"], 60_000);
+        assert_eq!(v["max"], 86_400_000);
+    }
+
+    #[test]
+    fn settings_clamped_warning_carries_both_values() {
+        let w = AppWarning::SettingsClamped {
+            original_ms: 30_000,
+            clamped_ms: 60_000,
+        };
+        let v: Value =
+            serde_json::from_str(&serde_json::to_string(&w).expect("ser")).expect("parse");
+        assert_eq!(v["code"], "settings_clamped");
+        assert_eq!(v["original_ms"], 30_000);
+        assert_eq!(v["clamped_ms"], 60_000);
+    }
+
+    #[test]
+    fn unknown_version_warning_carries_version_string() {
+        let w = AppWarning::SettingsUnknownVersion {
+            version: "secretary.settings.v99".to_string(),
+        };
+        let v: Value =
+            serde_json::from_str(&serde_json::to_string(&w).expect("ser")).expect("parse");
+        assert_eq!(v["code"], "settings_unknown_version");
+        assert_eq!(v["version"], "secretary.settings.v99");
+    }
+
+    // Two additional From<FfiVaultError> spot-checks pin the anti-oracle
+    // collapse + the detail-stripping path at the bridge seam itself.
+    // These complement the variant-shape tests above by exercising the
+    // mapping logic, not just the serde shape.
+
+    #[test]
+    fn ffi_wrong_password_or_corrupt_collapses_to_wrong_password() {
+        let mapped: AppError = FfiVaultError::WrongPasswordOrCorrupt.into();
+        let v = round_trip(&mapped);
+        assert_eq!(
+            v["code"], "wrong_password",
+            "anti-oracle: WrongPasswordOrCorrupt must collapse to WrongPassword"
+        );
+    }
+
+    #[test]
+    fn ffi_corrupt_vault_detail_is_logged_but_stripped_on_serialize() {
+        let mapped: AppError = FfiVaultError::CorruptVault {
+            detail: "dev-facing crypto failure context".to_string(),
+        }
+        .into();
+        let v = round_trip(&mapped);
+        assert_eq!(v["code"], "vault_corrupt");
+        assert!(
+            v.get("detail").is_none(),
+            "FfiVaultError::CorruptVault.detail must NOT cross IPC"
+        );
+    }
+}

--- a/desktop/src-tauri/src/main.rs
+++ b/desktop/src-tauri/src/main.rs
@@ -8,6 +8,7 @@
 // but the macro is canonical Tauri practice — keep it from day one.
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
+mod auto_lock;
 mod constants;
 mod errors;
 

--- a/desktop/src-tauri/src/main.rs
+++ b/desktop/src-tauri/src/main.rs
@@ -11,6 +11,7 @@
 mod auto_lock;
 mod constants;
 mod errors;
+mod settings;
 
 fn main() {
     tauri::Builder::default()

--- a/desktop/src-tauri/src/main.rs
+++ b/desktop/src-tauri/src/main.rs
@@ -9,6 +9,7 @@
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
 mod constants;
+mod errors;
 
 fn main() {
     tauri::Builder::default()

--- a/desktop/src-tauri/src/main.rs
+++ b/desktop/src-tauri/src/main.rs
@@ -8,6 +8,8 @@
 // but the macro is canonical Tauri practice — keep it from day one.
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
+mod constants;
+
 fn main() {
     tauri::Builder::default()
         .run(tauri::generate_context!())

--- a/desktop/src-tauri/src/settings.rs
+++ b/desktop/src-tauri/src/settings.rs
@@ -1,0 +1,269 @@
+//! Settings record schema + parse/serialize. The vault I/O facade
+//! (`load_from_vault`, `save_to_vault`) lands in Task 3 along with
+//! `VaultSession`.
+//!
+//! See spec §8 for the full schema rationale (record_type, deterministic
+//! UUIDs, lazy creation, validation bounds, version handling).
+
+use crate::constants::{
+    AUTO_LOCK_DEFAULT_MS, AUTO_LOCK_MAX_MS, AUTO_LOCK_MIN_MS,
+    SETTINGS_FIELD_AUTO_LOCK_TIMEOUT_MS, SETTINGS_RECORD_TYPE,
+};
+use crate::errors::{AppError, AppWarning};
+
+/// Parsed app settings — pure value type with no secret material.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct Settings {
+    pub auto_lock_timeout_ms: u64,
+}
+
+impl Default for Settings {
+    fn default() -> Self {
+        Self {
+            auto_lock_timeout_ms: AUTO_LOCK_DEFAULT_MS,
+        }
+    }
+}
+
+/// Result of parsing a settings record from the vault.
+///
+/// The `Ok((Settings, Vec<AppWarning>))` shape lets parse succeed with
+/// non-fatal warnings (e.g. clamped-on-load when an older client wrote
+/// a too-small value), which the frontend renders as a banner alongside
+/// the manifest.
+pub type ParseResult = Result<(Settings, Vec<AppWarning>), AppError>;
+
+/// Parse one field-name / field-value pair into a `Settings`. Returns the
+/// parsed settings + any warnings (clamp on out-of-range, unknown version,
+/// etc.).
+///
+/// `record_type` is the record's record_type string. `field_name` is the
+/// field's name. `field_value_text` is the field's text value (settings
+/// fields are always text per spec §8). Bytes-typed fields are rejected by
+/// the caller, before reaching this pure parser.
+pub fn parse_settings_field(
+    record_type: &str,
+    field_name: &str,
+    field_value_text: &str,
+) -> ParseResult {
+    if record_type != SETTINGS_RECORD_TYPE {
+        return Err(AppError::SettingsUnknownVersion {
+            version: record_type.to_string(),
+        });
+    }
+
+    if field_name != SETTINGS_FIELD_AUTO_LOCK_TIMEOUT_MS {
+        return Err(AppError::SettingsCorrupt {
+            detail: format!("unknown field name: {field_name}"),
+        });
+    }
+
+    let parsed: u64 = field_value_text
+        .parse()
+        .map_err(|e| AppError::SettingsCorrupt {
+            detail: format!("auto_lock_timeout_ms parse failure: {e}"),
+        })?;
+
+    let (final_value, warnings) = clamp_with_warning(parsed);
+    Ok((
+        Settings {
+            auto_lock_timeout_ms: final_value,
+        },
+        warnings,
+    ))
+}
+
+/// Apply bounds-clamping + emit a warning if clamped. Used by the load path.
+/// The save path uses `validate_save_value` instead — clamping silently on
+/// save would mask user intent.
+fn clamp_with_warning(value: u64) -> (u64, Vec<AppWarning>) {
+    if value < AUTO_LOCK_MIN_MS {
+        (
+            AUTO_LOCK_MIN_MS,
+            vec![AppWarning::SettingsClamped {
+                original_ms: value,
+                clamped_ms: AUTO_LOCK_MIN_MS,
+            }],
+        )
+    } else if value > AUTO_LOCK_MAX_MS {
+        (
+            AUTO_LOCK_MAX_MS,
+            vec![AppWarning::SettingsClamped {
+                original_ms: value,
+                clamped_ms: AUTO_LOCK_MAX_MS,
+            }],
+        )
+    } else {
+        (value, vec![])
+    }
+}
+
+/// Validate a settings value before saving (frontend-supplied value path).
+/// Rejects out-of-range with `SettingsOutOfRange` rather than clamping —
+/// the frontend dialog also validates client-side; this round-trips only
+/// on adversarial input.
+pub fn validate_save_value(value: u64) -> Result<(), AppError> {
+    if (AUTO_LOCK_MIN_MS..=AUTO_LOCK_MAX_MS).contains(&value) {
+        Ok(())
+    } else {
+        Err(AppError::SettingsOutOfRange {
+            min: AUTO_LOCK_MIN_MS,
+            max: AUTO_LOCK_MAX_MS,
+        })
+    }
+}
+
+/// Serialize a `Settings` into the (record_type, field_name, field_value_text)
+/// triple expected by the vault save path. Pure function — the save call
+/// itself (which packages this into a `BlockInput` and calls
+/// `secretary_ffi_bridge::save_block`) lives in Task 3.
+pub fn serialize_settings(s: &Settings) -> (String, String, String) {
+    (
+        SETTINGS_RECORD_TYPE.to_string(),
+        SETTINGS_FIELD_AUTO_LOCK_TIMEOUT_MS.to_string(),
+        s.auto_lock_timeout_ms.to_string(),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_uses_constant() {
+        assert_eq!(Settings::default().auto_lock_timeout_ms, AUTO_LOCK_DEFAULT_MS);
+    }
+
+    #[test]
+    fn parse_happy_path_no_warnings() {
+        let (s, warnings) = parse_settings_field(
+            SETTINGS_RECORD_TYPE,
+            SETTINGS_FIELD_AUTO_LOCK_TIMEOUT_MS,
+            "300000",
+        )
+        .expect("parse");
+        assert_eq!(s.auto_lock_timeout_ms, 300_000);
+        assert!(warnings.is_empty());
+    }
+
+    #[test]
+    fn parse_below_min_clamps_with_warning() {
+        let (s, warnings) = parse_settings_field(
+            SETTINGS_RECORD_TYPE,
+            SETTINGS_FIELD_AUTO_LOCK_TIMEOUT_MS,
+            "30000",
+        )
+        .expect("parse");
+        assert_eq!(s.auto_lock_timeout_ms, AUTO_LOCK_MIN_MS);
+        assert_eq!(warnings.len(), 1);
+        match &warnings[0] {
+            AppWarning::SettingsClamped {
+                original_ms,
+                clamped_ms,
+            } => {
+                assert_eq!(*original_ms, 30_000);
+                assert_eq!(*clamped_ms, AUTO_LOCK_MIN_MS);
+            }
+            other => panic!("expected SettingsClamped, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_above_max_clamps_with_warning() {
+        let oversized = AUTO_LOCK_MAX_MS + 1;
+        let (s, warnings) = parse_settings_field(
+            SETTINGS_RECORD_TYPE,
+            SETTINGS_FIELD_AUTO_LOCK_TIMEOUT_MS,
+            &oversized.to_string(),
+        )
+        .expect("parse");
+        assert_eq!(s.auto_lock_timeout_ms, AUTO_LOCK_MAX_MS);
+        assert_eq!(warnings.len(), 1);
+    }
+
+    #[test]
+    fn parse_unknown_version_errors() {
+        let err = parse_settings_field(
+            "secretary.settings.v99",
+            SETTINGS_FIELD_AUTO_LOCK_TIMEOUT_MS,
+            "600000",
+        )
+        .expect_err("must error");
+        match err {
+            AppError::SettingsUnknownVersion { version } => {
+                assert_eq!(version, "secretary.settings.v99");
+            }
+            other => panic!("expected SettingsUnknownVersion, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_unknown_field_name_errors() {
+        let err = parse_settings_field(SETTINGS_RECORD_TYPE, "unknown_field", "x")
+            .expect_err("must error");
+        match err {
+            AppError::SettingsCorrupt { .. } => {}
+            other => panic!("expected SettingsCorrupt, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_non_integer_errors() {
+        let err = parse_settings_field(
+            SETTINGS_RECORD_TYPE,
+            SETTINGS_FIELD_AUTO_LOCK_TIMEOUT_MS,
+            "not-a-number",
+        )
+        .expect_err("must error");
+        match err {
+            AppError::SettingsCorrupt { .. } => {}
+            other => panic!("expected SettingsCorrupt, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn validate_save_accepts_default() {
+        assert!(validate_save_value(AUTO_LOCK_DEFAULT_MS).is_ok());
+    }
+
+    #[test]
+    fn validate_save_rejects_below_min() {
+        let err = validate_save_value(AUTO_LOCK_MIN_MS - 1).expect_err("must error");
+        match err {
+            AppError::SettingsOutOfRange { min, max } => {
+                assert_eq!(min, AUTO_LOCK_MIN_MS);
+                assert_eq!(max, AUTO_LOCK_MAX_MS);
+            }
+            other => panic!("expected SettingsOutOfRange, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn validate_save_rejects_above_max() {
+        let err = validate_save_value(AUTO_LOCK_MAX_MS + 1).expect_err("must error");
+        match err {
+            AppError::SettingsOutOfRange { .. } => {}
+            other => panic!("expected SettingsOutOfRange, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn serialize_round_trips_through_parse() {
+        let original = Settings {
+            auto_lock_timeout_ms: 900_000,
+        };
+        let (record_type, field_name, field_value) = serialize_settings(&original);
+        let (parsed, warnings) =
+            parse_settings_field(&record_type, &field_name, &field_value).expect("parse");
+        assert_eq!(parsed, original);
+        assert!(warnings.is_empty());
+    }
+
+    #[test]
+    fn validate_save_accepts_min_and_max_inclusive() {
+        // The bounds are inclusive — pin that to prevent a sneaky off-by-one
+        // refactor that would reject the exact min/max user-picked values.
+        assert!(validate_save_value(AUTO_LOCK_MIN_MS).is_ok());
+        assert!(validate_save_value(AUTO_LOCK_MAX_MS).is_ok());
+    }
+}

--- a/desktop/src-tauri/src/settings.rs
+++ b/desktop/src-tauri/src/settings.rs
@@ -6,8 +6,8 @@
 //! UUIDs, lazy creation, validation bounds, version handling).
 
 use crate::constants::{
-    AUTO_LOCK_DEFAULT_MS, AUTO_LOCK_MAX_MS, AUTO_LOCK_MIN_MS,
-    SETTINGS_FIELD_AUTO_LOCK_TIMEOUT_MS, SETTINGS_RECORD_TYPE,
+    AUTO_LOCK_DEFAULT_MS, AUTO_LOCK_MAX_MS, AUTO_LOCK_MIN_MS, SETTINGS_FIELD_AUTO_LOCK_TIMEOUT_MS,
+    SETTINGS_RECORD_TYPE,
 };
 use crate::errors::{AppError, AppWarning};
 
@@ -131,7 +131,10 @@ mod tests {
 
     #[test]
     fn default_uses_constant() {
-        assert_eq!(Settings::default().auto_lock_timeout_ms, AUTO_LOCK_DEFAULT_MS);
+        assert_eq!(
+            Settings::default().auto_lock_timeout_ms,
+            AUTO_LOCK_DEFAULT_MS
+        );
     }
 
     #[test]

--- a/docs/handoffs/2026-05-27-d11-task-2-shipped.md
+++ b/docs/handoffs/2026-05-27-d11-task-2-shipped.md
@@ -19,7 +19,7 @@ Four pure-Rust modules that compile + unit-test in isolation, no I/O, no Tauri r
 | Handoff baton | This file ([`docs/handoffs/2026-05-27-d11-task-2-shipped.md`](.)) | Captures Task 2's delivery and frames Task 3. |
 | Symlink retarget | [`NEXT_SESSION.md`](../../NEXT_SESSION.md) | Bumped from `2026-05-27-d11-task-1-shipped.md` to this file. |
 
-**Commits on `feature/d11-task-2`** (5, one per module + a fmt fixup):
+**Commits on `feature/d11-task-2`** (5 original + 2 post-review fixups + a baton-sync amendment):
 
 | SHA | Subject |
 |---|---|
@@ -28,26 +28,28 @@ Four pure-Rust modules that compile + unit-test in isolation, no I/O, no Tauri r
 | `588f37e` | `feat(d11): IdleTracker pure module — now_ms + notify + is_expired (underflow-safe)` |
 | `0a1281a` | `feat(d11): Settings parse/serialize pure module + Task 2 clippy hardening` |
 | `de947dd` | `style(d11): cargo fmt fixup over Task 2 modules` |
+| `ea30470` | `docs(d11): document u64 ms truncation bound in auto_lock::now_ms` |
+| `31bb133` | `refactor(d11): split map_ffi_error pure helper from From<FfiVaultError>` |
 
 Post-squash-merge SHA on `main` will differ.
 
 ### Gauntlet (live, performed)
 
 ```
-PASSED: 992 FAILED: 0 IGNORED: 10        # baseline was 960 / 0 / 10
+PASSED: 993 FAILED: 0 IGNORED: 10        # baseline was 960 / 0 / 10
 cargo clippy --release --workspace --tests -- -D warnings   → clean
 cargo fmt --all -- --check                                  → clean
 uv run core/tests/python/conformance.py                     → PASS
 uv run core/tests/python/spec_test_name_freshness.py        → PASS
 ```
 
-Plan predicted +27 tests (960 → 987). Actual delta is **+32** (960 → 992) — five extra tests beyond the plan's count, all defensible additions and called out per-module:
+Plan predicted +27 tests (960 → 987). Actual delta is **+33** (960 → 993) — six extra tests beyond the plan's count, all defensible additions and called out per-module:
 
-- `errors.rs`: +2 — `ffi_wrong_password_or_corrupt_collapses_to_wrong_password` (pins the anti-oracle collapse at the From<FfiVaultError> seam, not just at the serde shape) + `ffi_corrupt_vault_detail_is_logged_but_stripped_on_serialize` (pins the detail-stripping path end-to-end).
+- `errors.rs`: +3 — `ffi_wrong_password_or_corrupt_collapses_to_wrong_password` (pins the anti-oracle collapse at the From<FfiVaultError> seam, not just at the serde shape) + `ffi_corrupt_vault_detail_is_logged_but_stripped_on_serialize` (pins the detail-stripping path end-to-end) + `map_ffi_error_is_pure_no_log_side_effect_required` (post-review-fixup: documents the API of the pure `map_ffi_error` helper that `From<FfiVaultError>` delegates to after logging).
 - `auto_lock.rs`: +1 — `now_ms_is_after_2020` (sanity check: would catch an accidental "return seconds instead of milliseconds" regression).
 - `settings.rs`: +2 — `parse_non_integer_errors` (the plan listed this in the test count but I had to verify) + `validate_save_accepts_min_and_max_inclusive` (the `..=` form is easy to off-by-one; pins the inclusivity).
 
-Per the plan's note on prediction tracking: surplus tests are good news; Task 3's gauntlet baseline becomes **992 / 0 / 10** rather than **987 / 0 / 10**.
+Per the plan's note on prediction tracking: surplus tests are good news; Task 3's gauntlet baseline becomes **993 / 0 / 10** rather than **987 / 0 / 10**.
 
 ### Plan execution trace (for the reviewer)
 
@@ -66,7 +68,7 @@ Per the plan (Task 3 begins at plan line 1500 of `docs/superpowers/plans/2026-05
 
 **Acceptance criteria for Task 3 (from the plan):**
 
-- Gauntlet count goes from **992 → ~1004** (+12 integration tests).
+- Gauntlet count goes from **993 → ~1005** (+12 integration tests).
 - `desktop/src-tauri/Cargo.toml` gains `tempfile = "=3.27.0"` (exact pin per CLAUDE.md atomic-write discipline) + `dirs = "5"` + `rand` (for the per-vault device UUID generation).
 - Settings round-trips through a real ephemeral vault: write via `save_block`, read back via `read_block`, parse via Task 2's `parse_settings_field`, assert equality.
 - Drop-chain wipe pinned: drop the `UnlockedSession`, then memory-inspect that the `UnlockedIdentity`'s secret bytes are zeroed (the bridge crate's existing zeroize tests give a working pattern).
@@ -83,6 +85,18 @@ Per the plan (Task 3 begins at plan line 1500 of `docs/superpowers/plans/2026-05
 
 Neither adaptation changes the spec or the architectural decisions. Both are encounters with reality that the plan author couldn't have predicted without the live attempt.
 
+### Post-review fixups (PR #137 review thread)
+
+Two minor items from the PR #137 self-review landed as separate commits on top of the original five (`ea30470`, `31bb133`):
+
+1. **Documented the `u64` ms truncation bound in `now_ms`.** `Duration::as_millis()` returns `u128`; the truncation to `u64` is safe well past any horizon this code will run, but worth one sentence in the docstring.
+2. **Factored `map_ffi_error` out of `From<FfiVaultError>`.** The original `From` body embedded a `tracing::warn!` side effect; conventionally `From` is expected to be pure-value. The pure mapping now lives in `pub fn map_ffi_error(e) -> AppError`, and `impl From` logs + delegates. The side effect is visible at the call site rather than buried in the conversion. Adds one test (`map_ffi_error_is_pure_no_log_side_effect_required`) documenting the pure-helper API; existing 8 `From`-path tests unchanged.
+
+Two further review items were deferred and filed as follow-up issues:
+
+- **#139** — `AppError` lacks `Deserialize`; the wire-format contract is enforced one-way only at the Rust level. The `#[serde(skip_serializing)]` on `detail` fields makes a strict identity round-trip impossible without changing attribute semantics; defer to Task 6 (TS discriminated union) so the wire-format pin has a single canonical source.
+- **#140** — `parse_settings_field`'s text-only invariant is documented but not type-enforced. Task 3 has the context (vault-load wiring + `RecordFieldValue` shape) to either enforce by signature or cover by acceptance test.
+
 ### Decisions settled
 
 - **Anti-oracle conflation preserved at the IPC seam.** Both `FfiVaultError::WrongPasswordOrCorrupt` and `FfiVaultError::WrongMnemonicOrCorrupt` collapse to `AppError::WrongPassword`. This is now pinned by `ffi_wrong_password_or_corrupt_collapses_to_wrong_password` so a future refactor that tries to split the variants for "better UX" will fail a test rather than slip through.
@@ -91,14 +105,16 @@ Neither adaptation changes the spec or the architectural decisions. Both are enc
 
 ### Risks carried forward
 
-- **Plan's gauntlet-count predictions for Tasks 3–5 should be re-validated.** Task 2 came in at **992** rather than the predicted **987** (+5 surplus tests). Task 3 was predicted at 999 (assuming 987 + 12); the actual baseline is now 992 + ~12 = ~1004. Task 4 at 1002 → ~1007; Task 5 at 1005 → ~1010. If actual counts diverge further, the plan should grow a one-line note rather than the implementations being padded/trimmed to hit predictions.
+- **Plan's gauntlet-count predictions for Tasks 3–5 should be re-validated.** Task 2 came in at **993** rather than the predicted **987** (+6 surplus tests, including +1 from the post-review fixup). Task 3 was predicted at 999 (assuming 987 + 12); the actual baseline is now 993 + ~12 = ~1005. Task 4 at 1002 → ~1008; Task 5 at 1005 → ~1011. If actual counts diverge further, the plan should grow a one-line note rather than the implementations being padded/trimmed to hit predictions.
 - **`AppError::KdfTooWeak` has no producer.** It survives as a typed variant for the future where the bridge surfaces the structured `WeakKdfParams` payload, but today every "weak KDF" failure folds through the bridge's `CorruptVault { detail }`. The serde-shape test `kdf_too_weak_carries_payload` keeps the wire format pinned, so when the bridge eventually exposes the structured payload the desktop side will already be ready. Document in `From<FfiVaultError>` docstring (done).
 - **`AppError::AlreadyUnlocked` / `AppError::NotUnlocked` have no producer in Task 2.** These are session-state errors — Task 3's `VaultSession::unlock` and `VaultSession::with_open_vault` produce them. The `#[allow(dead_code)]` on `AppError` covers them; the producer comment in the source names Task 4 (which is when the actual command handlers wrap them).
 
-### Issues currently open (unchanged from prior session)
+### Issues currently open (carry-over + new from PR #137 review)
 
 - #37, #117, #120, #122, #123 — none affected by Task 2.
 - #38, #45, #75, #76, #78, #79, #81, #87, #88, #90, #95, #98 — none affected.
+- **#139** — desktop: `AppError` lacks `Deserialize`; revisit alongside Task 6 TS discriminated union.
+- **#140** — desktop: `parse_settings_field` text-only invariant; resolve in Task 3 (signature change or acceptance test).
 
 ### Housekeeping (stale worktrees on disk)
 
@@ -125,7 +141,7 @@ git status --short              # expect: clean
 git checkout main
 git pull --ff-only origin main
 
-# Re-baseline the gauntlet on fresh main (expect 992 / 0 / 10):
+# Re-baseline the gauntlet on fresh main (expect 993 / 0 / 10):
 cargo test --release --workspace --no-fail-fast 2>&1 | grep -E "^test result:" | awk '{passed+=$4; failed+=$6; ignored+=$8} END {print "PASSED:", passed, "FAILED:", failed, "IGNORED:", ignored}'
 
 # Set up the Task 3 worktree:
@@ -147,7 +163,7 @@ uv run core/tests/python/spec_test_name_freshness.py
 ## Closing inventory
 
 - **Branch state on close:** `main` at `e329087` (D.1.1 Task 1 PR #131 merged earlier this session). `feature/d11-task-2` carries 5 commits on top (4 module commits + 1 fmt fixup).
-- **Workspace tests on `feature/d11-task-2`:** **992 passed + 10 ignored** (+32 over the post-Task-1 baseline of 960).
+- **Workspace tests on `feature/d11-task-2`:** **993 passed + 10 ignored** (+33 over the post-Task-1 baseline of 960; includes +1 from the post-review fixup).
 - **README.md:** unchanged. Per-task status flips on a sub-project in early implementation phase would be noise (see prior baton; same logic applies).
 - **ROADMAP.md:** unchanged. D.1 section's wording ("D.1.1 walking skeleton ... in design.") remains brief and inoffensive; the per-task implementation status doesn't belong in the cross-sub-project roadmap.
 - **CLAUDE.md:** unchanged this session.

--- a/docs/handoffs/2026-05-27-d11-task-2-shipped.md
+++ b/docs/handoffs/2026-05-27-d11-task-2-shipped.md
@@ -1,0 +1,160 @@
+# NEXT_SESSION.md — D.1.1 Task 2 (backend pure modules) shipped
+
+**Session date:** 2026-05-27 (continues from the D.1.1 Task 1 session earlier today; the scaffold landed via PR #131 at `e329087` on `main`. This session adds the four pure backend modules called out in the plan's Task 2.)
+**Status:** D.1.1 Task 2 authored on branch `feature/d11-task-2`; PR pending. Predecessors on `main`: D.1.1 spec + ADR 0007 (PR #130, `a5d85b9`) and D.1.1 Task 1 scaffold (PR #131, `e329087`).
+
+## (1) What we shipped this session
+
+Four pure-Rust modules that compile + unit-test in isolation, no I/O, no Tauri runtime, no `secretary-ffi-bridge` runtime dependencies (only typed value imports). Each module ships its own unit tests with the implementation, per CLAUDE.md TDD discipline.
+
+| Artifact | Path | Notes |
+|---|---|---|
+| Constants table | [`desktop/src-tauri/src/constants.rs`](../../desktop/src-tauri/src/constants.rs) | The 8 named constants from spec §8 (`AUTO_LOCK_*_MS`, `SETTINGS_BLOCK_NAME`, `SETTINGS_RECORD_TYPE`, `SETTINGS_FIELD_AUTO_LOCK_TIMEOUT_MS`, `ACTIVITY_NOTIFY_MIN_INTERVAL_MS`) + the `deterministic_uuid_16(input) = SHA-256(input)[0..16]` helper. **4 tests** including two frozen-hex tripwires that pin the on-disk UUIDs for the settings block (`04fcc7aa05345f631e7f1ce2db78ba9a`) and settings record (`4145cb7a4531f1ac41af6717e205e1a9`); any future change to those input strings becomes a test failure flagging a vault-format break before it ships. |
+| Error types | [`desktop/src-tauri/src/errors.rs`](../../desktop/src-tauri/src/errors.rs) | `AppError` (13 variants) + `AppWarning` (3 variants) — both serde-tagged discriminated unions; developer-facing `detail` fields are `#[serde(skip_serializing)]` so they're logged via `tracing` on the Rust side but never reach the frontend. `From<FfiVaultError>` is an explicit per-variant exhaustive match so any future bridge variant becomes a compile error forcing a deliberate UI-mapping choice. Anti-oracle property preserved at the seam: both `WrongPasswordOrCorrupt` and `WrongMnemonicOrCorrupt` collapse to `AppError::WrongPassword`. **8 tests** (6 serde-shape, 2 mapping spot-checks at the From<FfiVaultError> seam). |
+| Idle tracker | [`desktop/src-tauri/src/auto_lock.rs`](../../desktop/src-tauri/src/auto_lock.rs) | `IdleTracker { last_activity_ms }` + `now_ms()` free function. `notify` only advances forward (rejects backward clock skew, preventing spurious auto-lock after suspend/resume). `is_expired` uses `saturating_sub` so backward clock differences return false rather than panicking. **8 tests** including underflow-safety, monotonicity, and a `now_ms_is_after_2020` system-clock sanity check. |
+| Settings parser | [`desktop/src-tauri/src/settings.rs`](../../desktop/src-tauri/src/settings.rs) | `Settings { auto_lock_timeout_ms: u64 }` pure value type + `parse_settings_field` (load path: lenient — clamps out-of-bounds with `AppWarning::SettingsClamped`) + `validate_save_value` (save path: strict — rejects out-of-bounds with `AppError::SettingsOutOfRange`, so silent clamping can't mask user intent) + `serialize_settings` (returns the `(record_type, field_name, value_text)` triple that Task 3's vault-save will package into a `BlockInput`). **12 tests** including a serialize↔parse round-trip and inclusive min/max bounds pinning. |
+| Wiring in `main.rs` | [`desktop/src-tauri/src/main.rs`](../../desktop/src-tauri/src/main.rs) | Added `mod auto_lock; mod constants; mod errors; mod settings;` declarations. `fn main()` body unchanged from Task 1. |
+| Cargo deps | [`desktop/src-tauri/Cargo.toml`](../../desktop/src-tauri/Cargo.toml) | Added: `secretary-ffi-bridge` (workspace path — for `FfiVaultError` typed mapping), `serde` + `serde_json` (IPC wire format), `thiserror` (derive `Error`), `tracing` (Rust-side detail logging), `sha2` + `hex` (deterministic UUID helper + frozen-hex tests). Versions track the workspace conventions used by `core/` and `ffi/secretary-ffi-bridge/`. The `tempfile = "=3.27.0"` exact-pin (for atomic writes) is NOT pulled here — it lands in Task 3 when the `device_uuid` persistence path is wired up. |
+| Lockfile | [`Cargo.lock`](../../Cargo.lock) | Resolves the new transitive deps (serde 1.x, thiserror 2.x, tracing 0.1.x, sha2 0.10.x — all already in the workspace via other crates). |
+| Handoff baton | This file ([`docs/handoffs/2026-05-27-d11-task-2-shipped.md`](.)) | Captures Task 2's delivery and frames Task 3. |
+| Symlink retarget | [`NEXT_SESSION.md`](../../NEXT_SESSION.md) | Bumped from `2026-05-27-d11-task-1-shipped.md` to this file. |
+
+**Commits on `feature/d11-task-2`** (5, one per module + a fmt fixup):
+
+| SHA | Subject |
+|---|---|
+| `1330d24` | `feat(d11): constants module — auto-lock timings + settings schema names + deterministic UUID helper` |
+| `07dd9e3` | `feat(d11): AppError + AppWarning + From<FfiVaultError> mapping` |
+| `588f37e` | `feat(d11): IdleTracker pure module — now_ms + notify + is_expired (underflow-safe)` |
+| `0a1281a` | `feat(d11): Settings parse/serialize pure module + Task 2 clippy hardening` |
+| `de947dd` | `style(d11): cargo fmt fixup over Task 2 modules` |
+
+Post-squash-merge SHA on `main` will differ.
+
+### Gauntlet (live, performed)
+
+```
+PASSED: 992 FAILED: 0 IGNORED: 10        # baseline was 960 / 0 / 10
+cargo clippy --release --workspace --tests -- -D warnings   → clean
+cargo fmt --all -- --check                                  → clean
+uv run core/tests/python/conformance.py                     → PASS
+uv run core/tests/python/spec_test_name_freshness.py        → PASS
+```
+
+Plan predicted +27 tests (960 → 987). Actual delta is **+32** (960 → 992) — five extra tests beyond the plan's count, all defensible additions and called out per-module:
+
+- `errors.rs`: +2 — `ffi_wrong_password_or_corrupt_collapses_to_wrong_password` (pins the anti-oracle collapse at the From<FfiVaultError> seam, not just at the serde shape) + `ffi_corrupt_vault_detail_is_logged_but_stripped_on_serialize` (pins the detail-stripping path end-to-end).
+- `auto_lock.rs`: +1 — `now_ms_is_after_2020` (sanity check: would catch an accidental "return seconds instead of milliseconds" regression).
+- `settings.rs`: +2 — `parse_non_integer_errors` (the plan listed this in the test count but I had to verify) + `validate_save_accepts_min_and_max_inclusive` (the `..=` form is easy to off-by-one; pins the inclusivity).
+
+Per the plan's note on prediction tracking: surplus tests are good news; Task 3's gauntlet baseline becomes **992 / 0 / 10** rather than **987 / 0 / 10**.
+
+### Plan execution trace (for the reviewer)
+
+- Plan Steps 1–17 followed verbatim with two minor adaptations (called out in §(3)).
+- Step 18 (push + PR) executes at the end of this session.
+- All four modules under the 500-line CLAUDE.md threshold: constants ≈ 140 LOC, errors ≈ 290 LOC, auto_lock ≈ 118 LOC, settings ≈ 270 LOC.
+- Per-module TDD discipline: each module's tests written together with its implementation; each module committed in its own commit so the diff stays bisectable.
+
+## (2) What's next — D.1.1 Task 3 (session + settings I/O facade)
+
+Per the plan (Task 3 begins at plan line 1500 of `docs/superpowers/plans/2026-05-27-d11-tauri-walking-skeleton.md`), Task 3 wires the pure modules into a stateful session that owns the unlocked `OpenVaultManifest` + `UnlockedIdentity` and provides the actual vault I/O:
+
+- `desktop/src-tauri/src/session.rs` — `VaultSession` / `UnlockedSession` types + `Drop` impl + `unlock` / `lock` / `notify_activity` / `with_open_vault` methods. ~300 LOC.
+- `desktop/src-tauri/src/settings.rs` (extension) — `load_from_vault` + `save_to_vault` + `device_uuid` helpers (persist per-vault UUID at `dirs::data_dir()/secretary-desktop/devices/<vault_uuid_hex>.dev` for the vector-clock layer).
+- `desktop/src-tauri/tests/session_integration.rs` — ~12 cargo tests against `core/tests/data/golden_vault_001/` + ephemeral vaults.
+
+**Acceptance criteria for Task 3 (from the plan):**
+
+- Gauntlet count goes from **992 → ~1004** (+12 integration tests).
+- `desktop/src-tauri/Cargo.toml` gains `tempfile = "=3.27.0"` (exact pin per CLAUDE.md atomic-write discipline) + `dirs = "5"` + `rand` (for the per-vault device UUID generation).
+- Settings round-trips through a real ephemeral vault: write via `save_block`, read back via `read_block`, parse via Task 2's `parse_settings_field`, assert equality.
+- Drop-chain wipe pinned: drop the `UnlockedSession`, then memory-inspect that the `UnlockedIdentity`'s secret bytes are zeroed (the bridge crate's existing zeroize tests give a working pattern).
+- Clippy + fmt + conformance + spec-freshness all stay green.
+
+**Estimate:** ~75–90 min (Drop-chain test setup and `tempfile::TempDir`-driven ephemeral-vault fixtures take longer than pure-module work).
+
+## (3) Open decisions and risks
+
+### Plan adaptations (worth flagging to the reviewer)
+
+1. **`From<FfiVaultError>` match adapted to the bridge's actual variants.** The plan's draft used variant names like `FfiVaultError::Unlock { .. }`, `FfiVaultError::WeakKdfParams { .. }`, `FfiVaultError::Io { detail }` that don't exist in the current bridge crate — the plan warned this might happen ("If `FfiVaultError` variants don't match the names used in the `From` impl, fix the match arms to use the real names"). The actual bridge surface (per [`ffi/secretary-ffi-bridge/src/error/vault/mod.rs`](../../ffi/secretary-ffi-bridge/src/error/vault/mod.rs)) is 13 variants including `WrongPasswordOrCorrupt`, `WrongMnemonicOrCorrupt`, `InvalidMnemonic { detail }`, `VaultMismatch`, `CorruptVault { detail }`, `FolderInvalid { detail }`, `BlockNotFound { uuid_hex }`, `SaveCryptoFailure { detail }`, `CardDecodeFailure { detail }`, plus four share/restore variants (`NotAuthor`, `RecipientAlreadyPresent`, `MissingRecipientCard`, `BlockUuidAlreadyLive`, `BlockNotInTrash`). All are now mapped explicitly in the `From` impl with rationale comments naming which `AppError` variant each one routes to and why. The `WeakKdfParams` → `KdfTooWeak` mapping has no producer because the bridge already collapses `WeakKdfParams` into `CorruptVault { detail }` upstream — `AppError::KdfTooWeak` survives as a typed variant (with a serde-shape test) for the future where the bridge exposes the parameter pair structurally, but no `From` arm constructs it today. This is documented in the module docstring.
+2. **Clippy hardening rolled into Task 2 rather than deferred to Task 3.** The plan didn't anticipate clippy's `enum_variant_names` complaint about `AppWarning` (all three variants share the `Settings` prefix), `dead_code` complaints on the variants Task 4 will produce, or `assertions_on_constants` on tests like `assert!(AUTO_LOCK_MIN_MS < AUTO_LOCK_DEFAULT_MS)` (compile-time-known so it's not a runtime test). Resolved per CLAUDE.md "Clippy must stay clean" with: explicit `#[allow(clippy::enum_variant_names)]` + `#[allow(dead_code)]` allows with comments naming the future producer task and the IPC-contract reason for the shared prefix, and three compile-time-constant tests lifted to `const _: () = assert!(...)` (which upgrades the relationship check to a compile error if ever violated). All allows are scoped to specific items with documented justifications — no blanket file-level allows.
+
+Neither adaptation changes the spec or the architectural decisions. Both are encounters with reality that the plan author couldn't have predicted without the live attempt.
+
+### Decisions settled
+
+- **Anti-oracle conflation preserved at the IPC seam.** Both `FfiVaultError::WrongPasswordOrCorrupt` and `FfiVaultError::WrongMnemonicOrCorrupt` collapse to `AppError::WrongPassword`. This is now pinned by `ffi_wrong_password_or_corrupt_collapses_to_wrong_password` so a future refactor that tries to split the variants for "better UX" will fail a test rather than slip through.
+- **`detail` field policy on the IPC seam is unconditional.** Every variant that carries diagnostic context strips it on the wire via `#[serde(skip_serializing)]`; the detail is logged via `tracing::warn!` on the Rust side before stripping. `ffi_corrupt_vault_detail_is_logged_but_stripped_on_serialize` and `vault_corrupt_detail_is_stripped` pin both halves of the property.
+- **`FolderInvalid` maps to the generic `Io` bucket in `From<FfiVaultError>`.** Task 4's command handlers, which know the user-picked path, will construct `VaultPathNotFound` / `VaultPathNotAVault` directly at the boundary (where the path is in scope) rather than reverse-engineering from a detail string. The `Io` fallback exists so that any pre-Task-4 code path that exposes `FolderInvalid` surfaces something coherent.
+
+### Risks carried forward
+
+- **Plan's gauntlet-count predictions for Tasks 3–5 should be re-validated.** Task 2 came in at **992** rather than the predicted **987** (+5 surplus tests). Task 3 was predicted at 999 (assuming 987 + 12); the actual baseline is now 992 + ~12 = ~1004. Task 4 at 1002 → ~1007; Task 5 at 1005 → ~1010. If actual counts diverge further, the plan should grow a one-line note rather than the implementations being padded/trimmed to hit predictions.
+- **`AppError::KdfTooWeak` has no producer.** It survives as a typed variant for the future where the bridge surfaces the structured `WeakKdfParams` payload, but today every "weak KDF" failure folds through the bridge's `CorruptVault { detail }`. The serde-shape test `kdf_too_weak_carries_payload` keeps the wire format pinned, so when the bridge eventually exposes the structured payload the desktop side will already be ready. Document in `From<FfiVaultError>` docstring (done).
+- **`AppError::AlreadyUnlocked` / `AppError::NotUnlocked` have no producer in Task 2.** These are session-state errors — Task 3's `VaultSession::unlock` and `VaultSession::with_open_vault` produce them. The `#[allow(dead_code)]` on `AppError` covers them; the producer comment in the source names Task 4 (which is when the actual command handlers wrap them).
+
+### Issues currently open (unchanged from prior session)
+
+- #37, #117, #120, #122, #123 — none affected by Task 2.
+- #38, #45, #75, #76, #78, #79, #81, #87, #88, #90, #95, #98 — none affected.
+
+### Housekeeping (stale worktrees on disk)
+
+Carry-over from the prior baton (`feature/d11-task-1` is now also resolved after PR #131 merged, and the worktree was removed at the top of this session). Remaining stale worktrees that can be removed at any pause:
+
+```bash
+# From /Users/hherb/src/secretary, after the present PR merges:
+git worktree remove .worktrees/c1-1b-sync-merge   && git branch -D feature/c1-1b-task-17
+git worktree remove .worktrees/c2-task-1-spec     && git branch -D feature/c2-task-1-spec
+for n in 1 2 3 4 5 6 7 8 9 10; do
+  git worktree remove .worktrees/c2-task-$n       && git branch -D feature/c2-task-$n
+done
+git worktree remove .worktrees/d11-tauri-spec     && git branch -D feature/d11-tauri-spec
+# Keep .worktrees/d11-task-2 until this PR merges; remove after.
+```
+
+## (4) Exact commands to resume (Task 3)
+
+```bash
+# After this Task 2 PR (feature/d11-task-2) merges:
+cd /Users/hherb/src/secretary
+git fetch --prune origin
+git status --short              # expect: clean
+git checkout main
+git pull --ff-only origin main
+
+# Re-baseline the gauntlet on fresh main (expect 992 / 0 / 10):
+cargo test --release --workspace --no-fail-fast 2>&1 | grep -E "^test result:" | awk '{passed+=$4; failed+=$6; ignored+=$8} END {print "PASSED:", passed, "FAILED:", failed, "IGNORED:", ignored}'
+
+# Set up the Task 3 worktree:
+git worktree add .worktrees/d11-task-3 -b feature/d11-task-3 main
+cd .worktrees/d11-task-3
+
+# Open the plan and follow Task 3 step-by-step:
+#   docs/superpowers/plans/2026-05-27-d11-tauri-walking-skeleton.md
+# Search for "## Task 3:" (line ~1500). Each step block is self-contained.
+
+# After all wiring + ephemeral-vault integration tests pass:
+cargo test --release --workspace --no-fail-fast 2>&1 | grep -E "^test result:" | awk '{passed+=$4; failed+=$6; ignored+=$8} END {print "PASSED:", passed, "FAILED:", failed, "IGNORED:", ignored}'
+cargo clippy --release --workspace --tests -- -D warnings
+cargo fmt --all -- --check
+uv run core/tests/python/conformance.py
+uv run core/tests/python/spec_test_name_freshness.py
+```
+
+## Closing inventory
+
+- **Branch state on close:** `main` at `e329087` (D.1.1 Task 1 PR #131 merged earlier this session). `feature/d11-task-2` carries 5 commits on top (4 module commits + 1 fmt fixup).
+- **Workspace tests on `feature/d11-task-2`:** **992 passed + 10 ignored** (+32 over the post-Task-1 baseline of 960).
+- **README.md:** unchanged. Per-task status flips on a sub-project in early implementation phase would be noise (see prior baton; same logic applies).
+- **ROADMAP.md:** unchanged. D.1 section's wording ("D.1.1 walking skeleton ... in design.") remains brief and inoffensive; the per-task implementation status doesn't belong in the cross-sub-project roadmap.
+- **CLAUDE.md:** unchanged this session.
+- **NEXT_SESSION.md:** symlink retargeted to this file.
+- **`docs/adr/`:** unchanged.
+- **`desktop/src-tauri/src/`:** four new pure modules (`constants.rs`, `errors.rs`, `auto_lock.rs`, `settings.rs`) plus the `mod` declarations in `main.rs`. The `desktop/src/` (Svelte) tree is untouched in Task 2.
+- **Open issues:** see §(3) — none close with this PR.
+- **Open PRs:** one to be opened at end of this session (D.1.1 Task 2 — backend pure modules).
+- **Worktrees on disk:** stale worktrees listed in §(3) can be cleaned up at any pause; `feature/d11-task-2` stays until merge.
+- **This file:** the live baton for the Task 2 close. The next slice opens with `docs/handoffs/<date>-d11-task-3-shipped.md`.


### PR DESCRIPTION
## Summary

Four pure-Rust modules — no I/O, no Tauri runtime, no `secretary-ffi-bridge` runtime dependencies (only typed value imports). Each is unit-testable in isolation; together they form the foundation for the stateful session layer (Task 3) and the IPC command surface (Task 4).

- **`desktop/src-tauri/src/constants.rs`** — 8 named constants per spec §8 (`AUTO_LOCK_*_MS`, `SETTINGS_BLOCK_NAME`, `SETTINGS_RECORD_TYPE`, `SETTINGS_FIELD_AUTO_LOCK_TIMEOUT_MS`, `ACTIVITY_NOTIFY_MIN_INTERVAL_MS`) + `deterministic_uuid_16(input) = SHA-256(input)[0..16]`. Frozen-hex tripwire tests pin the on-disk settings-block UUID (`04fcc7aa05345f631e7f1ce2db78ba9a`) and settings-record UUID (`4145cb7a4531f1ac41af6717e205e1a9`) so any future change to the seed strings becomes a test failure flagging a vault-format break.
- **`desktop/src-tauri/src/errors.rs`** — `AppError` (13 variants, `thiserror::Error + serde::Serialize + serde(tag = \"code\", rename_all = \"snake_case\")`) + `AppWarning` (3 variants). Developer-facing `detail` fields use `#[serde(skip_serializing)]` so they're logged via `tracing::warn!` on the Rust side but never reach the frontend. `From<FfiVaultError>` is an explicit exhaustive match per the actual bridge surface (13 variants in [`ffi/secretary-ffi-bridge/src/error/vault/mod.rs`](../tree/feature/d11-task-2/ffi/secretary-ffi-bridge/src/error/vault/mod.rs)) — any future bridge variant becomes a compile error forcing a deliberate UI-mapping choice rather than a silent fold to Internal. Anti-oracle property preserved at the seam: both `WrongPasswordOrCorrupt` and `WrongMnemonicOrCorrupt` collapse to `AppError::WrongPassword`, pinned by `ffi_wrong_password_or_corrupt_collapses_to_wrong_password`.
- **`desktop/src-tauri/src/auto_lock.rs`** — `IdleTracker { last_activity_ms }` + `now_ms()` free function. `notify` only advances forward (rejects backward clock skew). `is_expired` uses `saturating_sub` so backward clock differences return false rather than panicking.
- **`desktop/src-tauri/src/settings.rs`** — `Settings` pure value type + `parse_settings_field` (load path, lenient: clamps out-of-bounds with `AppWarning::SettingsClamped`) + `validate_save_value` (save path, strict: rejects out-of-bounds with `AppError::SettingsOutOfRange`) + `serialize_settings` (returns the `(record_type, field_name, value_text)` triple that Task 3's vault-save will package into a `BlockInput`).

## Spec / Plan

- Spec §8 (settings schema + constants table), §9 (error model).
- Plan `docs/superpowers/plans/2026-05-27-d11-tauri-walking-skeleton.md`, Task 2.

## Gauntlet

- **Workspace tests: 992 / 0 / 10** (+32 over the post-Task-1 baseline of 960; plan predicted +27 — the +5 surplus tests are documented per-module in §(1) of the [handoff doc](../tree/feature/d11-task-2/docs/handoffs/2026-05-27-d11-task-2-shipped.md)).
- `cargo clippy --release --workspace --tests -- -D warnings` → clean.
- `cargo fmt --all -- --check` → clean.
- `uv run core/tests/python/conformance.py` → PASS.
- `uv run core/tests/python/spec_test_name_freshness.py` → PASS.

## Plan adaptations (worth flagging)

1. **`From<FfiVaultError>` match adapted to the bridge's actual variants.** The plan's draft used variant names that don't exist in the current bridge (`FfiVaultError::Unlock`, `WeakKdfParams`, `Io`); the plan author warned this might happen and instructed adaptation. All 13 real bridge variants now have explicit per-variant mappings with rationale comments naming which `AppError` variant each routes to and why. `WeakKdfParams` → `KdfTooWeak` has no producer because the bridge already collapses `WeakKdfParams` into `CorruptVault { detail }` upstream; `AppError::KdfTooWeak` survives as a typed variant with a serde-shape test for the future where the bridge exposes the parameter pair structurally.
2. **Clippy hardening rolled into Task 2 rather than deferred.** Three classes of clippy concern surfaced (`enum_variant_names` on `AppWarning` — shared `Settings` prefix is intentional + IPC-contract-locked; `dead_code` on variants Task 4 produces — pure-module ship-ahead-of-consumer pattern; `assertions_on_constants` on compile-time-known relationship tests — lifted to `const _: () = assert!(...)` which upgrades to a compile error). Each allow is scoped to a specific item with a comment naming the future producer task / the contract reason.

Full per-adaptation detail in §(3) of the [handoff doc](../tree/feature/d11-task-2/docs/handoffs/2026-05-27-d11-task-2-shipped.md).

## Test plan

- [ ] Verify the frozen SHA-256 hex strings in `constants::tests` match `printf '%s' \"<input>\" | shasum -a 256 | head -c 32`:
  - `__secretary_app_settings__` → `04fcc7aa05345f631e7f1ce2db78ba9a`
  - `secretary.settings.v1` → `4145cb7a4531f1ac41af6717e205e1a9`
- [ ] Confirm `From<FfiVaultError>` is exhaustive — `cargo check -p secretary-desktop` after locally adding a new bogus variant to the bridge crate should refuse to compile, pointing at the match in `errors.rs`.
- [ ] Confirm anti-oracle collapse is pinned: `cargo test --release -p secretary-desktop ffi_wrong_password_or_corrupt_collapses_to_wrong_password`.
- [ ] Confirm detail-stripping is pinned: `cargo test --release -p secretary-desktop ffi_corrupt_vault_detail_is_logged_but_stripped_on_serialize`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)