### PR TITLE
Add FFI secret-handling audit memo and update contributor docs

### DIFF
--- a/core/tests/python/spec_freshness_allowlist.txt
+++ b/core/tests/python/spec_freshness_allowlist.txt
@@ -18,3 +18,46 @@ docs/crypto-design.md::_conflicts
 
 # reason: KAT vector key in core/tests/data/conflict_kat.json (line 806), not a Rust fn name
 docs/threat-model.md::concurrent_tombstone_wins_preserves_live_unknown
+
+# --- ffi/secretary-ffi-bridge symbol citations (Sub-project B). The freshness
+# --- check only scans core/, so FFI-bridge symbol names register as bare-
+# --- unresolved. The FFI-secret-handling memo legitimately cites them.
+
+# reason: ffi/secretary-ffi-bridge/src/record/field.rs::FieldHandle::expose_text — FFI accessor, not in core/
+docs/manual/contributors/ffi-secret-handling-internal.md::expose_text
+
+# reason: ffi/secretary-ffi-bridge/src/record/field.rs::FieldHandle::expose_bytes — FFI accessor, not in core/
+docs/manual/contributors/ffi-secret-handling-internal.md::expose_bytes
+
+# reason: ffi/secretary-ffi-bridge/src/create.rs::MnemonicOutput::take_phrase — FFI one-shot accessor, not in core/
+docs/manual/contributors/ffi-secret-handling-internal.md::take_phrase
+
+# reason: ffi/secretary-ffi-bridge/src/record/orchestration.rs::read_block — FFI free fn, not in core/
+docs/manual/contributors/ffi-secret-handling-internal.md::read_block
+
+# reason: ffi/secretary-ffi-bridge/src/record/field.rs test name — naming convention prototype, not in core/
+docs/manual/contributors/ffi-secret-handling-internal.md::wipe_then_wipe_is_idempotent
+
+# reason: ffi/secretary-ffi-bridge/src/sync_helpers.rs::lock_or_recover — FFI mutex-poison helper, not in core/
+docs/manual/contributors/ffi-secret-handling-internal.md::lock_or_recover
+
+# reason: std::borrow::ToOwned::to_owned — Rust standard library method, not a project symbol
+docs/manual/contributors/ffi-secret-handling-internal.md::to_owned
+
+# reason: std::slice::ToOwned via [T]::to_vec — Rust standard library method, not a project symbol
+docs/manual/contributors/ffi-secret-handling-internal.md::to_vec
+
+# reason: ffi/secretary-ffi-bridge/src/identity.rs::UnlockedIdentity::user_uuid — FFI accessor, not in core/
+docs/manual/contributors/ffi-secret-handling-internal.md::user_uuid
+
+# reason: core/tests/data/golden_vault_001/ — KAT test-data directory name, not a Rust fn
+docs/manual/contributors/ffi-secret-handling-internal.md::golden_vault_001
+
+# reason: core/tests/data/golden_vault_002/ — KAT test-data directory name, not a Rust fn
+docs/manual/contributors/ffi-secret-handling-internal.md::golden_vault_002
+
+# reason: ffi/secretary-ffi-bridge/src/error.rs::FfiUnlockError — FFI error type, not in core/
+docs/manual/contributors/ffi-secret-handling-internal.md::FfiUnlockError::WrongPasswordOrCorrupt
+
+# reason: ffi/secretary-ffi-bridge/src/error.rs::FfiUnlockError — FFI error type, not in core/
+docs/manual/contributors/ffi-secret-handling-internal.md::FfiUnlockError::WrongMnemonicOrCorrupt

--- a/docs/manual/contributors/ffi-secret-handling-internal.md
+++ b/docs/manual/contributors/ffi-secret-handling-internal.md
@@ -1,0 +1,389 @@
+# FFI secret-handling internal audit
+
+This document is the **FFI-boundary secret-handling memo**. Companion to the
+[memory-hygiene audit](memory-hygiene-audit-internal.md) and the
+[side-channel audit](side-channel-audit-internal.md), both of which
+explicitly carved cross-FFI memory hygiene out of their scope. Sub-project B
+is now feature-complete through B.6 v2 (Rust core ↔ Python via PyO3, Rust
+core ↔ Swift / Kotlin via uniffi), so the cross-FFI surface that those
+earlier memos deferred is real code now and needs its own contributor-
+facing audit trail.
+
+**Scope:** the bridge crate
+[`ffi/secretary-ffi-bridge`](../../../ffi/secretary-ffi-bridge/) plus the
+two binding-flavor projection crates `secretary-ffi-py` and
+`secretary-ffi-uniffi`, specifically the discipline by which secret bytes
+cross the Rust → foreign-language boundary and the lifecycle of
+caller-owned secret copies on the foreign side.
+
+Out of scope: the Rust-core discipline that the bridge inherits (covered
+by the memory-hygiene and side-channel memos), the wire-format / on-disk
+discipline (covered by `docs/crypto-design.md` and `docs/vault-format.md`),
+and Sub-project D platform clipboard/UI hygiene.
+
+**Methodology:** for each opaque handle exposed across the FFI, identify
+(a) what secret-bearing state it wraps Rust-side, (b) how that state is
+projected through the foreign-language boundary (cloned, exposed, or
+left opaque), (c) the wipe discipline (idempotency, cascade, drop chain),
+(d) the residual exposure on the foreign side that the bridge cannot
+control.
+
+**Date:** 2026-05-28 (post-B.6 v2; post-C.2 ✅).
+
+---
+
+## Summary
+
+The bridge layer establishes a **uniform opaque-handle pattern** for
+every secret-bearing FFI handle (`UnlockedIdentity`, `MnemonicOutput`,
+`OpenVaultManifest`, `BlockReadOutput`, `Record`, `FieldHandle`). The
+pattern: `Arc<Mutex<Option<Inner>>>` (or `Mutex<Option<...>>` where
+shared-clone semantics aren't needed) so accessors are thread-safe and
+non-throwing, wipe is idempotent via `Option::take()`, and the inner
+secret-bearing state inherits the Rust-core's `Zeroize, ZeroizeOnDrop`
+discipline on drop.
+
+**The bridge handles wipe correctly.** The unfixable residual gap is on
+the foreign-runtime side: once a secret is copied out via
+`expose_text` / `expose_bytes` / `take_phrase`, it lives in
+caller-runtime heap (Python `bytes` / `str`, Swift `String` / `Data`,
+Kotlin `ByteArray` / `String`) which the bridge has no authority over.
+The accessors are documented as **one-shot read-out boundaries, not
+recoverable copies**, and the bridge-side `SecretString` / `SecretBytes`
+remains the only authoritative wipe target.
+
+The principal items contributors must hold in mind when modifying the
+bridge surface are:
+
+1. **The wipe cascade must remain intact.** Any new handle that wraps
+   secret-bearing state must implement `wipe()` (idempotent) and, if
+   it owns child handles, cascade `wipe()` to them. Adding a handle
+   that wraps a `SecretString` / `SecretBytes` without a corresponding
+   `wipe()` method is a regression even though `Drop` would still
+   eventually fire — the contract is that the foreign caller can force
+   the wipe at a known point.
+2. **The opaque-handle pattern is the FFI's `Sensitive<T>` analog.**
+   None of Python / Swift / Kotlin has a Rust-style generic
+   `Sensitive<T>` wrapper. The opaque handle plus `wipe()` is the
+   only authoritative-wipe primitive the bridge can offer. Returning
+   a raw `Vec<u8>` / `String` of secret bytes from a new method
+   without going through a handle is a foreign-API smell — review.
+3. **Read-out methods name the cost.** `expose_*` is the established
+   prefix for accessors that copy secret bytes out into caller-owned
+   heap; `take_*` is the established prefix for one-shot accessors
+   that consume the inner secret and zeroize it as a side effect.
+   Don't introduce a `get_*` / `read_*` accessor on a secret field —
+   the prefix loses the foreign reader's only signal that this
+   call has a residue-on-foreign-heap cost.
+
+---
+
+## Handle inventory
+
+The bridge surface (post-B.6 v2) exposes six handles that wrap
+secret-bearing state. Each is `Send + Sync` (via the `Mutex`),
+non-throwing on use-after-wipe, and zeroizes its inner state on drop or
+explicit `wipe()`.
+
+| Handle | File | Wraps | Cascade | Shared? |
+|---|---|---|---|---|
+| `UnlockedIdentity` | [`identity.rs`](../../../ffi/secretary-ffi-bridge/src/identity.rs) | `core::UnlockedIdentity` (IBK + 4 secret keys in `Sensitive`) | leaf | no (`Mutex<Option<...>>`) |
+| `MnemonicOutput` | [`create.rs`](../../../ffi/secretary-ffi-bridge/src/create.rs) | `core::unlock::mnemonic::Mnemonic` (phrase `String` + entropy `Sensitive<[u8; 32]>`) | leaf | no (`Mutex<Option<...>>`) |
+| `OpenVaultManifest` | [`vault.rs`](../../../ffi/secretary-ffi-bridge/src/vault.rs) | IBK `Sensitive<[u8; 32]>` + manifest + envelope + owner card | leaf (cascade-to-Record is via separate `read_block` call, not retained state) | no (`Mutex<Option<...>>`) |
+| `BlockReadOutput` | [`record/output.rs`](../../../ffi/secretary-ffi-bridge/src/record/output.rs) | `Vec<Record>` | cascades `wipe()` to each `Record` before clearing the vec | no (`Mutex<Option<...>>`) |
+| `Record` | [`record/handle.rs`](../../../ffi/secretary-ffi-bridge/src/record/handle.rs) | non-secret metadata + `Vec<FieldHandle>` | cascades `wipe()` to each `FieldHandle` | **yes** (`Arc<Mutex<Option<...>>>`) |
+| `FieldHandle` | [`record/field.rs`](../../../ffi/secretary-ffi-bridge/src/record/field.rs) | `RecordFieldValue` = `Text(SecretString)` or `Bytes(SecretBytes)` | leaf | **yes** (`Arc<Mutex<Option<...>>>`) |
+
+The `Arc<Mutex<Option<...>>>` shape on `Record` and `FieldHandle` is
+load-bearing for foreign-side ergonomics: foreign callers can hold a
+clone of a `Record` for the lifetime of one screen and the parent
+`BlockReadOutput` is free to be wiped independently. A `wipe()` on
+either clone wipes the shared underlying state — the inner
+`Option::take()` is shared across all `Arc` clones, so every other
+clone sees `None` on its next accessor call and falls through to the
+non-throwing default. **This is intentional** — the alternative
+(per-clone state) would let one Rust-side wipe leave a stale plaintext
+copy live behind a foreign clone the bridge no longer tracks.
+
+---
+
+## Wipe discipline
+
+### Idempotency
+
+Every `wipe()` method on every handle uses
+`*guard = None` (or `let _ = guard.take()`) so a second `wipe()` call
+is a no-op rather than a panic. This is observable in the test suites
+under each module (`wipe_then_wipe_is_idempotent` is the canonical
+test name; see `record/field.rs:218–222` as the prototype).
+
+### Cascade ordering
+
+`BlockReadOutput::wipe` walks its `records: Vec<Record>` and calls
+`wipe()` on each before clearing the vec
+([output.rs:90](../../../ffi/secretary-ffi-bridge/src/record/output.rs#L90)).
+Each `Record::wipe` in turn walks its `fields: Vec<FieldHandle>` and
+calls `wipe()` on each. Each `FieldHandle::wipe` takes the inner
+`Option<...>`, which triggers the `RecordFieldValue` drop chain that
+zeroizes the wrapped `SecretString` / `SecretBytes`.
+
+The Rust `Drop` chain would also produce this cascade automatically;
+the explicit cascade is defense-in-depth and gives foreign callers a
+deterministic-time wipe primitive. Both paths converge on the same
+`Sensitive`-wrapper drop.
+
+### Use-after-wipe semantics
+
+Accessors on a wiped handle return zero / empty / `None` (whichever
+makes sense for the return type) rather than panicking or surfacing a
+typed error. The pattern is uniform across modules — see
+`lock_or_recover` in
+[`sync_helpers.rs`](../../../ffi/secretary-ffi-bridge/src/sync_helpers.rs)
+for the Mutex-poison-recovery helper that every accessor uses.
+
+The rationale: foreign-side callers routinely have lingering
+references after a programmatic `wipe()` (a UI screen still in scope, a
+debounced re-render, etc.). Surfacing a `WipedHandle` error variant on
+every accessor would force every foreign call site to wrap in a
+`try`/`catch` purely for a no-op-on-wipe path. Returning the
+zero-equivalent default lets the foreign caller observe "I'm wiped"
+via the value (empty string, all-zero UUID) without exception
+handling.
+
+This is one of the few places where the bridge's API deliberately
+deviates from "errors are typed; absence is `Option`". The reason is
+foreign-ergonomic, not Rust-idiomatic; document it in any new accessor
+you add.
+
+---
+
+## Cross-boundary secret-copy accessors
+
+Three accessor families produce foreign-runtime heap copies of secret
+bytes. Each one's caveat applies uniformly: **the bridge cannot
+zeroize the returned value once it crosses the FFI boundary**. The
+only authoritative wipe is `handle.wipe()` on the Rust-side handle.
+
+### `FieldHandle::expose_text` / `expose_bytes`
+
+[`record/field.rs:125`](../../../ffi/secretary-ffi-bridge/src/record/field.rs#L125)
+and
+[`record/field.rs:152`](../../../ffi/secretary-ffi-bridge/src/record/field.rs#L152).
+
+`FieldHandle::expose_text` returns `Option<String>` (clone of the
+inner `SecretString::expose()` via std `to_owned`).
+`FieldHandle::expose_bytes` returns `Option<Vec<u8>>` (clone of the
+inner `SecretBytes::expose()` via std `to_vec`). `None` is returned
+if the field is the other variant or the handle has been wiped.
+
+The clones cross the FFI as the foreign-language's natural string /
+byte-array type:
+
+- **Python**: `str` / `bytes`. `str` is interned + immutable; `bytes`
+  is immutable. Neither can be authoritatively zeroized from Python
+  alone. Foreign callers wanting best-effort cleanup convert
+  immediately to `bytearray` and overwrite with zeros, then `del`. The
+  immutable interned `str` is the harder case — see the foreign-side
+  doc in `secretary-ffi-py/README.md` for the idioms.
+- **Swift**: `String` (UTF-8) / `Data`. Both are value types but the
+  allocator is not zeroize-aware. The standard idiom is to scope the
+  use tightly (`do { let s = handle.exposeText(); use(s); }` so the
+  deinit fires at end of block).
+- **Kotlin**: `String` / `ByteArray`. `ByteArray` supports `.fill(0)`
+  (best-effort); `String` is interned + immutable and cannot be
+  authoritatively wiped without going through `CharArray` plumbing,
+  which the foreign-side smoke runners don't exercise.
+
+The repeated message in the inline rustdoc on these methods is
+"foreign-runtime heap-copy caveat: the [String/Vec] handed back is
+*functionally* un-zeroizable in most foreign runtimes." That sentence
+is load-bearing — it warns foreign-side reviewers that the only
+authoritative wipe is the bridge-side `wipe()`, not whatever the
+foreign caller does with the returned value.
+
+### `MnemonicOutput::take_phrase`
+
+[`create.rs`](../../../ffi/secretary-ffi-bridge/src/create.rs)
+(see the `take_phrase` impl after the type definition).
+
+Returns `Option<Vec<u8>>` containing the UTF-8 bytes of the 24-word
+BIP-39 mnemonic. **One-shot** — the inner `Mnemonic` is consumed and
+dropped on the first successful call (which zeroizes the inner
+`String` phrase + `Sensitive<[u8; 32]>` entropy); subsequent calls
+return `None` rather than an error.
+
+The one-shot semantics are the bridge's discipline equivalent of "the
+mnemonic is intended for the user to write down once and never to be
+retrieved again". A foreign caller that wants to display the mnemonic
+twice (e.g. "confirm your written copy") must hold the bytes
+themselves between displays — and zeroize them between displays —
+because the bridge will not re-emit them.
+
+### `UnlockedIdentity::display_name` / `user_uuid`
+
+[`identity.rs`](../../../ffi/secretary-ffi-bridge/src/identity.rs).
+
+These are **non-secret** accessors. `display_name` is user-chosen
+metadata; `user_uuid` is a public derived identifier. They are listed
+here because they share the opaque-handle infrastructure and
+contributors might assume the secret-copy caveat applies. It does not.
+
+---
+
+## Bridge-side `Sensitive`-wrapper discipline
+
+The bridge does not introduce new `Sensitive` wrappers — it inherits
+the core's. The places where the bridge handles raw `[u8; 32]` /
+`Vec<u8>` of secret material follow the established stack-residue
+discipline from the memory-hygiene memo.
+
+Three sites worth flagging for contributors modifying the bridge:
+
+1. [`sync/prepare.rs:169`](../../../core/src/sync/prepare.rs#L169) —
+   not bridge code, but the sync layer (Sub-project C) was written
+   after the memory-hygiene audit and follows the exact pattern:
+   ```rust
+   let mut x_sk_bytes = *identity.identity.x25519_sk.expose();
+   let reader_x_sk: X25519Secret = Sensitive::new(x_sk_bytes);
+   x_sk_bytes.zeroize();
+   ```
+   Mentioned here because contributors evaluating bridge-side secret
+   handling should also read the sync-layer call sites to see the
+   pattern enforced cross-module.
+
+2. [`sync/commit/write.rs:237`](../../../core/src/sync/commit/write.rs#L237) —
+   the parallel `ed_sk_bytes.zeroize()` pattern for the author's
+   Ed25519 secret key.
+
+3. The bridge crate itself does **not** expose secret bytes from a
+   handle as a raw `*expose()` slice — it always either copies-out
+   (via std `to_owned` / `to_vec` for the foreign caller, who then
+   owns the residual) or passes through to a Rust-side
+   `Sensitive::new(...)` construction. Sites where future bridge work
+   might need to copy secret bytes between the inner `Sensitive` and
+   a new Rust-side `Sensitive` should follow the
+   `bind → wrap → zeroize` pattern verbatim.
+
+---
+
+## Anti-oracle conflation across the FFI
+
+The §13 anti-oracle property
+([`docs/threat-model.md`](../../threat-model.md) §13) requires that
+"wrong key" and "vault corruption" be indistinguishable to the
+adversary on the unlock path. The bridge preserves this via the
+`FfiUnlockError::WrongPasswordOrCorrupt` and
+`FfiUnlockError::WrongMnemonicOrCorrupt` variants, which are the
+**deliberately conflated** terminal classes for the password and
+mnemonic unlock paths respectively.
+
+The conflation MUST NOT be split on the foreign side. Splitting
+"WrongPassword" from "Corrupt" in a foreign UI would re-introduce the
+oracle that the bridge variant collapses. The rustdoc on the
+`FfiUnlockError` enum variant pins this; the Python / Swift / Kotlin
+projections preserve it (single exception class
+`WrongPasswordOrCorrupt`, single Swift / Kotlin enum case).
+
+`InvalidMnemonic { detail }` is a separate variant because it fires
+**before** any vault byte is touched (BIP-39 validation) — surfacing
+the specific failure mode (wrong word count, unknown word, bad
+checksum, invalid UTF-8) gives the user a clear UX path with zero
+oracle cost. The detail string is intentionally informational and
+should be displayed to the user.
+
+---
+
+## What is *not* covered
+
+The bridge inherits, doesn't fix, the following residual exposures
+already flagged in the prerequisite memos:
+
+- **Codec-boundary plaintext residue** (memory-hygiene memo →
+  "What is *not* covered" under Resolved). The CBOR encode/decode
+  path goes through `ciborium::Value` and a plain `Vec<u8>` canonical
+  buffer between the `SecretString` / `SecretBytes` and the AEAD
+  call. This applies equally on the bridge side: when
+  `read_block` constructs a `FieldHandle`, the secret bytes have
+  already been zeroize-typed before reaching the bridge, but the
+  intermediate decode buffer between AEAD-decrypt and `SecretString::
+  new` is not zeroized. Same exposure window as core; same
+  follow-up.
+- **Upstream `hkdf` / `ml-kem` / `ml-dsa` internal state**
+  (memory-hygiene memo → Deferred items §1, §2). The bridge
+  surfaces these primitives via the core API; if upstream zeroize
+  support lands, the bridge inherits it without bridge-side work.
+
+The bridge introduces no *new* residual exposures beyond these. The
+foreign-runtime heap-copy caveat documented per accessor is not a
+"residual exposure" in the memo sense — it's a fundamental property
+of the FFI boundary that the bridge documents and works around with
+the opaque-handle + `wipe()` primitive.
+
+### Sub-project D platform concerns (carved out)
+
+When the platform UI (Sub-project D, currently in flight as the
+Tauri 2 desktop walking skeleton — ADR 0007 + `desktop/`) copies a
+secret to the system clipboard, that's a Sub-project D concern that
+the bridge cannot reach. The bridge gives the UI the **secret bytes**
+via `expose_text` / `expose_bytes`; what the UI does with them
+between read and clipboard-clear is Sub-project D's responsibility.
+
+The Tauri 2 desktop scaffold's IPC layer (`desktop/src-tauri/src/`)
+re-bridges through `secretary-ffi-py` for the live UI; the same
+`expose_*` discipline applies at every IPC `tauri::command` boundary
+that returns secret bytes. Contributors adding such commands should
+default to opaque-handle equivalents (e.g. return a handle ID and
+have the foreground process re-expose on demand) rather than passing
+plaintext through IPC.
+
+---
+
+## Adding a new bridge handle
+
+The checklist that follows is the contract a new handle must meet to
+preserve the discipline documented above. None of this is enforced by
+the compiler; it's enforced by review.
+
+1. **Wrap the secret-bearing inner type in `Mutex<Option<Inner>>`**
+   (`Arc<Mutex<Option<Inner>>>` if foreign callers need to hold
+   independent clones). `Inner` should not implement `Clone`
+   — clones must go through `Arc::clone` on the outer handle.
+2. **Make all accessors non-throwing.** Use `lock_or_recover` from
+   `sync_helpers.rs` to absorb mutex poison. Return zero /
+   empty / `None` for the wiped case.
+3. **Implement `wipe()` as `*guard = None`.** Idempotent by
+   construction. Add a `wipe_then_wipe_is_idempotent` test.
+4. **Cascade `wipe()` to any child handles** the new handle owns.
+   See `BlockReadOutput::wipe` and `Record::wipe` for the prototype.
+5. **Document the foreign-runtime heap-copy caveat** on any accessor
+   that returns secret bytes (`expose_*` / `take_*` prefix). The
+   inline rustdoc is the audit trail.
+6. **Project through both PyO3 and uniffi.** Method names follow the
+   vocabulary in the bridge README ("Foreign-side projection notes"):
+   `wipe()` Rust-side; `close()` Python-side; `wipe()` uniffi-side.
+7. **Add an integration test under
+   `ffi/secretary-ffi-bridge/tests/`** that exercises the
+   wipe + use-after-wipe path against `golden_vault_001` (or
+   `golden_vault_002`).
+
+---
+
+## Conclusion
+
+The FFI surface inherits the Rust core's secret-handling discipline
+(via `SecretString` / `SecretBytes` / `Sensitive<T>`) and adds a
+uniform opaque-handle layer on top. The handle layer's contract is
+small and consistent: `Arc<Mutex<Option<Inner>>>`, idempotent
+`wipe()`, cascade-to-children, non-throwing use-after-wipe.
+
+The unfixable residual is the foreign-runtime heap-copy caveat. The
+bridge documents it per accessor and offers `wipe()` on the Rust-side
+handle as the only authoritative cleanup primitive. Sub-project D
+platform UIs will need to make their own decisions about clipboard
+lifetime and IPC plaintext handling; the bridge gives them the raw
+material plus the contract, not the policy.
+
+FFI secret-handling status: **clean for v1's Sub-project B scope at
+the bridge level**, with the foreign-runtime heap-copy caveat carved
+out per-accessor and the Sub-project D platform-policy concerns
+flagged for the appropriate later phase.

--- a/docs/manual/contributors/index.md
+++ b/docs/manual/contributors/index.md
@@ -1,9 +1,10 @@
 # Contributor-facing internal documentation
 
 This directory holds the **internal** documentation written for the people
-maintaining Secretary's Rust core: wire-protocol contracts that aren't
-otherwise visible from the code, and audit memos that recorded the
-methodology and findings of Phase A.7's three internal hardening passes.
+maintaining Secretary's Rust core and its surrounding sub-projects: wire-
+protocol contracts that aren't otherwise visible from the code, and audit
+memos that record the methodology and findings of the cross-cutting
+hardening passes.
 
 It is **not** user-facing documentation — for that, see
 [../primer/cryptography/index.md](../primer/cryptography/index.md) (the
@@ -13,7 +14,9 @@ hardening guide).
 
 ## What's in here
 
-### [`differential-replay-protocol.md`](differential-replay-protocol.md)
+### Wire-protocol contracts
+
+#### [`differential-replay-protocol.md`](differential-replay-protocol.md)
 
 The wire protocol the Rust integration test
 [`core/tests/differential_replay.rs`](../../../core/tests/differential_replay.rs)
@@ -24,10 +27,18 @@ encode/decode behaviour of an existing target. Some of the contract is
 machine-checked by `differential_replay.rs`; the rest is convention, easy to
 break silently if you don't know it's there.
 
-### [`side-channel-audit-internal.md`](side-channel-audit-internal.md)
+### Audit memos
 
-Phase A.7's internal pass over constant-time-sensitive call sites in the
-Rust core. Walks every CT-sensitive comparison flagged by
+The four memos below were originally written as Phase A.7's internal
+hardening track (the Rust-core audits, 2026-05-02) and have since grown to
+cover the FFI boundary (Sub-project B, 2026-05-28) as the secret-handling
+surface expanded across the language boundary.
+
+#### [`side-channel-audit-internal.md`](side-channel-audit-internal.md)
+
+Internal pass over constant-time-sensitive call sites in the Rust core
+([`core/src/{crypto,identity,unlock,vault}/`](../../../core/src/)). Walks
+every CT-sensitive comparison flagged by
 [`docs/threat-model.md`](../../threat-model.md) §3.2 / §3.3, identifies the
 underlying upstream primitive, and documents what discipline that primitive
 provides. **Read the relevant section before changing any signature
@@ -36,35 +47,102 @@ comparison** — the memo records which guarantees are upstream-provided
 versus which are defensive at the call site, and a regression in either
 direction is hard to spot from the diff alone.
 
-### [`memory-hygiene-audit-internal.md`](memory-hygiene-audit-internal.md)
+#### [`memory-hygiene-audit-internal.md`](memory-hygiene-audit-internal.md)
 
-Phase A.7's internal pass over zeroize discipline in the Rust core. Walks
-every type that wraps secret bytes, verifies its zeroize-on-drop wrapper
-discipline, and enumerates the stack-residue patterns where a secret value
-could linger in a named-but-unzeroized stack slot. **Read the relevant
-section before adding a new secret-bearing field, widening an existing
-secret's lifetime, or changing the drop ordering of a composite type
-holding multiple secrets.** The "Resolved" section at the bottom is
-load-bearing: it records which originally-deferred items have since been
-fixed (most recently `RecordFieldValue::{Text, Bytes}` → `SecretString` /
-`SecretBytes` and the `MlDsa65Secret` / `MlKem768Secret` newtype-zeroize
-follow-up).
+Internal pass over zeroize discipline in the Rust core. Walks every type
+that wraps secret bytes, verifies its zeroize-on-drop wrapper discipline,
+and enumerates the stack-residue patterns where a secret value could
+linger in a named-but-unzeroized stack slot. **Read the relevant section
+before adding a new secret-bearing field, widening an existing secret's
+lifetime, or changing the drop ordering of a composite type holding
+multiple secrets.** The "Resolved" section is load-bearing: it records
+which originally-deferred items have since been fixed.
+
+The memo's discipline has been carried forward into the sync orchestration
+layer ([`core/src/sync/`](../../../core/src/sync/), Sub-project C) and the
+FFI bridge ([`ffi/secretary-ffi-bridge/`](../../../ffi/secretary-ffi-bridge/),
+Sub-project B) — both layers were written after the audit landed and
+follow the established `bind → wrap → zeroize` pattern at every secret-
+material site. New cross-module sites are expected to keep that pattern.
+
+#### [`ffi-secret-handling-internal.md`](ffi-secret-handling-internal.md)
+
+The cross-FFI memory-hygiene companion that the earlier two audits
+explicitly deferred (under "Out of scope: cross-FFI memory hygiene
+(Sub-project B)"). Walks the six opaque handles exposed across the
+FFI (`UnlockedIdentity`, `MnemonicOutput`, `OpenVaultManifest`,
+`BlockReadOutput`, `Record`, `FieldHandle`), the `Arc<Mutex<Option<T>>>`
+pattern they share, the wipe-cascade discipline, and the
+foreign-runtime heap-copy caveat that the bridge cannot close from the
+Rust side. **Read this before adding a new bridge-side handle or
+accessor that returns secret bytes** — the "Adding a new bridge handle"
+checklist at the bottom is the contract the new code must meet.
+
+## A note on line references
+
+Each memo cites specific Rust file paths plus line numbers (e.g.
+[`core/src/crypto/aead.rs#L162`](../../../core/src/crypto/aead.rs#L162))
+to anchor its claims. Line numbers drift as the code evolves — the
+`#L162` anchor remains a valid hyperlink even when the cited symbol has
+moved a few lines, and the
+[`core/tests/python/spec_test_name_freshness.py`](../../../core/tests/python/spec_test_name_freshness.py)
+drift check covers the **symbol-name** citations (function names, type
+names, variant names) that are the load-bearing part of any reference.
+Run that script (`uv run` from the repo root) before shipping a memo
+update; it will flag any citation that no longer resolves in `core/`.
+
+If you find a citation whose line number is so out of date that the
+hyperlink no longer lands near the intended symbol, fix the line number
+in passing — but treat the symbol-name claim as the source of truth.
 
 ## Relationship to the external review
 
-These three memos are the **principal handoff package** for the planned
+These memos are the **principal handoff package** for the planned
 external paid review of the Rust core. The cryptographic-design and
 threat-model documents in [`docs/`](../../) are normative specs (what the
 code must implement); these memos are the audit trail (what the code
 actually does, and where the discipline holds vs. depends on an upstream
 crate's documented behaviour). An external reviewer with FIPS 203 / FIPS
-204 implementer experience should read the threat model first, then these
-three memos, then the corresponding source files.
+204 implementer experience should read the threat model first, then the
+two Rust-core memos (side-channel + memory-hygiene), then the
+corresponding source files. The FFI memo is a separate add-on for a
+reviewer with FFI-boundary expertise; the FFI's *cryptographic* surface
+is the core's (re-exposed verbatim), so cryptographic-discipline review
+of the bridge is mostly an exercise in re-verifying that the bridge
+doesn't break the discipline the core already established.
 
 The external review is a separate, paid, time-bound engagement and is out
 of scope for any in-session pass. See
-[`secretary_next_session.md`](../../../secretary_next_session.md) → "External
-(paid, time-bound)" for the current status.
+[`secretary_next_session.md`](../../../secretary_next_session.md) and
+[`ROADMAP.md`](../../../ROADMAP.md) for the current status of Phase A.7's
+external track.
+
+## Where the project is, vs. where the original memos were written
+
+The four audit memos were written in May 2026 against
+Sub-project A (Rust core) only. Since then:
+
+- **Sub-project B** (FFI bindings) — complete through B.6 v2. The
+  bridge crate + PyO3 + uniffi (Swift, Kotlin) expose unlock / open /
+  read / save / share / trash / restore. Cross-language conformance
+  KAT replays Rust ↔ Swift ↔ Kotlin parity. See
+  [`ROADMAP.md`](../../../ROADMAP.md) → Sub-project B for the per-
+  phase summary.
+- **Sub-project C** (sync orchestration) — C.1 (sync detection),
+  C.1.1a (conflict-copy ingestion), C.1.1b (merge layer), C.2 (the
+  headless `secretary-sync` CLI) all ✅ complete. C.3 (mobile
+  adapters) + C.4 (cross-device convergence conformance) pending.
+- **Sub-project D** (platform UIs) — pivoted to Tauri 2 per
+  [ADR 0007](../../adr/0007-d-row-tauri.md); D.1.1 (walking-skeleton
+  desktop client) in flight.
+
+The Rust core's *normative* behaviour is unchanged across these
+sub-projects (the spec is frozen for v1, see
+[`CLAUDE.md`](../../../CLAUDE.md) → "Spec is normative"). The memos'
+findings remain valid for the core; the FFI memo extends the
+discipline coverage to the bridge layer; sub-project C's sync code
+follows the established patterns; sub-project D's platform-UI hygiene
+will need its own memo when D matures past the walking-skeleton phase.
 
 ## When updating these memos
 
@@ -75,8 +153,18 @@ don't fit an existing memo's scope go into a new memo with its own
 methodology statement, not glued onto the side of one that's already
 shipped.
 
+A practical heuristic for choosing where new findings go:
+
+- **Bug fix in code already covered by a memo** → update the memo's
+  affected section in place, marking the date.
+- **New code in the existing scope (e.g. a new `core::crypto` primitive)** →
+  extend the relevant memo's coverage table; preserve the original
+  scope statement.
+- **New code in adjacent scope (e.g. a new FFI handle, a new sync
+  layer)** → either extend the cross-sub-project FFI memo (if it's an
+  FFI handle) or open a new memo with a clear scope statement (if it's
+  a new layer that needs its own treatment).
+
 If a memo cites a specific function name, file, or constant, the
 [`core/tests/python/spec_test_name_freshness.py`](../../../core/tests/python/spec_test_name_freshness.py)
-drift check covers it. Run that script (`uv run` from the repo root) before
-shipping a memo update; it will flag any citation that no longer resolves
-in `core/`.
+drift check covers it. Run that script before shipping a memo update.

--- a/docs/manual/contributors/memory-hygiene-audit-internal.md
+++ b/docs/manual/contributors/memory-hygiene-audit-internal.md
@@ -21,7 +21,13 @@ defeat zeroize discipline, (c) the surrounding code zeroizes any
 stack-residue copies after the secret is moved into the wrapper.
 
 **Date:** 2026-05-02 (post-side-channel internal audit; 430 tests + 6
-ignored on `main`).
+ignored on `main`). **Re-verified 2026-05-28** against the post-
+Sub-project-B/C codebase — see the "Cross-sub-project discipline" and
+"Re-verification" sections below. The line numbers cited in the
+stack-residue table and the file-anchor citations have drifted by a few
+lines per file as the modules have grown; the symbol-name citations
+remain authoritative and all twelve `.zeroize()` post-move calls have
+been confirmed present in the current code.
 
 ---
 
@@ -61,14 +67,17 @@ in-memory types). See "Resolved: record-content zeroize" below.
 ## Wrapper discipline
 
 [core/src/crypto/secret.rs](../../../core/src/crypto/secret.rs)
-defines the two secret-bearing wrappers used throughout the crate:
+defines the three secret-bearing wrappers used throughout the crate
+(the third, `SecretString`, was introduced by PR #16's
+`RecordFieldValue` rewrap — see "Resolved: record-content zeroize"):
 
 | Wrapper | Derive | Storage | Custom impls | Notes |
 |---|---|---|---|---|
-| `SecretBytes` | `Zeroize, ZeroizeOnDrop` | `Vec<u8>` (heap) | `Debug` (redacted, prints len only); `PartialEq, Eq` via `subtle::ConstantTimeEq` | No `Clone` derived; `Display` not implemented. |
-| `Sensitive<T: Zeroize>` | `Zeroize, ZeroizeOnDrop` | `T` (typically `[u8; 32]` or `Vec<u8>`) | `Debug` (redacted, prints `<redacted>`) | Intentionally **does not** implement `PartialEq` — see [secret.rs:75-85](../../../core/src/crypto/secret.rs#L75-L85): `subtle` only provides `ConstantTimeEq` for slices and integer primitives, and an `==` impl bounded on `T: ConstantTimeEq` would silently fail to apply to `[u8; N]`. Callers needing byte-equality compare slices via `a.expose()[..].ct_eq(&b.expose()[..])`. |
+| `SecretBytes` | `Zeroize, ZeroizeOnDrop, Clone` | `Vec<u8>` (heap) | `Debug` (redacted, prints len only); `PartialEq, Eq` via `subtle::ConstantTimeEq` | `Clone` was added with PR #16 for conflict-resolution duplicate-detection and proptest shrinking; the cloned allocation is itself zeroize-on-drop. `Display` not implemented. |
+| `SecretString` | `Zeroize, ZeroizeOnDrop, Clone` | `String` (heap) | `Debug` (redacted, prints len only); `PartialEq, Eq` via byte-slice `subtle::ConstantTimeEq` | Sibling of `SecretBytes` for human-readable secrets (passwords, secret notes, recovery phrases stored in records). |
+| `Sensitive<T: Zeroize>` | `Zeroize, ZeroizeOnDrop` | `T` (typically `[u8; 32]` or `Vec<u8>`) | `Debug` (redacted, prints `<redacted>`) | Intentionally **does not** implement `PartialEq` — see the inline comment above the type definition in [secret.rs](../../../core/src/crypto/secret.rs): `subtle` only provides `ConstantTimeEq` for slices and integer primitives, and an `==` impl bounded on `T: ConstantTimeEq` would silently fail to apply to `[u8; N]`. Callers needing byte-equality compare slices via `a.expose()[..].ct_eq(&b.expose()[..])`. |
 
-**Both wrappers are sound.** No changes recommended.
+**All three wrappers are sound.** No changes recommended.
 
 ## Top-level secret types
 
@@ -250,6 +259,57 @@ additive. Pinned by two integration tests at
 `ml_dsa_65_secret_zeroize_clears_inner_bytes` and
 `ml_kem_768_secret_zeroize_clears_inner_bytes`.
 
+## Cross-sub-project discipline (re-verification, 2026-05-28)
+
+Sub-projects B and C were written **after** the original 2026-05-02
+audit. A spot re-verification confirms both new layers follow the
+established `bind → wrap → zeroize` pattern at every secret-bearing
+site:
+
+- **Sub-project C — sync orchestration**
+  ([core/src/sync/](../../../core/src/sync/)). The two new sites that
+  copy secret keys out of `Sensitive<...>` wrappers for per-block AEAD
+  decryption and signing both follow the pattern verbatim:
+  - [sync/prepare.rs#L169](../../../core/src/sync/prepare.rs#L169) —
+    `let mut x_sk_bytes = *identity.identity.x25519_sk.expose(); let
+    reader_x_sk: X25519Secret = Sensitive::new(x_sk_bytes);
+    x_sk_bytes.zeroize();`
+  - [sync/commit/write.rs#L237](../../../core/src/sync/commit/write.rs#L237) —
+    the parallel `ed_sk_bytes.zeroize()` pattern for the author's
+    Ed25519 secret key.
+
+  No new top-level secret types are introduced — the sync layer
+  composes `Sensitive`-wrapped values from the existing core types
+  rather than declaring its own wrappers.
+
+- **Sub-project B — FFI bridge**
+  ([ffi/secretary-ffi-bridge/](../../../ffi/secretary-ffi-bridge/)).
+  The bridge re-exposes core types through opaque-handle wrappers
+  (`UnlockedIdentity`, `MnemonicOutput`, `OpenVaultManifest`,
+  `BlockReadOutput`, `Record`, `FieldHandle`) using the `Mutex<Option
+  <Inner>>` (or `Arc<Mutex<Option<Inner>>>` for shared handles)
+  pattern. The inner `Inner` types are all built from the established
+  `Sensitive` / `SecretBytes` / `SecretString` wrappers, so the
+  bridge inherits the drop-cascade zeroize discipline without
+  introducing new bytes-handling sites. The dedicated
+  [`ffi-secret-handling-internal.md`](ffi-secret-handling-internal.md)
+  memo walks the bridge layer in detail and covers the foreign-
+  runtime heap-copy caveat that the bridge cannot close from the
+  Rust side.
+
+- **CLI (`cli/`)** — the `secretary-sync` binary consumes the sync
+  layer through its library surface; it does not introduce new
+  secret-bearing types. The TTY / stdin password-sourcing path in
+  [cli/src/unlock.rs](../../../cli/src/unlock.rs) reads the password
+  into a `SecretBytes` and feeds it directly to the core unlock
+  entry points without intermediate plaintext.
+
+The pattern from this memo's "Stack-residue gaps fixed" table is now
+the cross-codebase expectation. New work that introduces a fresh
+`Sensitive::new(stack_var)` site without the accompanying
+`stack_var.zeroize()` will fail the FFI memo's "Adding a new bridge
+handle" checklist and should fail review here too.
+
 ## Deferred items (not addressed in this pass)
 
 The two type-level deferred items from the original audit (record-content
@@ -296,6 +356,13 @@ verify both crates' drop discipline at their pinned versions.
   language's allocator and GC own a copy of any secret material
   passed across. The discipline there is Sub-project B's concern; the
   Rust core's job is to make sure its side of the boundary is clean.
+  As of the 2026-05-28 re-verification, the bridge-side discipline is
+  covered by a dedicated companion memo
+  ([`ffi-secret-handling-internal.md`](ffi-secret-handling-internal.md));
+  the foreign-runtime heap-copy caveat (Python `bytes`, Swift `String`,
+  Kotlin `ByteArray` not being authoritatively zeroizable from the
+  bridge) remains an inherent property of the FFI boundary and is
+  documented per-accessor on the bridge side.
 - **Clipboard hygiene** (Sub-project D): when a user copies a
   password to the system clipboard, the clipboard daemon owns a copy
   the Rust core has no visibility into. Mitigation is platform-UI

--- a/docs/manual/contributors/side-channel-audit-internal.md
+++ b/docs/manual/contributors/side-channel-audit-internal.md
@@ -21,7 +21,11 @@ primitive, and the constant-time-discipline the primitive provides
 plain `==` on a secret-derived value.
 
 **Date:** 2026-05-02 (post-PR-#12 monitor stabilisation; 430 tests +
-6 ignored on `main`).
+6 ignored on `main`). **Re-verified 2026-05-28** against the
+post-Sub-project-B/C codebase — see "Re-verification" notes inline. Line
+numbers cited below have drifted by a few lines per file as the modules
+have grown; the symbol-name citations remain authoritative and the
+hyperlinks still land near the intended code.
 
 ---
 
@@ -39,16 +43,20 @@ their values are observable to any adversary that can read the cloud-
 folder copy of the vault.
 
 The `subtle` crate is a direct dependency
-([core/Cargo.toml:17](../../../core/Cargo.toml#L17)) and surfaces a
-`Sensitive<T>::ct_eq` API at
-[core/src/crypto/secret.rs:64-67](../../../core/src/crypto/secret.rs#L64-L67).
-That API has no production call sites today — by design, because the
-verify-then-decap pattern means the codebase never compares two secret
-byte strings for equality outside of AEAD MAC verification. The API
-exists for future hardening (e.g. if Sub-project C orchestration
-introduces a "do these two unwrapped block-content keys agree?" check)
-or for FFI consumers (Sub-project B) that need to expose CT-equality
-to clients.
+([core/Cargo.toml](../../../core/Cargo.toml) — currently `subtle = "2"`).
+The `Sensitive<T>` wrapper intentionally **does not** implement
+`PartialEq` (see §6 below); the `==` operator on secret-bearing types
+routes through `subtle::ConstantTimeEq` exclusively via the
+`PartialEq` impls on `SecretBytes` and `SecretString` — both newer than
+the original audit (PR #16, post-2026-05-02). See
+[core/src/crypto/secret.rs](../../../core/src/crypto/secret.rs) for the
+two `PartialEq for SecretBytes` / `PartialEq for SecretString` impls
+that delegate to `ct_eq` on the underlying byte/`str` representation.
+The verify-then-decap pattern still means the codebase has no explicit
+**call site** that does `a.ct_eq(b)` outside of these `PartialEq`
+impls themselves — `==` on `Record` / `RecordField` values for
+proptest-shrinking and conflict-resolution duplicate-detection
+transparently uses the CT path.
 
 The principal items to flag for external review are not bugs in
 *our* code but **assumptions we make about upstream crates** — we
@@ -220,22 +228,30 @@ per dalek's documented invariants) and `ml-kem` 0.2 (RustCrypto FIPS
 "tamper with recipient table" (binds via AEAD AAD on the block).
 
 **Production paths (all `==` on `[u8; 16]`):**
-- [core/src/vault/orchestrators.rs:530](../../../core/src/vault/orchestrators.rs#L530) —
-  `manifest_file.author_fingerprint != owner_fp`.
-- [core/src/vault/orchestrators.rs:1038](../../../core/src/vault/orchestrators.rs#L1038),
-  [:1066](../../../core/src/vault/orchestrators.rs#L1066) —
-  `author_fp != block_file.author_fingerprint` cross-check.
-- [core/src/vault/orchestrators.rs:1089](../../../core/src/vault/orchestrators.rs#L1089),
-  [:1121](../../../core/src/vault/orchestrators.rs#L1121) —
+- [core/src/vault/orchestrators.rs#L751](../../../core/src/vault/orchestrators.rs#L751) —
+  `manifest_file.author_fingerprint != owner_fp` (open-vault path).
+- [core/src/vault/orchestrators.rs#L1227](../../../core/src/vault/orchestrators.rs#L1227) —
+  `author_fp != block_file.author_fingerprint` cross-check on the
+  read-block path; mirrored in `share_block` at the §1840–1904
+  recipient-resolution block.
+- [core/src/vault/orchestrators.rs#L1278](../../../core/src/vault/orchestrators.rs#L1278),
+  [#L1310](../../../core/src/vault/orchestrators.rs#L1310) —
   recipient-table lookup `.any(|w| w.recipient_fingerprint == ...)`
   and `.find(|(fp, _)| *fp == wrap.recipient_fingerprint)`.
-- [core/src/vault/block.rs:1242](../../../core/src/vault/block.rs#L1242),
-  [:1670](../../../core/src/vault/block.rs#L1670) — duplicate-
-  fingerprint check on adjacent sorted entries (well-formedness).
-- [core/src/vault/block.rs:1751](../../../core/src/vault/block.rs#L1751),
-  [:1777](../../../core/src/vault/block.rs#L1777) —
-  `block.author_fingerprint != sender_card_fingerprint` cross-check
-  + reader entry lookup `.find(|r| &r.recipient_fingerprint == reader_card_fingerprint)`.
+- [core/src/vault/block.rs#L1747](../../../core/src/vault/block.rs#L1747) —
+  `block.author_fingerprint != sender_card_fingerprint` cross-check.
+- [core/src/vault/block.rs#L1773](../../../core/src/vault/block.rs#L1773) —
+  reader entry lookup
+  `.find(|r| &r.recipient_fingerprint == reader_card_fingerprint)`.
+- Duplicate-fingerprint well-formedness check on adjacent sorted
+  entries — see the `duplicate recipient fingerprint in recipient
+  table` error class and the surrounding well-formedness code in
+  [core/src/vault/block.rs](../../../core/src/vault/block.rs).
+- Sync orchestration cross-checks (added in C.1.1a, post-audit):
+  [core/src/sync/ingest.rs](../../../core/src/sync/ingest.rs)
+  authenticates sibling envelopes against the canonical owner
+  identity via the same fingerprint primitives, applying identical
+  non-CT-is-acceptable reasoning.
 
 **Why `==` is acceptable here:** `Fingerprint = [u8; 16]` is a
 **public** value by design. Fingerprints are derived from BLAKE3 of
@@ -308,29 +324,42 @@ data-independent Argon2id pass schedule.
 ## 6. `subtle` crate adoption
 
 `subtle = "2"` is a direct dependency. The single import is at
-[core/src/crypto/secret.rs:14](../../../core/src/crypto/secret.rs#L14)
-and the only API exposed is `Sensitive<T>::ct_eq`
-([:64-67](../../../core/src/crypto/secret.rs#L64-L67)) for byte-
-string comparison.
+[core/src/crypto/secret.rs](../../../core/src/crypto/secret.rs)
+(`use subtle::ConstantTimeEq;` near the top of the file).
 
-`Sensitive<T>` deliberately does **not** implement `PartialEq` —
-documented at
-[core/src/crypto/secret.rs:76-78](../../../core/src/crypto/secret.rs#L76-L78):
-"`subtle` only provides `ConstantTimeEq` for slices and integer
-primitives; an `==` impl bounded on `T: ConstantTimeEq` would
-silently fail to apply to `[u8; N]`, the dominant case." This forces
-callers to use `ct_eq` explicitly when comparing secrets, rather than
-the syntactic `==` which would silently fall back to a non-CT impl.
+Three CT-aware comparison surfaces live on the secret-bearing wrappers:
 
-**Production call sites of `ct_eq`:** zero. By design — see Summary
-above. The verify-then-decap pattern means the codebase never has a
-"compare two secret byte strings" moment outside of AEAD MAC verify
-(where the comparison is inside the upstream crate).
+1. **`SecretBytes: PartialEq`** — `eq` delegates to
+   `self.inner.ct_eq(&other.inner)`. The `ct_eq` short-circuits on
+   length mismatch (returns false without reading mismatched bytes); for
+   equal lengths it's branch-free over the byte content.
+2. **`SecretString: PartialEq`** — `eq` delegates to
+   `self.inner.as_bytes().ct_eq(other.inner.as_bytes())`. Same
+   short-circuit-on-length-mismatch + branch-free-on-content
+   discipline as `SecretBytes`.
+3. **`Sensitive<T>`: no `PartialEq`** — documented at the type level:
+   `subtle` only provides `ConstantTimeEq` for slices and integer
+   primitives; an `==` impl bounded on `T: ConstantTimeEq` would
+   silently fail to apply to `[u8; N]`, the dominant use case (32-byte
+   keys). Callers needing byte-equality on a `Sensitive<[u8; N]>`
+   compare slices explicitly: `a.expose()[..].ct_eq(&b.expose()[..])`.
+
+**Production call sites of `ct_eq`:** the two `PartialEq` impls above,
+both internal to `secret.rs`. No external `.ct_eq(...)` call sites
+exist in `core/`, `cli/`, or `ffi/`. The verify-then-decap pattern
+still means the codebase has no explicit secret-vs-secret equality
+comparison outside of AEAD MAC verify (which is inside the upstream
+crate) — the two `PartialEq` impls exist so that **transparent** `==`
+on `Record` / `RecordField` (used in CRDT conflict resolution and
+proptest shrinking) routes through CT comparison instead of the
+non-CT byte-slice `==` that would otherwise apply.
 
 **Gaps to flag for external review:**
 - None — the API surface is small, the discipline is documented at
   the type level, and the absence of CT-violating fallbacks is
-  enforced by the absence of a `PartialEq` impl on `Sensitive`.
+  enforced by the absence of a `PartialEq` impl on `Sensitive` plus
+  the active CT-routing `PartialEq` impls on `SecretBytes` and
+  `SecretString`.
 
 ---
 
@@ -356,11 +385,15 @@ auditors.
    is non-secret information.
 
 3. **`ml-dsa` version pin**: the crate is at `0.1.0-rc.8` (release
-   candidate). Consider switching to a stable 1.x release once
-   available, and adding a comment in
+   candidate) as of 2026-05-28 — no change since the original audit.
+   Consider switching to a stable 1.x release once available, and
+   adding a comment in
    [core/Cargo.toml](../../../core/Cargo.toml) flagging the security-
-   critical pin (similar to `tempfile = "=3.27.0"`'s
-   exact-pin pattern).
+   critical pin (similar to the existing
+   `zeroize = "=1.8.2"` and `tempfile = "=3.27.0"` exact-pin
+   pattern — note that `zeroize` joined the exact-pin set after the
+   original audit, the third security-critical dep on that
+   discipline).
 
 These are not blockers for the external review; they're small
 discipline-tightening that the external reviewer might recommend
@@ -387,6 +420,33 @@ anyway.
 
 ---
 
+## Re-verification: Sub-projects B and C
+
+The audit was written against Sub-project A only. As of 2026-05-28
+both Sub-project B (FFI bindings, complete through B.6 v2) and
+Sub-project C (sync orchestration: C.1, C.1.1a/b, C.2 — headless
+`secretary-sync` CLI — all complete) have shipped substantial new
+Rust code that handles secret material. A spot re-verification:
+
+- **Sub-project B (`ffi/secretary-ffi-bridge`)** inherits the core's
+  CT discipline transparently — the bridge does not introduce any
+  new secret-vs-secret equality comparisons of its own. The
+  `FieldHandle::expose_text` / `FieldHandle::expose_bytes` accessors return
+  caller-owned plaintext (the foreign-runtime heap-copy caveat in
+  [`ffi-secret-handling-internal.md`](ffi-secret-handling-internal.md));
+  once a secret crosses the FFI boundary, CT discipline becomes a
+  foreign-runtime concern that the bridge cannot enforce. **No
+  bridge-side CT regression** was found.
+- **Sub-project C (`core/src/sync/`)** introduces additional sites
+  that copy secret bytes out of `Sensitive`-wrapped sources for
+  per-block AEAD decryption and signing (see
+  [`prepare.rs#L169`](../../../core/src/sync/prepare.rs#L169) and
+  [`commit/write.rs#L237`](../../../core/src/sync/commit/write.rs#L237)
+  for the X25519 and Ed25519 secret-key copy-then-wrap-then-zeroize
+  sites). These follow the established `bind → wrap → zeroize`
+  pattern from the memory-hygiene memo's stack-residue table. No
+  new `==`-on-secret comparison was introduced.
+
 ## Conclusion
 
 The internal pass found no bugs and no gaps in our own code. The
@@ -407,5 +467,11 @@ The verify-then-decap pattern (signature → AEAD-MAC → decap, in that
 order) means the codebase never has a "compare two secret byte
 strings for equality" moment outside of AEAD MAC verification —
 which is itself constant-time inside the upstream crate. The
-`Sensitive::ct_eq` API exists for future callers (Sub-project B FFI,
-Sub-project C orchestration) but has no current production use.
+`SecretBytes` / `SecretString` `PartialEq` impls route the
+transparent `==` operator through `subtle::ConstantTimeEq` for the
+two cases (record-field equality in conflict resolution and proptest
+shrinking) where syntactic `==` on secret-bearing values is in
+production use today. `Sensitive<T>` deliberately retains no
+`PartialEq` impl so that a slip into non-CT equality on a
+fixed-size-array secret produces a compile error rather than a
+silent fallback.


### PR DESCRIPTION
## Summary

This PR adds the FFI-boundary secret-handling audit memo (`ffi-secret-handling-internal.md`) as a companion to the existing memory-hygiene and side-channel audits. It also updates the contributor documentation index and re-verifies the earlier audits against the post-Sub-project-B/C codebase.

## Key changes

- **New audit memo** (`docs/manual/contributors/ffi-secret-handling-internal.md`): 389-line comprehensive audit of the FFI bridge's secret-handling discipline, covering:
  - The uniform `Arc<Mutex<Option<Inner>>>` opaque-handle pattern used for all six secret-bearing FFI handles
  - Wipe discipline (idempotency, cascade ordering, use-after-wipe semantics)
  - Cross-boundary secret-copy accessors (`expose_text`, `expose_bytes`, `take_phrase`) and their foreign-runtime heap-copy caveat
  - Bridge-side `Sensitive`-wrapper discipline inherited from core
  - Anti-oracle conflation across the FFI boundary
  - Checklist for adding new bridge handles

- **Updated contributor docs index** (`docs/manual/contributors/index.md`): Reorganized to reflect the four-memo audit suite (side-channel, memory-hygiene, FFI secret-handling, plus the deferred external-review track). Added context on where the project stands relative to when the original memos were written (Sub-project A only → now includes B and C).

- **Re-verified side-channel audit** (`docs/manual/contributors/side-channel-audit-internal.md`): Added "Re-verification: Sub-projects B and C" section confirming that the FFI bridge and sync orchestration layers inherit the core's CT discipline transparently and introduce no new secret-vs-secret equality comparisons. Updated inline citations to reflect code drift since 2026-05-02.

- **Re-verified memory-hygiene audit** (`docs/manual/contributors/memory-hygiene-audit-internal.md`): Added "Cross-sub-project discipline" section confirming Sub-projects B and C follow the established `bind → wrap → zeroize` pattern at every secret-bearing site. Updated wrapper discipline table to reflect `SecretString` introduction (PR #16) and `SecretBytes` `Clone` derive addition.

- **Updated freshness allowlist** (`core/tests/python/spec_freshness_allowlist.txt`): Added 14 entries for FFI-bridge symbol citations that legitimately appear in the new memo but don't resolve in `core/` (e.g., `FieldHandle::expose_text`, `MnemonicOutput::take_phrase`, `lock_or_recover`).

## Notable implementation details

- The FFI memo's "Handle inventory" table documents the six opaque handles, their wrapping strategy (`Mutex<Option<...>>` vs. `Arc<Mutex<Option<...>>>`), and cascade wipe ordering.
- The memo explicitly carves out Sub-project D platform-UI concerns (clipboard/IPC plaintext handling) as out of scope for the bridge layer.
- The "Adding a new bridge handle" checklist at the end is the contract for future FFI work: opaque-handle pattern, non-throwing accessors, idempotent `wipe()`, cascade to children, documented foreign-runtime caveat, projection through both PyO3 and uniffi, and integration test coverage.
- All three re-verified memos note that line-number citations may drift but symbol-name citations remain authoritative, with the `spec_test_name_freshness.py` script as the validation tool.

https://claude.ai/code/session_01WJXxnoREWvAa5coX8v3NoA