### PR TITLE
feat(d11): Task 7 — Unlock route + PathPicker + theme.css (closes #149, #150)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2795,6 +2795,7 @@ checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
 dependencies = [
  "bitflags 2.11.1",
  "block2",
+ "libc",
  "objc2",
  "objc2-core-foundation",
 ]
@@ -3525,6 +3526,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "rfd"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a15ad77d9e70a92437d8f74c35d99b4e4691128df018833e99f90bcd36152672"
+dependencies = [
+ "block2",
+ "dispatch2",
+ "glib-sys",
+ "gobject-sys",
+ "gtk-sys",
+ "js-sys",
+ "log",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-core-foundation",
+ "objc2-foundation",
+ "raw-window-handle",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "rpassword"
 version = "7.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3745,6 +3770,7 @@ dependencies = [
  "sha2",
  "tauri",
  "tauri-build",
+ "tauri-plugin-dialog",
  "tempfile",
  "thiserror 2.0.18",
  "tracing",
@@ -4455,6 +4481,64 @@ dependencies = [
  "syn 2.0.117",
  "tauri-codegen",
  "tauri-utils",
+]
+
+[[package]]
+name = "tauri-plugin"
+version = "2.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e126abc9e84e35cdfd01596140a73a1850cdb0df0a23acf0185776c30b469a6e"
+dependencies = [
+ "anyhow",
+ "glob",
+ "plist",
+ "schemars 0.8.22",
+ "serde",
+ "serde_json",
+ "tauri-utils",
+ "walkdir",
+]
+
+[[package]]
+name = "tauri-plugin-dialog"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65981abb771e74e571a38196c3baa11c459379164791eba0e67abc1a5fac9884"
+dependencies = [
+ "log",
+ "raw-window-handle",
+ "rfd",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "tauri-plugin-fs",
+ "thiserror 2.0.18",
+ "url",
+]
+
+[[package]]
+name = "tauri-plugin-fs"
+version = "2.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7ecc274121aca0c036a2b42d1cbe83d368d348f54e0bb8a735c2b1548e8f371"
+dependencies = [
+ "anyhow",
+ "dunce",
+ "glob",
+ "log",
+ "objc2-foundation",
+ "percent-encoding",
+ "schemars 0.8.22",
+ "serde",
+ "serde_json",
+ "serde_repr",
+ "tauri",
+ "tauri-plugin",
+ "tauri-utils",
+ "thiserror 2.0.18",
+ "toml 1.1.2+spec-1.1.0",
+ "url",
 ]
 
 [[package]]
@@ -5813,6 +5897,15 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.5",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
@@ -5859,11 +5952,28 @@ dependencies = [
  "windows_aarch64_gnullvm 0.52.6",
  "windows_aarch64_msvc 0.52.6",
  "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm",
+ "windows_i686_gnullvm 0.52.6",
  "windows_i686_msvc 0.52.6",
  "windows_x86_64_gnu 0.52.6",
  "windows_x86_64_gnullvm 0.52.6",
  "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
+dependencies = [
+ "windows-link 0.2.1",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm 0.53.1",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
 ]
 
 [[package]]
@@ -5903,6 +6013,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5919,6 +6035,12 @@ name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -5939,10 +6061,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
+
+[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -5963,6 +6097,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5979,6 +6119,12 @@ name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -5999,6 +6145,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6015,6 +6167,12 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"

--- a/NEXT_SESSION.md
+++ b/NEXT_SESSION.md
@@ -1,1 +1,1 @@
-docs/handoffs/2026-05-28-d11-task-6-shipped.md
+docs/handoffs/2026-05-28-d11-task-7-shipped.md

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -21,8 +21,11 @@
   },
   "devDependencies": {
     "@eslint/js": "^9",
-    "@sveltejs/vite-plugin-svelte": "^4",
+    "@sveltejs/vite-plugin-svelte": "^5.1.1",
     "@tauri-apps/cli": "^2",
+    "@testing-library/jest-dom": "^6.9.1",
+    "@testing-library/svelte": "^5.3.1",
+    "@testing-library/user-event": "^14.6.1",
     "eslint": "^9",
     "jsdom": "^25",
     "svelte": "^5",

--- a/desktop/pnpm-lock.yaml
+++ b/desktop/pnpm-lock.yaml
@@ -19,11 +19,20 @@ importers:
         specifier: ^9
         version: 9.39.4
       '@sveltejs/vite-plugin-svelte':
-        specifier: ^4
-        version: 4.0.4(svelte@5.55.9(@typescript-eslint/types@8.60.0))(vite@6.4.2)
+        specifier: ^5.1.1
+        version: 5.1.1(svelte@5.55.9(@typescript-eslint/types@8.60.0))(vite@6.4.2)
       '@tauri-apps/cli':
         specifier: ^2
         version: 2.11.2
+      '@testing-library/jest-dom':
+        specifier: ^6.9.1
+        version: 6.9.1
+      '@testing-library/svelte':
+        specifier: ^5.3.1
+        version: 5.3.1(svelte@5.55.9(@typescript-eslint/types@8.60.0))(vite@6.4.2)(vitest@2.1.9(jsdom@25.0.1))
+      '@testing-library/user-event':
+        specifier: ^14.6.1
+        version: 14.6.1(@testing-library/dom@10.4.1)
       eslint:
         specifier: ^9
         version: 9.39.4
@@ -54,8 +63,23 @@ importers:
 
 packages:
 
+  '@adobe/css-tools@4.5.0':
+    resolution: {integrity: sha512-6OzddxPio9UiWTCemp4N8cYLV2ZN1ncRnV1cVGtve7dhPOtRkleRyx32GQCYSwDYgaHU3USMm84tNsvKzRCa1Q==}
+
   '@asamuzakjp/css-color@3.2.0':
     resolution: {integrity: sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==}
+
+  '@babel/code-frame@7.29.7':
+    resolution: {integrity: sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-identifier@7.29.7':
+    resolution: {integrity: sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/runtime@7.29.7':
+    resolution: {integrity: sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==}
+    engines: {node: '>=6.9.0'}
 
   '@csstools/color-helpers@5.1.0':
     resolution: {integrity: sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==}
@@ -596,20 +620,20 @@ packages:
     peerDependencies:
       acorn: ^8.9.0
 
-  '@sveltejs/vite-plugin-svelte-inspector@3.0.1':
-    resolution: {integrity: sha512-2CKypmj1sM4GE7HjllT7UKmo4Q6L5xFRd7VMGEWhYnZ+wc6AUVU01IBd7yUi6WnFndEwWoMNOd6e8UjoN0nbvQ==}
+  '@sveltejs/vite-plugin-svelte-inspector@4.0.1':
+    resolution: {integrity: sha512-J/Nmb2Q2y7mck2hyCX4ckVHcR5tu2J+MtBEQqpDrrgELZ2uvraQcK/ioCV61AqkdXFgriksOKIceDcQmqnGhVw==}
     engines: {node: ^18.0.0 || ^20.0.0 || >=22}
     peerDependencies:
-      '@sveltejs/vite-plugin-svelte': ^4.0.0-next.0||^4.0.0
-      svelte: ^5.0.0-next.96 || ^5.0.0
-      vite: ^5.0.0
+      '@sveltejs/vite-plugin-svelte': ^5.0.0
+      svelte: ^5.0.0
+      vite: ^6.0.0
 
-  '@sveltejs/vite-plugin-svelte@4.0.4':
-    resolution: {integrity: sha512-0ba1RQ/PHen5FGpdSrW7Y3fAMQjrXantECALeOiOdBdzR5+5vPP6HVZRLmZaQL+W8m++o+haIAKq5qT+MiZ7VA==}
+  '@sveltejs/vite-plugin-svelte@5.1.1':
+    resolution: {integrity: sha512-Y1Cs7hhTc+a5E9Va/xwKlAJoariQyHY+5zBgCZg4PFWNYQ1nMN9sjK1zhw1gK69DuqVP++sht/1GZg1aRwmAXQ==}
     engines: {node: ^18.0.0 || ^20.0.0 || >=22}
     peerDependencies:
-      svelte: ^5.0.0-next.96 || ^5.0.0
-      vite: ^5.0.0
+      svelte: ^5.0.0
+      vite: ^6.0.0
 
   '@tauri-apps/api@2.11.0':
     resolution: {integrity: sha512-7CinYODhky9lmO23xHnUFv0Xt43fbtWMyxZcLcRBlFkcgXKuEirBvHpmtJ89YMhyeGcq20Wuc47Fa4XjyniywA==}
@@ -692,6 +716,42 @@ packages:
 
   '@tauri-apps/plugin-dialog@2.7.1':
     resolution: {integrity: sha512-OK1UBXYt+ojcmxMktzzuyonYIFta8CmAASpX+CA+DTGK24KlHjhYI6x2iOJ/TjZF4N7/ACK1oFmEOjIY9IhzOQ==}
+
+  '@testing-library/dom@10.4.1':
+    resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
+    engines: {node: '>=18'}
+
+  '@testing-library/jest-dom@6.9.1':
+    resolution: {integrity: sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==}
+    engines: {node: '>=14', npm: '>=6', yarn: '>=1'}
+
+  '@testing-library/svelte-core@1.0.0':
+    resolution: {integrity: sha512-VkUePoLV6oOYwSUvX6ShA8KLnJqZiYMIbP2JW2t0GLWLkJxKGvuH5qrrZBV/X7cXFnLGuFQEC7RheYiZOW68KQ==}
+    engines: {node: '>=16'}
+    peerDependencies:
+      svelte: ^3 || ^4 || ^5 || ^5.0.0-next.0
+
+  '@testing-library/svelte@5.3.1':
+    resolution: {integrity: sha512-8Ez7ZOqW5geRf9PF5rkuopODe5RGy3I9XR+kc7zHh26gBiktLaxTfKmhlGaSHYUOTQE7wFsLMN9xCJVCszw47w==}
+    engines: {node: '>= 10'}
+    peerDependencies:
+      svelte: ^3 || ^4 || ^5 || ^5.0.0-next.0
+      vite: '*'
+      vitest: '*'
+    peerDependenciesMeta:
+      vite:
+        optional: true
+      vitest:
+        optional: true
+
+  '@testing-library/user-event@14.6.1':
+    resolution: {integrity: sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==}
+    engines: {node: '>=12', npm: '>=6'}
+    peerDependencies:
+      '@testing-library/dom': '>=7.21.4'
+
+  '@types/aria-query@5.0.4':
+    resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
 
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
@@ -810,12 +870,23 @@ packages:
   ajv@6.15.0:
     resolution: {integrity: sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==}
 
+  ansi-regex@5.0.1:
+    resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
+    engines: {node: '>=8'}
+
   ansi-styles@4.3.0:
     resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
     engines: {node: '>=8'}
 
+  ansi-styles@5.2.0:
+    resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
+    engines: {node: '>=10'}
+
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
+
+  aria-query@5.3.0:
+    resolution: {integrity: sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==}
 
   aria-query@5.3.1:
     resolution: {integrity: sha512-Z/ZeOgVl7bcSYZ/u/rh0fOpvEpq//LZmdbkXyc7syVzjPAhfOa9ebsdTSjEBDU4vs5nC98Kfduj1uFo0qyET3g==}
@@ -896,6 +967,9 @@ packages:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
 
+  css.escape@1.5.1:
+    resolution: {integrity: sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==}
+
   cssstyle@4.6.0:
     resolution: {integrity: sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==}
     engines: {node: '>=18'}
@@ -931,8 +1005,18 @@ packages:
     resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
     engines: {node: '>=0.4.0'}
 
+  dequal@2.0.3:
+    resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
+    engines: {node: '>=6'}
+
   devalue@5.8.1:
     resolution: {integrity: sha512-4CXDYRBGqN+57wVJkuXBYmpAVUSg3L6JAQa/DFqm238G73E1wuyc/JhGQJzN7vUf/CMphYau2zXbfWzDR5aTEw==}
+
+  dom-accessibility-api@0.5.16:
+    resolution: {integrity: sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==}
+
+  dom-accessibility-api@0.6.3:
+    resolution: {integrity: sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==}
 
   dunder-proto@1.0.1:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
@@ -1152,6 +1236,10 @@ packages:
     resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
     engines: {node: '>=0.8.19'}
 
+  indent-string@4.0.0:
+    resolution: {integrity: sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==}
+    engines: {node: '>=8'}
+
   is-extglob@2.1.1:
     resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
     engines: {node: '>=0.10.0'}
@@ -1168,6 +1256,9 @@ packages:
 
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
+
+  js-tokens@4.0.0:
+    resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
   js-yaml@4.1.1:
     resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
@@ -1218,6 +1309,10 @@ packages:
   lru-cache@10.4.3:
     resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
 
+  lz-string@1.5.0:
+    resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
+    hasBin: true
+
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
@@ -1232,6 +1327,10 @@ packages:
   mime-types@2.1.35:
     resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
     engines: {node: '>= 0.6'}
+
+  min-indent@1.0.1:
+    resolution: {integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==}
+    engines: {node: '>=4'}
 
   minimatch@10.2.5:
     resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
@@ -1307,13 +1406,24 @@ packages:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
 
+  pretty-format@27.5.1:
+    resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
+    engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
+
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
 
+  react-is@17.0.2:
+    resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
+
   readdirp@4.1.2:
     resolution: {integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==}
     engines: {node: '>= 14.18.0'}
+
+  redent@3.0.0:
+    resolution: {integrity: sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==}
+    engines: {node: '>=8'}
 
   resolve-from@4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
@@ -1366,6 +1476,10 @@ packages:
 
   std-env@3.10.0:
     resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
+
+  strip-indent@3.0.0:
+    resolution: {integrity: sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==}
+    engines: {node: '>=8'}
 
   strip-json-comments@3.1.1:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
@@ -1627,6 +1741,8 @@ packages:
 
 snapshots:
 
+  '@adobe/css-tools@4.5.0': {}
+
   '@asamuzakjp/css-color@3.2.0':
     dependencies:
       '@csstools/css-calc': 2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
@@ -1634,6 +1750,16 @@ snapshots:
       '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
       '@csstools/css-tokenizer': 3.0.4
       lru-cache: 10.4.3
+
+  '@babel/code-frame@7.29.7':
+    dependencies:
+      '@babel/helper-validator-identifier': 7.29.7
+      js-tokens: 4.0.0
+      picocolors: 1.1.1
+
+  '@babel/helper-validator-identifier@7.29.7': {}
+
+  '@babel/runtime@7.29.7': {}
 
   '@csstools/color-helpers@5.1.0': {}
 
@@ -1962,18 +2088,18 @@ snapshots:
     dependencies:
       acorn: 8.16.0
 
-  '@sveltejs/vite-plugin-svelte-inspector@3.0.1(@sveltejs/vite-plugin-svelte@4.0.4(svelte@5.55.9(@typescript-eslint/types@8.60.0))(vite@6.4.2))(svelte@5.55.9(@typescript-eslint/types@8.60.0))(vite@6.4.2)':
+  '@sveltejs/vite-plugin-svelte-inspector@4.0.1(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.55.9(@typescript-eslint/types@8.60.0))(vite@6.4.2))(svelte@5.55.9(@typescript-eslint/types@8.60.0))(vite@6.4.2)':
     dependencies:
-      '@sveltejs/vite-plugin-svelte': 4.0.4(svelte@5.55.9(@typescript-eslint/types@8.60.0))(vite@6.4.2)
+      '@sveltejs/vite-plugin-svelte': 5.1.1(svelte@5.55.9(@typescript-eslint/types@8.60.0))(vite@6.4.2)
       debug: 4.4.3
       svelte: 5.55.9(@typescript-eslint/types@8.60.0)
       vite: 6.4.2
     transitivePeerDependencies:
       - supports-color
 
-  '@sveltejs/vite-plugin-svelte@4.0.4(svelte@5.55.9(@typescript-eslint/types@8.60.0))(vite@6.4.2)':
+  '@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.55.9(@typescript-eslint/types@8.60.0))(vite@6.4.2)':
     dependencies:
-      '@sveltejs/vite-plugin-svelte-inspector': 3.0.1(@sveltejs/vite-plugin-svelte@4.0.4(svelte@5.55.9(@typescript-eslint/types@8.60.0))(vite@6.4.2))(svelte@5.55.9(@typescript-eslint/types@8.60.0))(vite@6.4.2)
+      '@sveltejs/vite-plugin-svelte-inspector': 4.0.1(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.55.9(@typescript-eslint/types@8.60.0))(vite@6.4.2))(svelte@5.55.9(@typescript-eslint/types@8.60.0))(vite@6.4.2)
       debug: 4.4.3
       deepmerge: 4.3.1
       kleur: 4.1.5
@@ -2036,6 +2162,45 @@ snapshots:
   '@tauri-apps/plugin-dialog@2.7.1':
     dependencies:
       '@tauri-apps/api': 2.11.0
+
+  '@testing-library/dom@10.4.1':
+    dependencies:
+      '@babel/code-frame': 7.29.7
+      '@babel/runtime': 7.29.7
+      '@types/aria-query': 5.0.4
+      aria-query: 5.3.0
+      dom-accessibility-api: 0.5.16
+      lz-string: 1.5.0
+      picocolors: 1.1.1
+      pretty-format: 27.5.1
+
+  '@testing-library/jest-dom@6.9.1':
+    dependencies:
+      '@adobe/css-tools': 4.5.0
+      aria-query: 5.3.1
+      css.escape: 1.5.1
+      dom-accessibility-api: 0.6.3
+      picocolors: 1.1.1
+      redent: 3.0.0
+
+  '@testing-library/svelte-core@1.0.0(svelte@5.55.9(@typescript-eslint/types@8.60.0))':
+    dependencies:
+      svelte: 5.55.9(@typescript-eslint/types@8.60.0)
+
+  '@testing-library/svelte@5.3.1(svelte@5.55.9(@typescript-eslint/types@8.60.0))(vite@6.4.2)(vitest@2.1.9(jsdom@25.0.1))':
+    dependencies:
+      '@testing-library/dom': 10.4.1
+      '@testing-library/svelte-core': 1.0.0(svelte@5.55.9(@typescript-eslint/types@8.60.0))
+      svelte: 5.55.9(@typescript-eslint/types@8.60.0)
+    optionalDependencies:
+      vite: 6.4.2
+      vitest: 2.1.9(jsdom@25.0.1)
+
+  '@testing-library/user-event@14.6.1(@testing-library/dom@10.4.1)':
+    dependencies:
+      '@testing-library/dom': 10.4.1
+
+  '@types/aria-query@5.0.4': {}
 
   '@types/estree@1.0.8': {}
 
@@ -2191,11 +2356,19 @@ snapshots:
       json-schema-traverse: 0.4.1
       uri-js: 4.4.1
 
+  ansi-regex@5.0.1: {}
+
   ansi-styles@4.3.0:
     dependencies:
       color-convert: 2.0.1
 
+  ansi-styles@5.2.0: {}
+
   argparse@2.0.1: {}
+
+  aria-query@5.3.0:
+    dependencies:
+      dequal: 2.0.3
 
   aria-query@5.3.1: {}
 
@@ -2266,6 +2439,8 @@ snapshots:
       shebang-command: 2.0.0
       which: 2.0.2
 
+  css.escape@1.5.1: {}
+
   cssstyle@4.6.0:
     dependencies:
       '@asamuzakjp/css-color': 3.2.0
@@ -2290,7 +2465,13 @@ snapshots:
 
   delayed-stream@1.0.0: {}
 
+  dequal@2.0.3: {}
+
   devalue@5.8.1: {}
+
+  dom-accessibility-api@0.5.16: {}
+
+  dom-accessibility-api@0.6.3: {}
 
   dunder-proto@1.0.1:
     dependencies:
@@ -2566,6 +2747,8 @@ snapshots:
 
   imurmurhash@0.1.4: {}
 
+  indent-string@4.0.0: {}
+
   is-extglob@2.1.1: {}
 
   is-glob@4.0.3:
@@ -2579,6 +2762,8 @@ snapshots:
       '@types/estree': 1.0.9
 
   isexe@2.0.0: {}
+
+  js-tokens@4.0.0: {}
 
   js-yaml@4.1.1:
     dependencies:
@@ -2641,6 +2826,8 @@ snapshots:
 
   lru-cache@10.4.3: {}
 
+  lz-string@1.5.0: {}
+
   magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
@@ -2652,6 +2839,8 @@ snapshots:
   mime-types@2.1.35:
     dependencies:
       mime-db: 1.52.0
+
+  min-indent@1.0.1: {}
 
   minimatch@10.2.5:
     dependencies:
@@ -2716,9 +2905,22 @@ snapshots:
 
   prelude-ls@1.2.1: {}
 
+  pretty-format@27.5.1:
+    dependencies:
+      ansi-regex: 5.0.1
+      ansi-styles: 5.2.0
+      react-is: 17.0.2
+
   punycode@2.3.1: {}
 
+  react-is@17.0.2: {}
+
   readdirp@4.1.2: {}
+
+  redent@3.0.0:
+    dependencies:
+      indent-string: 4.0.0
+      strip-indent: 3.0.0
 
   resolve-from@4.0.0: {}
 
@@ -2782,6 +2984,10 @@ snapshots:
   stackback@0.0.2: {}
 
   std-env@3.10.0: {}
+
+  strip-indent@3.0.0:
+    dependencies:
+      min-indent: 1.0.1
 
   strip-json-comments@3.1.1: {}
 

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -90,6 +90,13 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 #   is already in `desktop/package.json`. Capability is granted via
 #   `desktop/src-tauri/capabilities/default.json` (`dialog:allow-open`);
 #   no other dialog permissions are needed by D.1.1.
+#
+# Caret range (not the exact-pin convention used by `tempfile`): the
+# dialog plugin is UI-only and no key material or vault bytes cross
+# it — the JS side receives only the chosen folder path (a string
+# already inside our trust boundary). No security-critical guarantee
+# rides on a specific 2.x patch version, so the standard caret range
+# is appropriate here.
 tauri-plugin-dialog = "2"
 
 [lints]

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -83,6 +83,15 @@ rand = "0.9"
 #   `env-filter` lets `RUST_LOG` tune verbosity at runtime.
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
+# Task 7 frontend addition:
+# - `tauri-plugin-dialog` exposes the native folder/file-picker dialog
+#   used by `desktop/src/components/PathPicker.svelte` for choosing a
+#   vault folder. The JS-side companion (`@tauri-apps/plugin-dialog`)
+#   is already in `desktop/package.json`. Capability is granted via
+#   `desktop/src-tauri/capabilities/default.json` (`dialog:allow-open`);
+#   no other dialog permissions are needed by D.1.1.
+tauri-plugin-dialog = "2"
+
 [lints]
 workspace = true
 

--- a/desktop/src-tauri/capabilities/default.json
+++ b/desktop/src-tauri/capabilities/default.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "https://schema.tauri.app/config/2.0.0/capability",
+  "identifier": "default",
+  "description": "Default capabilities for the secretary-desktop main window. Grants the bare minimum the D.1.1 walking skeleton needs: Tauri core (event listening, IPC invoke) and the open-folder dialog used by PathPicker. Extend per-task as new capabilities are required.",
+  "windows": ["main"],
+  "permissions": [
+    "core:default",
+    "dialog:allow-open"
+  ]
+}

--- a/desktop/src-tauri/src/main.rs
+++ b/desktop/src-tauri/src/main.rs
@@ -55,6 +55,11 @@ fn main() {
     );
 
     tauri::Builder::default()
+        // The dialog plugin powers `PathPicker.svelte`'s native folder-
+        // selection dialog (frontend opens it via
+        // `@tauri-apps/plugin-dialog`). Permissions for the JS side are
+        // granted by `capabilities/default.json` (`dialog:allow-open`).
+        .plugin(tauri_plugin_dialog::init())
         .manage(Mutex::new(VaultSession::new(device_data_dir)))
         .invoke_handler(tauri::generate_handler![
             unlock::unlock_with_password,

--- a/desktop/src/App.svelte
+++ b/desktop/src/App.svelte
@@ -1,16 +1,61 @@
 <script lang="ts">
-  // D.1.1 placeholder. Routing + sessionState subscription lands in Task 10.
+  import { onMount } from 'svelte';
+  import { listen, type UnlistenFn } from '@tauri-apps/api/event';
+  import { sessionState, vaultLocked } from './lib/stores';
+  import Unlock from './routes/Unlock.svelte';
+  import './theme.css';
+
+  // The backend `vault-locked` event fires from two call sites:
+  //   - explicit user-lock (`commands::lock`) → reason: 'explicit'
+  //   - auto-lock timer tick (`main::auto_lock_timer_loop`) → reason: 'auto'
+  // Both mean the same thing to the UI ("vault is now locked"); they
+  // differ only in which AutoLockNotice copy the toast surface renders.
+  type VaultLockedPayload = { reason: 'explicit' | 'auto' };
+
+  // Map the backend reason to the AutoLockNotice reason. The shape pin
+  // `vault_locked_event_name_is_kebab_case` on the Rust side keeps the
+  // event name in lockstep with the listener string below.
+  const REASON_TO_NOTICE = {
+    explicit: 'manual',
+    auto: 'idle'
+  } as const;
+
+  // Listener installation is async — `listen()` returns a Promise.
+  // Stash the unlisten fn in a closure-local so the onMount cleanup
+  // can detach even if the resolver lands after unmount.
+  onMount(() => {
+    let unlisten: UnlistenFn | null = null;
+    let unmounted = false;
+
+    listen<VaultLockedPayload>('vault-locked', (event) => {
+      const notice = REASON_TO_NOTICE[event.payload.reason];
+      vaultLocked(notice);
+    }).then((fn) => {
+      if (unmounted) {
+        // Unmount raced the listener resolve — detach immediately so we
+        // don't leak the subscription across the component lifecycle.
+        fn();
+      } else {
+        unlisten = fn;
+      }
+    });
+
+    return () => {
+      unmounted = true;
+      if (unlisten) {
+        unlisten();
+      }
+    };
+  });
 </script>
 
-<main>
-  <h1>Secretary</h1>
-  <p>D.1.1 walking skeleton — bootstrapping…</p>
-</main>
-
-<style>
-  main {
-    font-family: system-ui, -apple-system, sans-serif;
-    padding: 2rem;
-    text-align: center;
-  }
-</style>
+{#if $sessionState.status === 'unlocked'}
+  <!-- Vault route lands in Task 8. Placeholder copy keeps the smoke
+       test legible until BlockList ships. -->
+  <main>
+    <h1>Secretary</h1>
+    <p>Vault view coming in Task 8.</p>
+  </main>
+{:else}
+  <Unlock />
+{/if}

--- a/desktop/src/components/PathPicker.svelte
+++ b/desktop/src/components/PathPicker.svelte
@@ -1,0 +1,44 @@
+<script lang="ts">
+  import { open as openDialog } from '@tauri-apps/plugin-dialog';
+
+  type Props = {
+    value: string;
+    onSelect: (path: string) => void;
+    disabled?: boolean;
+  };
+
+  const PICKER_TITLE = 'Choose vault folder';
+
+  let { value, onSelect, disabled = false }: Props = $props();
+
+  async function pick(): Promise<void> {
+    // Disabled buttons can't be clicked via the UI, but a stray
+    // programmatic dispatch shouldn't leak a stray dialog.
+    if (disabled) return;
+    const selected = await openDialog({
+      directory: true,
+      multiple: false,
+      title: PICKER_TITLE
+    });
+    // `multiple: false` constrains the return to `string | null`, but
+    // we defend against a future refactor that flips `multiple: true`
+    // by ignoring array returns rather than passing them through.
+    if (typeof selected === 'string') {
+      onSelect(selected);
+    }
+  }
+</script>
+
+<!-- Styles live in `src/theme.css` as `.path-picker { … }`; see the note
+     at the bottom of theme.css for why component-scoped `<style>` blocks
+     are avoided in this project. -->
+<div class="path-picker">
+  <input
+    type="text"
+    readonly
+    value={value || ''}
+    placeholder="No folder selected"
+    {disabled}
+  />
+  <button type="button" onclick={pick} {disabled}>Choose…</button>
+</div>

--- a/desktop/src/lib/stores.ts
+++ b/desktop/src/lib/stores.ts
@@ -30,11 +30,16 @@ export type SessionState =
   | { status: 'unlocked'; manifest: ManifestDto; settings: SettingsDto }
   | { status: 'locking'; startedAt: number };
 
-const INITIAL_STATE: SessionState = { status: 'locked', lastError: null };
+// Factory rather than a shared constant: each call yields a fresh
+// object so the initial-write and `_resetSessionStateForTest` can never
+// hand out aliased references that a test might accidentally mutate.
+function initialState(): SessionState {
+  return { status: 'locked', lastError: null };
+}
 
 // Internal writable — mutations gate through the transition helpers
 // below. Not exported; the public `sessionState` is a read-only view.
-const _internal = writable<SessionState>(INITIAL_STATE);
+const _internal = writable<SessionState>(initialState());
 
 // Public subscription surface. Components consume via the `$` Svelte
 // auto-subscription idiom (`$sessionState.status === 'unlocked'`).
@@ -117,7 +122,7 @@ export function vaultLocked(reason: 'idle' | 'manual', at: number = Date.now()):
  * convention in `auto_lock.ts`.
  */
 export function _resetSessionStateForTest(): void {
-  _internal.set(INITIAL_STATE);
+  _internal.set(initialState());
   autoLockNotice.set(null);
 }
 

--- a/desktop/src/lib/stores.ts
+++ b/desktop/src/lib/stores.ts
@@ -1,27 +1,58 @@
-// Svelte stores for session-level state. The discriminated union lets
-// consumers exhaust on `.status` rather than juggle booleans, and the
-// per-variant payloads make illegal states (e.g. reading `manifest`
-// while `locked`) unrepresentable at the type level.
+// Session-level Svelte stores with a state-machine API.
+//
+// The raw `writable<SessionState>` lives as the non-exported `_internal`;
+// the public surface is the readable `sessionState` plus a small set of
+// transition helpers that enforce the legal-edge graph below. Illegal
+// edges throw in dev (Vitest runs in dev mode so the tests catch them)
+// and log + no-op in prod so a frontend state-machine bug never DOS's
+// the user. The backend is the source of truth for vault state, hence
+// `vaultLocked` is authoritative — it accepts from any current state.
+//
+// Legal transitions (any → locked via vaultLocked is always allowed):
+//
+//   locked      → unlocking    beginUnlock()
+//   unlocking   → unlocked     unlockSucceeded(manifest, settings)
+//   unlocking   → locked       unlockFailed(err)
+//   unlocked    → locking      beginLock()
+//   *           → locked       vaultLocked('idle' | 'manual', at)
+//
+// `unlocking` and `locking` carry `startedAt: number` so the UI can
+// detect stuck transitions and surface a toast (consumer lands in
+// Tasks 8–10).
 
-import { writable, derived } from 'svelte/store';
+import { writable, derived, type Readable } from 'svelte/store';
 import type { AppError } from './errors';
 import type { ManifestDto, SettingsDto } from './ipc';
 
 export type SessionState =
   | { status: 'locked'; lastError: AppError | null }
-  | { status: 'unlocking' }
+  | { status: 'unlocking'; startedAt: number }
   | { status: 'unlocked'; manifest: ManifestDto; settings: SettingsDto }
-  | { status: 'locking' };
+  | { status: 'locking'; startedAt: number };
 
-export const sessionState = writable<SessionState>({ status: 'locked', lastError: null });
+const INITIAL_STATE: SessionState = { status: 'locked', lastError: null };
 
-// Short-lived notice surfaced when the auto-lock timer fires (`idle`),
-// the user clicks Lock (`manual`), or the activity-tracker keep-alive
-// IPC starts failing (`keep_alive_failing`). The discriminated union
-// lets the toast component pick its copy and severity based on `reason`
-// rather than parsing a free-form string. `at` is the millisecond
-// timestamp when the notice was raised, used for de-duplication and
-// auto-dismiss timing.
+// Internal writable — mutations gate through the transition helpers
+// below. Not exported; the public `sessionState` is a read-only view.
+const _internal = writable<SessionState>(INITIAL_STATE);
+
+// Public subscription surface. Components consume via the `$` Svelte
+// auto-subscription idiom (`$sessionState.status === 'unlocked'`).
+// No `.set` / `.update` exposed — callers must use a transition helper.
+export const sessionState: Readable<SessionState> = {
+  subscribe: _internal.subscribe
+};
+
+// Short-lived notice surfaced when the backend `vault-locked` event
+// fires (`idle` for auto-lock, `manual` for explicit-lock), or when
+// the activity-tracker keep-alive IPC starts failing repeatedly. The
+// discriminated union lets the toast component pick its copy and
+// severity. `at` is the millisecond timestamp at which the notice
+// was raised, used for de-duplication and auto-dismiss timing.
+//
+// `vaultLocked()` sets the `idle` / `manual` reasons automatically as
+// part of the transition; `keep_alive_failing` is set directly by
+// `auto_lock.ts` since it's not tied to a session-state transition.
 export type AutoLockNotice =
   | { reason: 'idle'; at: number }
   | { reason: 'manual'; at: number }
@@ -33,3 +64,98 @@ export const autoLockNotice = writable<AutoLockNotice | null>(null);
 export const currentSettings = derived(sessionState, ($s) =>
   $s.status === 'unlocked' ? $s.settings : null
 );
+
+// --- Transition helpers ----------------------------------------------------
+
+/**
+ * `locked → unlocking`. Records `startedAt` so the UI can detect stuck
+ * unlocks. Pass an explicit `now` for deterministic tests.
+ */
+export function beginUnlock(now: number = Date.now()): void {
+  transition(['locked'], { status: 'unlocking', startedAt: now });
+}
+
+/**
+ * `unlocking → unlocked`. Carries the manifest + settings into the
+ * variant payload.
+ */
+export function unlockSucceeded(manifest: ManifestDto, settings: SettingsDto): void {
+  transition(['unlocking'], { status: 'unlocked', manifest, settings });
+}
+
+/**
+ * `unlocking → locked`. Carries the typed error so the Unlock form can
+ * render `userMessageFor(err)` inline.
+ */
+export function unlockFailed(err: AppError): void {
+  transition(['unlocking'], { status: 'locked', lastError: err });
+}
+
+/**
+ * `unlocked → locking`. Records `startedAt`; the actual lock IPC fires
+ * after this and the transition to `locked` happens via `vaultLocked`
+ * when the backend's `vault-locked` event arrives (spec §7 — backend
+ * reality is source of truth).
+ */
+export function beginLock(now: number = Date.now()): void {
+  transition(['unlocked'], { status: 'locking', startedAt: now });
+}
+
+/**
+ * `* → locked`. Authoritative end-state from the backend `vault-locked`
+ * event; accepted from any current state. Also raises the matching
+ * `autoLockNotice` so the toast surface can render the reason copy.
+ */
+export function vaultLocked(reason: 'idle' | 'manual', at: number = Date.now()): void {
+  _internal.set({ status: 'locked', lastError: null });
+  autoLockNotice.set({ reason, at });
+}
+
+/**
+ * Test-only escape hatch — restores both stores to initial state.
+ * Underscore prefix matches the `_resetActivityTrackingForTest`
+ * convention in `auto_lock.ts`.
+ */
+export function _resetSessionStateForTest(): void {
+  _internal.set(INITIAL_STATE);
+  autoLockNotice.set(null);
+}
+
+// --- Internal --------------------------------------------------------------
+
+/**
+ * Atomic check-and-set: if `current.status` is not in `allowed`, the
+ * transition is illegal and we either throw (dev) or log + no-op (prod).
+ * Using `update()` rather than `get(_internal)` + `set(...)` keeps the
+ * check and the set under the same store lock.
+ */
+function transition(
+  allowed: ReadonlyArray<SessionState['status']>,
+  toState: SessionState
+): void {
+  _internal.update((current) => {
+    if (!allowed.includes(current.status)) {
+      illegalTransition(current.status, toState.status, allowed);
+      return current;
+    }
+    return toState;
+  });
+}
+
+function illegalTransition(
+  from: SessionState['status'],
+  to: SessionState['status'],
+  allowed: ReadonlyArray<SessionState['status']>
+): void {
+  const msg = `illegal session transition: ${from} → ${to} (allowed from: ${allowed.join(', ')})`;
+  // Vite/Vitest sets `import.meta.env.DEV === true` for dev + test
+  // builds; production bundles get `false`. Throwing in dev surfaces
+  // state-machine bugs immediately in tests; logging in prod keeps the
+  // user from seeing a hard crash for a recoverable frontend slip —
+  // the backend remains the source of truth either way.
+  if (import.meta.env.DEV) {
+    throw new Error(msg);
+  } else {
+    console.error(msg);
+  }
+}

--- a/desktop/src/routes/Unlock.svelte
+++ b/desktop/src/routes/Unlock.svelte
@@ -1,0 +1,96 @@
+<script lang="ts">
+  import PathPicker from '../components/PathPicker.svelte';
+  import { sessionState, beginUnlock, unlockSucceeded, unlockFailed } from '../lib/stores';
+  import { unlockWithPassword, getSettings } from '../lib/ipc';
+  import { userMessageFor, type AppError } from '../lib/errors';
+
+  let folderPath = $state('');
+  let password = $state('');
+  let submitting = $state(false);
+
+  const formValid = $derived(folderPath.length > 0 && password.length > 0);
+
+  async function submit(e: SubmitEvent): Promise<void> {
+    e.preventDefault();
+    if (!formValid || submitting) return;
+    submitting = true;
+    beginUnlock();
+    try {
+      const manifest = await unlockWithPassword(folderPath, password);
+      // Manifest only carries `warnings`; the full settings DTO comes
+      // from `getSettings` so the post-unlock route has the auto-lock
+      // timeout (etc.) readily available.
+      const settings = await getSettings();
+      unlockSucceeded(manifest, settings);
+      // Password lifetime ends here — strip from DOM state immediately
+      // rather than relying on the route swap to clear the binding.
+      password = '';
+    } catch (err) {
+      unlockFailed(err as AppError);
+    } finally {
+      submitting = false;
+    }
+  }
+
+  // Inline error: render the userMessageFor() shape of the last unlock
+  // failure. `$sessionState` is the Svelte auto-subscription accessor;
+  // it narrows on `.status` so reading `.lastError` is type-safe.
+  let errMsg = $derived(
+    $sessionState.status === 'locked' && $sessionState.lastError
+      ? userMessageFor($sessionState.lastError)
+      : null
+  );
+</script>
+
+<!-- Styles for `.unlock*` live in `src/theme.css`; component-scoped
+     <style> blocks trip a Vite-6 preprocessCSS bug under Vitest, so all
+     visual rules are centralised. -->
+<main class="unlock">
+  <div class="unlock__card">
+    <div class="unlock__icon" aria-hidden="true">🔐</div>
+    <h1 class="unlock__title">Secretary</h1>
+    <p class="unlock__subtitle">Open a vault</p>
+
+    <form onsubmit={submit}>
+      {#if errMsg}
+        <div class="unlock__error" role="alert">
+          <div class="unlock__error-title">{errMsg.title}</div>
+          {#if errMsg.detail}
+            <div class="unlock__error-detail">{errMsg.detail}</div>
+          {/if}
+          {#if errMsg.actionHint}
+            <div class="unlock__error-hint">{errMsg.actionHint}</div>
+          {/if}
+        </div>
+      {/if}
+
+      <label class="unlock__field">
+        <span class="unlock__label">Vault folder</span>
+        <PathPicker
+          value={folderPath}
+          onSelect={(p) => (folderPath = p)}
+          disabled={submitting}
+        />
+      </label>
+
+      <label class="unlock__field">
+        <span class="unlock__label">Password</span>
+        <input
+          type="password"
+          class="unlock__password"
+          bind:value={password}
+          placeholder="••••••••"
+          disabled={submitting}
+        />
+      </label>
+
+      <button type="submit" class="unlock__submit" disabled={!formValid || submitting}>
+        {submitting ? 'Unlocking…' : 'Unlock'}
+      </button>
+
+      <div class="unlock__footer">
+        Lost your password? Use recovery phrase (coming soon)
+      </div>
+    </form>
+  </div>
+</main>

--- a/desktop/src/routes/Unlock.svelte
+++ b/desktop/src/routes/Unlock.svelte
@@ -22,12 +22,15 @@
       // timeout (etc.) readily available.
       const settings = await getSettings();
       unlockSucceeded(manifest, settings);
-      // Password lifetime ends here — strip from DOM state immediately
-      // rather than relying on the route swap to clear the binding.
-      password = '';
     } catch (err) {
       unlockFailed(err as AppError);
     } finally {
+      // Password lifetime ends here regardless of outcome — strip the
+      // binding immediately so a failed attempt doesn't leave the string
+      // sitting in DOM state across the user's next keystroke. JS strings
+      // are immutable so we can't truly zeroize, but unbinding minimises
+      // the live-reference window the GC has to chase.
+      password = '';
       submitting = false;
     }
   }

--- a/desktop/src/theme.css
+++ b/desktop/src/theme.css
@@ -1,0 +1,128 @@
+/* Secretary desktop — CSS custom-property theme tokens.
+ *
+ * Loaded once from App.svelte; every component references these tokens
+ * via `var(--…)`. No CSS framework — plain custom properties keep the
+ * bundle minimal (~2 KB after gzip) and let the entire theme be
+ * reviewed in a single file. Dark mode is handled by overriding the
+ * tokens in `@media (prefers-color-scheme: dark)` below; no JS toggle.
+ */
+
+:root {
+  /* Color tokens — neutral base. Components compose via semantic names
+     rather than literal hex values so dark-mode lives in one place. */
+  --color-bg: #fafafa;
+  --color-bg-elevated: #ffffff;
+  --color-text: #1a1a1a;
+  --color-text-muted: #6b6b6b;
+  --color-border: #e0e0e0;
+  --color-primary: #2563eb;
+  --color-primary-hover: #1d4ed8;
+  --color-danger: #dc2626;
+  --color-danger-bg: #fef2f2;
+  --color-warning: #d97706;
+  --color-warning-bg: #fffbeb;
+
+  /* Spacing scale — 4 px base; powers-of-2-ish to keep the rhythm
+     consistent across components without exhausting the design space. */
+  --space-1: 4px;
+  --space-2: 8px;
+  --space-3: 12px;
+  --space-4: 16px;
+  --space-5: 24px;
+  --space-6: 32px;
+  --space-7: 48px;
+  --space-8: 64px;
+
+  /* Border-radius tokens */
+  --radius-sm: 4px;
+  --radius-md: 6px;
+  --radius-lg: 10px;
+
+  /* Typography */
+  --font-stack: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+  --font-stack-mono: ui-monospace, "SF Mono", Menlo, monospace;
+  --font-size-xs: 11px;
+  --font-size-sm: 13px;
+  --font-size-md: 15px;
+  --font-size-lg: 18px;
+  --font-size-xl: 22px;
+
+  /* Shadows — opacity tuned for the light theme; dark mode overrides
+     each shadow token below since black-on-black is invisible. */
+  --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.04);
+  --shadow-md: 0 4px 12px rgba(0, 0, 0, 0.08);
+  --shadow-lg: 0 16px 32px rgba(0, 0, 0, 0.12);
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --color-bg: #0f0f10;
+    --color-bg-elevated: #1a1a1c;
+    --color-text: #f5f5f5;
+    --color-text-muted: #a1a1a1;
+    --color-border: #2a2a2d;
+    --color-primary: #60a5fa;
+    --color-primary-hover: #93c5fd;
+    --color-danger: #f87171;
+    --color-danger-bg: #2a1414;
+    --color-warning: #fbbf24;
+    --color-warning-bg: #2a2014;
+  }
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  font-family: var(--font-stack);
+  font-size: var(--font-size-md);
+  color: var(--color-text);
+  background: var(--color-bg);
+  margin: 0;
+}
+
+/* ---- Component classes -------------------------------------------------
+ *
+ * Component-scoped styles live in `theme.css` (this file) rather than in
+ * `<style>` blocks inside individual `.svelte` files. Reason: Vite 6's
+ * internal `preprocessCSS` trips a `PartialEnvironment` proxy bug under
+ * Vitest, which would otherwise force us to remove component styles to
+ * keep the harness green. Side benefit: every visual choice is reviewable
+ * in one file rather than spread across components.
+ *
+ * Naming convention: `.<component>` for the root, `.<component>__<part>`
+ * for inner parts (BEM-light). New components add a small block below.
+ */
+
+/* PathPicker */
+.path-picker {
+  display: flex;
+  gap: var(--space-2);
+}
+.path-picker input {
+  flex: 1;
+  padding: var(--space-2) var(--space-3);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  background: var(--color-bg-elevated);
+  color: var(--color-text);
+  font-family: var(--font-stack-mono);
+  font-size: var(--font-size-sm);
+}
+.path-picker button {
+  padding: var(--space-2) var(--space-4);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  background: var(--color-bg-elevated);
+  color: var(--color-text);
+  cursor: pointer;
+  font-size: var(--font-size-sm);
+}
+.path-picker button:hover:not(:disabled) {
+  background: var(--color-border);
+}
+.path-picker button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}

--- a/desktop/src/theme.css
+++ b/desktop/src/theme.css
@@ -126,3 +126,98 @@ body {
   opacity: 0.5;
   cursor: not-allowed;
 }
+
+/* Unlock route */
+.unlock {
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: var(--space-5);
+}
+.unlock__card {
+  max-width: 420px;
+  width: 100%;
+  padding: var(--space-7) var(--space-5);
+  background: var(--color-bg-elevated);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-md);
+  text-align: center;
+}
+.unlock__icon {
+  font-size: 48px;
+  margin-bottom: var(--space-2);
+}
+.unlock__title {
+  margin: 0 0 var(--space-1);
+  font-size: var(--font-size-xl);
+}
+.unlock__subtitle {
+  margin: 0 0 var(--space-6);
+  color: var(--color-text-muted);
+  font-size: var(--font-size-sm);
+}
+.unlock__field {
+  display: block;
+  margin-bottom: var(--space-4);
+  text-align: left;
+}
+.unlock__label {
+  display: block;
+  margin-bottom: var(--space-2);
+  font-size: var(--font-size-xs);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--color-text-muted);
+}
+.unlock__password {
+  width: 100%;
+  padding: var(--space-2) var(--space-3);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  background: var(--color-bg);
+  color: var(--color-text);
+  font-size: var(--font-size-md);
+}
+.unlock__submit {
+  width: 100%;
+  padding: var(--space-3);
+  margin-top: var(--space-2);
+  border: none;
+  border-radius: var(--radius-md);
+  background: var(--color-primary);
+  color: white;
+  font-weight: 600;
+  font-size: var(--font-size-md);
+  cursor: pointer;
+}
+.unlock__submit:hover:not(:disabled) {
+  background: var(--color-primary-hover);
+}
+.unlock__submit:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+.unlock__error {
+  margin-bottom: var(--space-4);
+  padding: var(--space-3);
+  border-radius: var(--radius-md);
+  background: var(--color-danger-bg);
+  color: var(--color-danger);
+  font-size: var(--font-size-sm);
+  text-align: left;
+}
+.unlock__error-title {
+  font-weight: 600;
+}
+.unlock__error-detail,
+.unlock__error-hint {
+  margin-top: var(--space-1);
+  font-size: var(--font-size-xs);
+}
+.unlock__footer {
+  margin-top: var(--space-5);
+  text-align: center;
+  color: var(--color-text-muted);
+  font-size: var(--font-size-xs);
+}

--- a/desktop/src/vite-env.d.ts
+++ b/desktop/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/desktop/tests/App.test.ts
+++ b/desktop/tests/App.test.ts
@@ -1,0 +1,147 @@
+// Tests for App.svelte's router + vault-locked event listener.
+//
+// Closes issue #149: between Task 5 (backend auto-lock emits the
+// `vault-locked` event from two call sites) and Task 6 (frontend pure
+// modules shipped), no consumer wired up the listener — so the Rust
+// auto-lock would fire server-side but the UI would keep showing
+// "unlocked" until the next IPC surfaced `AppError::NotUnlocked`.
+//
+// This file pins both halves of the contract:
+//
+//   - the listener is installed at mount, detached at unmount;
+//   - `reason: 'auto'`     → autoLockNotice.reason === 'idle';
+//   - `reason: 'explicit'` → autoLockNotice.reason === 'manual';
+//   - sessionState transitions to `locked` regardless of the reason or
+//     the prior state;
+//   - the router renders `<Unlock />` when locked, the post-unlock
+//     placeholder when unlocked.
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { render } from '@testing-library/svelte';
+import { get } from 'svelte/store';
+import App from '../src/App.svelte';
+import {
+  sessionState,
+  autoLockNotice,
+  beginUnlock,
+  unlockSucceeded,
+  _resetSessionStateForTest
+} from '../src/lib/stores';
+import type { ManifestDto, SettingsDto } from '../src/lib/ipc';
+
+const MANIFEST: ManifestDto = {
+  vaultUuidHex: 'aa',
+  ownerUserUuidHex: 'bb',
+  blockCount: 0,
+  blockSummaries: [],
+  warnings: []
+};
+const SETTINGS: SettingsDto = { autoLockTimeoutMs: 600_000 };
+
+// `listen()` returns a `Promise<() => void>` — the resolved value is
+// the unlisten function. Capture both the handler (so tests can drive
+// it directly) and the unlisten spy (so unmount detachment can be
+// asserted).
+type EventHandler = (event: { payload: { reason: 'explicit' | 'auto' } }) => void;
+const { listenMock, capturedHandlers, unlistenMock, openDialogMock } = vi.hoisted(() => {
+  const handlers: EventHandler[] = [];
+  return {
+    listenMock: vi.fn(),
+    capturedHandlers: handlers,
+    unlistenMock: vi.fn(),
+    openDialogMock: vi.fn()
+  };
+});
+vi.mock('@tauri-apps/api/event', () => ({
+  listen: (event: string, handler: EventHandler) => {
+    listenMock(event, handler);
+    capturedHandlers.push(handler);
+    return Promise.resolve(unlistenMock);
+  }
+}));
+vi.mock('@tauri-apps/plugin-dialog', () => ({ open: openDialogMock }));
+
+beforeEach(() => {
+  _resetSessionStateForTest();
+  listenMock.mockClear();
+  unlistenMock.mockClear();
+  capturedHandlers.length = 0;
+});
+
+describe('App.svelte — router', () => {
+  it('renders the Unlock route when sessionState is locked (initial)', () => {
+    const { getByRole } = render(App);
+    expect(getByRole('heading', { name: /secretary/i })).toBeTruthy();
+    expect(getByRole('button', { name: /unlock/i })).toBeTruthy();
+  });
+
+  it('renders the placeholder vault view when sessionState is unlocked', () => {
+    beginUnlock(0);
+    unlockSucceeded(MANIFEST, SETTINGS);
+    const { getByText } = render(App);
+    expect(getByText(/vault view coming in task 8/i)).toBeTruthy();
+  });
+});
+
+describe('App.svelte — vault-locked event listener (#149)', () => {
+  it('subscribes to the vault-locked event at mount', async () => {
+    render(App);
+    // The `listen` call is fired inside an async onMount; flush the
+    // promise queue once before asserting.
+    await Promise.resolve();
+    expect(listenMock).toHaveBeenCalledTimes(1);
+    expect(listenMock).toHaveBeenCalledWith('vault-locked', expect.any(Function));
+  });
+
+  it('reason="auto" maps to autoLockNotice.reason="idle" and transitions to locked', async () => {
+    beginUnlock(0);
+    unlockSucceeded(MANIFEST, SETTINGS);
+    render(App);
+    await Promise.resolve();
+    // Drive the listener directly with a backend-shaped event.
+    capturedHandlers[0]({ payload: { reason: 'auto' } });
+
+    expect(get(sessionState).status).toBe('locked');
+    const notice = get(autoLockNotice);
+    expect(notice).not.toBeNull();
+    if (notice) {
+      expect(notice.reason).toBe('idle');
+      expect(typeof notice.at).toBe('number');
+    }
+  });
+
+  it('reason="explicit" maps to autoLockNotice.reason="manual" and transitions to locked', async () => {
+    beginUnlock(0);
+    unlockSucceeded(MANIFEST, SETTINGS);
+    render(App);
+    await Promise.resolve();
+    capturedHandlers[0]({ payload: { reason: 'explicit' } });
+
+    expect(get(sessionState).status).toBe('locked');
+    const notice = get(autoLockNotice);
+    expect(notice).not.toBeNull();
+    if (notice) {
+      expect(notice.reason).toBe('manual');
+    }
+  });
+
+  it('also locks correctly when the event fires from `unlocking` (mid-flight race)', async () => {
+    beginUnlock(0);
+    render(App);
+    await Promise.resolve();
+    capturedHandlers[0]({ payload: { reason: 'auto' } });
+    // Authoritative `vaultLocked` accepts from any state, including
+    // `unlocking` — the backend has decided to lock, frontend follows.
+    expect(get(sessionState).status).toBe('locked');
+  });
+
+  it('detaches the listener on unmount', async () => {
+    const { unmount } = render(App);
+    await Promise.resolve();
+    expect(unlistenMock).not.toHaveBeenCalled();
+    unmount();
+    // Cleanup may queue a microtask; flush once.
+    await Promise.resolve();
+    expect(unlistenMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/desktop/tests/App.test.ts
+++ b/desktop/tests/App.test.ts
@@ -17,7 +17,7 @@
 //     placeholder when unlocked.
 
 import { describe, it, expect, beforeEach, vi } from 'vitest';
-import { render } from '@testing-library/svelte';
+import { render, waitFor } from '@testing-library/svelte';
 import { get } from 'svelte/store';
 import App from '../src/App.svelte';
 import {
@@ -86,10 +86,7 @@ describe('App.svelte — router', () => {
 describe('App.svelte — vault-locked event listener (#149)', () => {
   it('subscribes to the vault-locked event at mount', async () => {
     render(App);
-    // The `listen` call is fired inside an async onMount; flush the
-    // promise queue once before asserting.
-    await Promise.resolve();
-    expect(listenMock).toHaveBeenCalledTimes(1);
+    await waitFor(() => expect(listenMock).toHaveBeenCalledTimes(1));
     expect(listenMock).toHaveBeenCalledWith('vault-locked', expect.any(Function));
   });
 
@@ -97,8 +94,8 @@ describe('App.svelte — vault-locked event listener (#149)', () => {
     beginUnlock(0);
     unlockSucceeded(MANIFEST, SETTINGS);
     render(App);
-    await Promise.resolve();
-    // Drive the listener directly with a backend-shaped event.
+    // Wait until the listener has been installed before driving it.
+    await waitFor(() => expect(capturedHandlers.length).toBeGreaterThan(0));
     capturedHandlers[0]({ payload: { reason: 'auto' } });
 
     expect(get(sessionState).status).toBe('locked');
@@ -114,7 +111,7 @@ describe('App.svelte — vault-locked event listener (#149)', () => {
     beginUnlock(0);
     unlockSucceeded(MANIFEST, SETTINGS);
     render(App);
-    await Promise.resolve();
+    await waitFor(() => expect(capturedHandlers.length).toBeGreaterThan(0));
     capturedHandlers[0]({ payload: { reason: 'explicit' } });
 
     expect(get(sessionState).status).toBe('locked');
@@ -128,7 +125,7 @@ describe('App.svelte — vault-locked event listener (#149)', () => {
   it('also locks correctly when the event fires from `unlocking` (mid-flight race)', async () => {
     beginUnlock(0);
     render(App);
-    await Promise.resolve();
+    await waitFor(() => expect(capturedHandlers.length).toBeGreaterThan(0));
     capturedHandlers[0]({ payload: { reason: 'auto' } });
     // Authoritative `vaultLocked` accepts from any state, including
     // `unlocking` — the backend has decided to lock, frontend follows.
@@ -137,11 +134,11 @@ describe('App.svelte — vault-locked event listener (#149)', () => {
 
   it('detaches the listener on unmount', async () => {
     const { unmount } = render(App);
-    await Promise.resolve();
+    // Wait for the `.then` resolution that stashes `unlisten` so the
+    // unmount cleanup takes the synchronous detach branch.
+    await waitFor(() => expect(listenMock).toHaveBeenCalled());
     expect(unlistenMock).not.toHaveBeenCalled();
     unmount();
-    // Cleanup may queue a microtask; flush once.
-    await Promise.resolve();
-    expect(unlistenMock).toHaveBeenCalledTimes(1);
+    await waitFor(() => expect(unlistenMock).toHaveBeenCalledTimes(1));
   });
 });

--- a/desktop/tests/PathPicker.test.ts
+++ b/desktop/tests/PathPicker.test.ts
@@ -8,7 +8,7 @@
 // disabled prop blocks the click handler entirely.
 
 import { describe, it, expect, beforeEach, vi } from 'vitest';
-import { render, fireEvent } from '@testing-library/svelte';
+import { render, fireEvent, waitFor } from '@testing-library/svelte';
 import PathPicker from '../src/components/PathPicker.svelte';
 
 // The dialog plugin must be mocked: jsdom has no Tauri runtime, so the
@@ -70,10 +70,10 @@ describe('PathPicker', () => {
       props: { value: '', onSelect }
     });
     await fireEvent.click(getByRole('button'));
-    // open() resolves async — flush microtasks before asserting.
-    await Promise.resolve();
+    // `waitFor` polls until the assertion passes — robust against any
+    // future microtask-depth changes in `pick()`.
+    await waitFor(() => expect(onSelect).toHaveBeenCalledWith('/home/alice/vault'));
     expect(onSelect).toHaveBeenCalledTimes(1);
-    expect(onSelect).toHaveBeenCalledWith('/home/alice/vault');
   });
 
   it('does NOT call onSelect when the dialog is cancelled (returns null)', async () => {
@@ -83,6 +83,9 @@ describe('PathPicker', () => {
       props: { value: '', onSelect }
     });
     await fireEvent.click(getByRole('button'));
+    // Settle the awaited dialog promise + the conditional branch
+    // continuation before asserting the negative.
+    await openMock.mock.results[0].value;
     await Promise.resolve();
     expect(onSelect).not.toHaveBeenCalled();
   });
@@ -113,6 +116,9 @@ describe('PathPicker', () => {
       props: { value: '', onSelect }
     });
     await fireEvent.click(getByRole('button'));
+    // Settle the awaited dialog promise + the conditional branch
+    // continuation before asserting the negative.
+    await openMock.mock.results[0].value;
     await Promise.resolve();
     expect(onSelect).not.toHaveBeenCalled();
   });

--- a/desktop/tests/PathPicker.test.ts
+++ b/desktop/tests/PathPicker.test.ts
@@ -1,0 +1,119 @@
+// Component-level tests for PathPicker.svelte.
+//
+// PathPicker wraps `@tauri-apps/plugin-dialog`'s native folder-picker
+// dialog. The component itself is small (text field + button); the
+// behaviour worth pinning is the open()-then-onSelect contract: the
+// dialog opens with the expected options, a returned string fires the
+// callback, a cancelled dialog (null return) is a no-op, and the
+// disabled prop blocks the click handler entirely.
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { render, fireEvent } from '@testing-library/svelte';
+import PathPicker from '../src/components/PathPicker.svelte';
+
+// The dialog plugin must be mocked: jsdom has no Tauri runtime, so the
+// real module would fail at import. `vi.hoisted` returns the mock fn
+// before the `vi.mock` factory runs (the factory body executes BEFORE
+// module-scope `const` initializers).
+const { openMock } = vi.hoisted(() => ({ openMock: vi.fn() }));
+vi.mock('@tauri-apps/plugin-dialog', () => ({ open: openMock }));
+
+beforeEach(() => {
+  openMock.mockReset();
+});
+
+describe('PathPicker', () => {
+  it('renders the current value in the text input', () => {
+    const { getByRole } = render(PathPicker, {
+      props: { value: '/home/alice/vault', onSelect: vi.fn() }
+    });
+    const input = getByRole('textbox') as HTMLInputElement;
+    expect(input.value).toBe('/home/alice/vault');
+  });
+
+  it('shows placeholder when value is empty', () => {
+    const { getByRole } = render(PathPicker, {
+      props: { value: '', onSelect: vi.fn() }
+    });
+    const input = getByRole('textbox') as HTMLInputElement;
+    expect(input.value).toBe('');
+    expect(input.placeholder).toMatch(/no folder/i);
+  });
+
+  it('input is readonly — value comes from the dialog only', () => {
+    const { getByRole } = render(PathPicker, {
+      props: { value: '/x', onSelect: vi.fn() }
+    });
+    const input = getByRole('textbox') as HTMLInputElement;
+    expect(input.readOnly).toBe(true);
+  });
+
+  it('opens the folder picker dialog when the button is clicked', async () => {
+    openMock.mockResolvedValueOnce('/home/alice/picked');
+    const onSelect = vi.fn();
+    const { getByRole } = render(PathPicker, {
+      props: { value: '', onSelect }
+    });
+    await fireEvent.click(getByRole('button'));
+    expect(openMock).toHaveBeenCalledTimes(1);
+    expect(openMock).toHaveBeenCalledWith({
+      directory: true,
+      multiple: false,
+      title: expect.any(String)
+    });
+  });
+
+  it('calls onSelect with the chosen folder path', async () => {
+    openMock.mockResolvedValueOnce('/home/alice/vault');
+    const onSelect = vi.fn();
+    const { getByRole } = render(PathPicker, {
+      props: { value: '', onSelect }
+    });
+    await fireEvent.click(getByRole('button'));
+    // open() resolves async — flush microtasks before asserting.
+    await Promise.resolve();
+    expect(onSelect).toHaveBeenCalledTimes(1);
+    expect(onSelect).toHaveBeenCalledWith('/home/alice/vault');
+  });
+
+  it('does NOT call onSelect when the dialog is cancelled (returns null)', async () => {
+    openMock.mockResolvedValueOnce(null);
+    const onSelect = vi.fn();
+    const { getByRole } = render(PathPicker, {
+      props: { value: '', onSelect }
+    });
+    await fireEvent.click(getByRole('button'));
+    await Promise.resolve();
+    expect(onSelect).not.toHaveBeenCalled();
+  });
+
+  it('disabled prop prevents opening the dialog', async () => {
+    const onSelect = vi.fn();
+    const { getByRole } = render(PathPicker, {
+      props: { value: '', onSelect, disabled: true }
+    });
+    const button = getByRole('button') as HTMLButtonElement;
+    expect(button.disabled).toBe(true);
+    await fireEvent.click(button);
+    // Disabled buttons don't fire click handlers; even if the user
+    // manages to dispatch one programmatically the open() call must
+    // be a no-op so we never leak a stray dialog.
+    expect(openMock).not.toHaveBeenCalled();
+    expect(onSelect).not.toHaveBeenCalled();
+  });
+
+  it('does not crash when the dialog returns a non-string array (multi-select misuse)', async () => {
+    // `multiple: false` is hard-coded so the return type is `string | null`,
+    // but the runtime can't enforce that. Defensive check: if a future
+    // refactor changes the options and yields an array, we ignore it
+    // rather than calling onSelect with the wrong shape.
+    openMock.mockResolvedValueOnce(['/a', '/b'] as unknown as string);
+    const onSelect = vi.fn();
+    const { getByRole } = render(PathPicker, {
+      props: { value: '', onSelect }
+    });
+    await fireEvent.click(getByRole('button'));
+    await Promise.resolve();
+    expect(onSelect).not.toHaveBeenCalled();
+  });
+});

--- a/desktop/tests/Unlock.test.ts
+++ b/desktop/tests/Unlock.test.ts
@@ -8,7 +8,7 @@
 //   5. submit ignored while already submitting (no double-fire)
 
 import { describe, it, expect, beforeEach, vi } from 'vitest';
-import { render, fireEvent } from '@testing-library/svelte';
+import { render, fireEvent, waitFor } from '@testing-library/svelte';
 import { get } from 'svelte/store';
 import Unlock from '../src/routes/Unlock.svelte';
 import {
@@ -77,13 +77,13 @@ describe('Unlock — initial render', () => {
 
     // Pick folder.
     await fireEvent.click(getByRole('button', { name: /choose/i }));
-    await Promise.resolve();
+    await waitFor(() => expect(openDialogMock).toHaveBeenCalled());
     // Fill password.
     const passwordInput = getByLabelText(/password/i) as HTMLInputElement;
     await fireEvent.input(passwordInput, { target: { value: 'hunter2' } });
 
     const submitBtn = getByRole('button', { name: /unlock/i }) as HTMLButtonElement;
-    expect(submitBtn.disabled).toBe(false);
+    await waitFor(() => expect(submitBtn.disabled).toBe(false));
   });
 });
 
@@ -95,21 +95,21 @@ describe('Unlock — happy path', () => {
 
     const { getByRole, getByLabelText } = render(Unlock);
     await fireEvent.click(getByRole('button', { name: /choose/i }));
-    await Promise.resolve();
+    await waitFor(() => expect(openDialogMock).toHaveBeenCalled());
     await fireEvent.input(getByLabelText(/password/i), { target: { value: 'hunter2' } });
     await fireEvent.click(getByRole('button', { name: /unlock/i }));
 
-    // Two awaits to flush the chained ipc resolves + the final transition.
-    await Promise.resolve();
-    await Promise.resolve();
-    await Promise.resolve();
+    // `waitFor` polls until the assertion passes; this is robust against
+    // future IPC-chain link additions in `submit()`, where the previous
+    // `await Promise.resolve()` triplet would have silently asserted
+    // against a half-resolved state.
+    await waitFor(() => expect(get(sessionState).status).toBe('unlocked'));
 
     expect(unlockMock).toHaveBeenCalledTimes(1);
     expect(unlockMock).toHaveBeenCalledWith('/home/alice/vault', 'hunter2');
     expect(settingsMock).toHaveBeenCalledTimes(1);
 
     const s = get(sessionState);
-    expect(s.status).toBe('unlocked');
     if (s.status === 'unlocked') {
       expect(s.manifest).toEqual(MANIFEST);
       expect(s.settings).toEqual(SETTINGS);
@@ -123,15 +123,11 @@ describe('Unlock — happy path', () => {
 
     const { getByRole, getByLabelText } = render(Unlock);
     await fireEvent.click(getByRole('button', { name: /choose/i }));
-    await Promise.resolve();
+    await waitFor(() => expect(openDialogMock).toHaveBeenCalled());
     const passwordInput = getByLabelText(/password/i) as HTMLInputElement;
     await fireEvent.input(passwordInput, { target: { value: 'hunter2' } });
     await fireEvent.click(getByRole('button', { name: /unlock/i }));
-    await Promise.resolve();
-    await Promise.resolve();
-    await Promise.resolve();
-
-    expect(passwordInput.value).toBe('');
+    await waitFor(() => expect(passwordInput.value).toBe(''));
   });
 });
 
@@ -142,15 +138,12 @@ describe('Unlock — error path', () => {
 
     const { getByRole, getByLabelText, findByText } = render(Unlock);
     await fireEvent.click(getByRole('button', { name: /choose/i }));
-    await Promise.resolve();
+    await waitFor(() => expect(openDialogMock).toHaveBeenCalled());
     await fireEvent.input(getByLabelText(/password/i), { target: { value: 'bad' } });
     await fireEvent.click(getByRole('button', { name: /unlock/i }));
-    await Promise.resolve();
-    await Promise.resolve();
-    await Promise.resolve();
+    await waitFor(() => expect(get(sessionState).status).toBe('locked'));
 
     const s = get(sessionState);
-    expect(s.status).toBe('locked');
     if (s.status === 'locked') {
       expect(s.lastError).toEqual({ code: 'wrong_password' });
     }
@@ -160,6 +153,23 @@ describe('Unlock — error path', () => {
     expect(settingsMock).not.toHaveBeenCalled();
   });
 
+  it('clears the password field on unlock failure (do not retain in DOM across retry)', async () => {
+    // Security pin: the password string must not linger in the DOM
+    // binding after a failed attempt. JS strings are immutable so we
+    // can't truly zeroize, but unbinding minimises the live-reference
+    // window the GC has to chase.
+    unlockMock.mockRejectedValueOnce({ code: 'wrong_password' });
+    openDialogMock.mockResolvedValueOnce('/v');
+
+    const { getByRole, getByLabelText } = render(Unlock);
+    await fireEvent.click(getByRole('button', { name: /choose/i }));
+    await waitFor(() => expect(openDialogMock).toHaveBeenCalled());
+    const passwordInput = getByLabelText(/password/i) as HTMLInputElement;
+    await fireEvent.input(passwordInput, { target: { value: 'bad' } });
+    await fireEvent.click(getByRole('button', { name: /unlock/i }));
+    await waitFor(() => expect(passwordInput.value).toBe(''));
+  });
+
   it('vault_path_not_found surfaces the path in the inline detail', async () => {
     const path = '/no/such/vault';
     unlockMock.mockRejectedValueOnce({ code: 'vault_path_not_found', path });
@@ -167,12 +177,10 @@ describe('Unlock — error path', () => {
 
     const { getByRole, getByLabelText, findByText } = render(Unlock);
     await fireEvent.click(getByRole('button', { name: /choose/i }));
-    await Promise.resolve();
+    await waitFor(() => expect(openDialogMock).toHaveBeenCalled());
     await fireEvent.input(getByLabelText(/password/i), { target: { value: 'x' } });
     await fireEvent.click(getByRole('button', { name: /unlock/i }));
-    await Promise.resolve();
-    await Promise.resolve();
-    await Promise.resolve();
+    await waitFor(() => expect(get(sessionState).status).toBe('locked'));
 
     expect(await findByText(new RegExp(path))).toBeTruthy();
   });

--- a/desktop/tests/Unlock.test.ts
+++ b/desktop/tests/Unlock.test.ts
@@ -1,0 +1,194 @@
+// Component-level tests for Unlock.svelte — the first user-visible
+// route. Exercises the form-submission lifecycle:
+//
+//   1. submit disabled until folderPath + password both have content
+//   2. happy path: unlockWithPassword → getSettings → unlocked state
+//   3. wrong-password path: lastError set, locked state, password cleared
+//   4. inline error renders userMessageFor(err).title
+//   5. submit ignored while already submitting (no double-fire)
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { render, fireEvent } from '@testing-library/svelte';
+import { get } from 'svelte/store';
+import Unlock from '../src/routes/Unlock.svelte';
+import {
+  sessionState,
+  _resetSessionStateForTest
+} from '../src/lib/stores';
+import type { ManifestDto, SettingsDto } from '../src/lib/ipc';
+
+const MANIFEST: ManifestDto = {
+  vaultUuidHex: 'aa',
+  ownerUserUuidHex: 'bb',
+  blockCount: 0,
+  blockSummaries: [],
+  warnings: []
+};
+const SETTINGS: SettingsDto = { autoLockTimeoutMs: 600_000 };
+
+// Mock the IPC layer + dialog plugin (both used by the form). `vi.hoisted`
+// returns the mocks before the `vi.mock` factories run.
+const { unlockMock, settingsMock, openDialogMock } = vi.hoisted(() => ({
+  unlockMock: vi.fn(),
+  settingsMock: vi.fn(),
+  openDialogMock: vi.fn()
+}));
+vi.mock('../src/lib/ipc', async (importActual) => {
+  // Keep the real types + APP_ERROR_CODES export shape; override the
+  // command wrappers used by Unlock.svelte.
+  const actual = await importActual<typeof import('../src/lib/ipc')>();
+  return {
+    ...actual,
+    unlockWithPassword: unlockMock,
+    getSettings: settingsMock
+  };
+});
+vi.mock('@tauri-apps/plugin-dialog', () => ({ open: openDialogMock }));
+
+beforeEach(() => {
+  _resetSessionStateForTest();
+  unlockMock.mockReset();
+  settingsMock.mockReset();
+  openDialogMock.mockReset();
+});
+
+describe('Unlock — initial render', () => {
+  it('renders the form heading + password field + submit button', () => {
+    const { getByRole, getByLabelText } = render(Unlock);
+    expect(getByRole('heading', { name: /secretary/i })).toBeTruthy();
+    expect(getByLabelText(/password/i)).toBeTruthy();
+    expect(getByRole('button', { name: /unlock/i })).toBeTruthy();
+  });
+
+  it('submit button is disabled until both folderPath and password are set', async () => {
+    const { getByRole, getByLabelText } = render(Unlock);
+    const submitBtn = getByRole('button', { name: /unlock/i }) as HTMLButtonElement;
+    expect(submitBtn.disabled).toBe(true);
+
+    // Fill password only — still disabled (no folder).
+    const passwordInput = getByLabelText(/password/i) as HTMLInputElement;
+    await fireEvent.input(passwordInput, { target: { value: 'hunter2' } });
+    expect(submitBtn.disabled).toBe(true);
+  });
+
+  it('enables submit when both folder + password are present (via PathPicker)', async () => {
+    openDialogMock.mockResolvedValueOnce('/home/alice/vault');
+    const { getByRole, getByLabelText } = render(Unlock);
+
+    // Pick folder.
+    await fireEvent.click(getByRole('button', { name: /choose/i }));
+    await Promise.resolve();
+    // Fill password.
+    const passwordInput = getByLabelText(/password/i) as HTMLInputElement;
+    await fireEvent.input(passwordInput, { target: { value: 'hunter2' } });
+
+    const submitBtn = getByRole('button', { name: /unlock/i }) as HTMLButtonElement;
+    expect(submitBtn.disabled).toBe(false);
+  });
+});
+
+describe('Unlock — happy path', () => {
+  it('submitting calls unlockWithPassword(folder, password) then getSettings, transitions to unlocked', async () => {
+    unlockMock.mockResolvedValueOnce(MANIFEST);
+    settingsMock.mockResolvedValueOnce(SETTINGS);
+    openDialogMock.mockResolvedValueOnce('/home/alice/vault');
+
+    const { getByRole, getByLabelText } = render(Unlock);
+    await fireEvent.click(getByRole('button', { name: /choose/i }));
+    await Promise.resolve();
+    await fireEvent.input(getByLabelText(/password/i), { target: { value: 'hunter2' } });
+    await fireEvent.click(getByRole('button', { name: /unlock/i }));
+
+    // Two awaits to flush the chained ipc resolves + the final transition.
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(unlockMock).toHaveBeenCalledTimes(1);
+    expect(unlockMock).toHaveBeenCalledWith('/home/alice/vault', 'hunter2');
+    expect(settingsMock).toHaveBeenCalledTimes(1);
+
+    const s = get(sessionState);
+    expect(s.status).toBe('unlocked');
+    if (s.status === 'unlocked') {
+      expect(s.manifest).toEqual(MANIFEST);
+      expect(s.settings).toEqual(SETTINGS);
+    }
+  });
+
+  it('clears the password field after successful unlock (do not retain in DOM)', async () => {
+    unlockMock.mockResolvedValueOnce(MANIFEST);
+    settingsMock.mockResolvedValueOnce(SETTINGS);
+    openDialogMock.mockResolvedValueOnce('/v');
+
+    const { getByRole, getByLabelText } = render(Unlock);
+    await fireEvent.click(getByRole('button', { name: /choose/i }));
+    await Promise.resolve();
+    const passwordInput = getByLabelText(/password/i) as HTMLInputElement;
+    await fireEvent.input(passwordInput, { target: { value: 'hunter2' } });
+    await fireEvent.click(getByRole('button', { name: /unlock/i }));
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(passwordInput.value).toBe('');
+  });
+});
+
+describe('Unlock — error path', () => {
+  it('wrong_password transitions to locked, sets lastError, surfaces userMessageFor.title', async () => {
+    unlockMock.mockRejectedValueOnce({ code: 'wrong_password' });
+    openDialogMock.mockResolvedValueOnce('/v');
+
+    const { getByRole, getByLabelText, findByText } = render(Unlock);
+    await fireEvent.click(getByRole('button', { name: /choose/i }));
+    await Promise.resolve();
+    await fireEvent.input(getByLabelText(/password/i), { target: { value: 'bad' } });
+    await fireEvent.click(getByRole('button', { name: /unlock/i }));
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    const s = get(sessionState);
+    expect(s.status).toBe('locked');
+    if (s.status === 'locked') {
+      expect(s.lastError).toEqual({ code: 'wrong_password' });
+    }
+    // Inline error shows "Wrong password" — the title from
+    // userMessageFor({ code: 'wrong_password' }).
+    expect(await findByText(/wrong password/i)).toBeTruthy();
+    expect(settingsMock).not.toHaveBeenCalled();
+  });
+
+  it('vault_path_not_found surfaces the path in the inline detail', async () => {
+    const path = '/no/such/vault';
+    unlockMock.mockRejectedValueOnce({ code: 'vault_path_not_found', path });
+    openDialogMock.mockResolvedValueOnce(path);
+
+    const { getByRole, getByLabelText, findByText } = render(Unlock);
+    await fireEvent.click(getByRole('button', { name: /choose/i }));
+    await Promise.resolve();
+    await fireEvent.input(getByLabelText(/password/i), { target: { value: 'x' } });
+    await fireEvent.click(getByRole('button', { name: /unlock/i }));
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(await findByText(new RegExp(path))).toBeTruthy();
+  });
+});
+
+describe('Unlock — submit guards', () => {
+  it('submit is a no-op when form is invalid (empty fields)', async () => {
+    const { getByRole } = render(Unlock);
+    // Force-click via dispatching submit on the form. The button is
+    // disabled — click is ignored — but the keyboard "Enter" path
+    // would dispatch on the form. Use the form directly to simulate.
+    const form = getByRole('button', { name: /unlock/i }).closest('form');
+    expect(form).toBeTruthy();
+    if (form) {
+      await fireEvent.submit(form);
+    }
+    expect(unlockMock).not.toHaveBeenCalled();
+  });
+});

--- a/desktop/tests/stores.test.ts
+++ b/desktop/tests/stores.test.ts
@@ -1,20 +1,42 @@
-// Pins the SessionState transitions, the `currentSettings` derived store,
-// and the AutoLockNotice discriminated union. No consumer (App.svelte
-// Task 7+) wires the stores yet, so behaviour-level tests here are the
-// only gate that regressions to the state encoding surface immediately.
+// Pins the SessionState transition contract and the derived stores.
+//
+// PR #148 shipped `SessionState` as a raw `writable<SessionState>` exported
+// directly to consumers. Issue #150 closed in this PR demotes the writable
+// to a non-exported `_internal` and exposes only legal-transition helpers
+// (`beginUnlock`, `unlockSucceeded`, `unlockFailed`, `beginLock`,
+// `vaultLocked`) plus a read-only subscription view. Illegal edges throw
+// in dev (Vitest runs in dev mode, so the tests below catch them); prod
+// builds log + no-op so a frontend state-machine bug never DOS's the user.
 
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { get } from 'svelte/store';
 import {
   sessionState,
   currentSettings,
   autoLockNotice,
+  beginUnlock,
+  unlockSucceeded,
+  unlockFailed,
+  beginLock,
+  vaultLocked,
+  _resetSessionStateForTest,
   type SessionState
 } from '../src/lib/stores';
+import type { ManifestDto, SettingsDto } from '../src/lib/ipc';
+import type { AppError } from '../src/lib/errors';
+
+const MANIFEST: ManifestDto = {
+  vaultUuidHex: 'aa',
+  ownerUserUuidHex: 'bb',
+  blockCount: 0,
+  blockSummaries: [],
+  warnings: []
+};
+const SETTINGS: SettingsDto = { autoLockTimeoutMs: 600_000 };
+const WRONG_PWD: AppError = { code: 'wrong_password' };
 
 beforeEach(() => {
-  sessionState.set({ status: 'locked', lastError: null });
-  autoLockNotice.set(null);
+  _resetSessionStateForTest();
 });
 
 describe('sessionState initial shape', () => {
@@ -25,79 +47,231 @@ describe('sessionState initial shape', () => {
       expect(s.lastError).toBeNull();
     }
   });
+
+  it('exposes a read-only subscription surface (no .set method)', () => {
+    // Demotion check: a runtime `set` on the public store would indicate
+    // the demotion was undone and consumers can bypass transition rules.
+    expect((sessionState as unknown as { set?: unknown }).set).toBeUndefined();
+  });
 });
 
-describe('currentSettings derived selector', () => {
-  it('is null in the locked state', () => {
-    sessionState.set({ status: 'locked', lastError: null });
-    expect(get(currentSettings)).toBeNull();
+describe('legal transitions', () => {
+  it('locked → unlocking via beginUnlock (carries startedAt)', () => {
+    beginUnlock(12_345);
+    const s = get(sessionState);
+    expect(s.status).toBe('unlocking');
+    if (s.status === 'unlocking') {
+      expect(s.startedAt).toBe(12_345);
+    }
   });
 
-  it('is null in the unlocking state', () => {
-    sessionState.set({ status: 'unlocking' });
-    expect(get(currentSettings)).toBeNull();
+  it('beginUnlock defaults startedAt to Date.now() when omitted', () => {
+    const before = Date.now();
+    beginUnlock();
+    const after = Date.now();
+    const s = get(sessionState);
+    if (s.status === 'unlocking') {
+      expect(s.startedAt).toBeGreaterThanOrEqual(before);
+      expect(s.startedAt).toBeLessThanOrEqual(after);
+    } else {
+      throw new Error('expected unlocking');
+    }
   });
 
-  it('is null in the locking state', () => {
-    sessionState.set({ status: 'locking' });
-    expect(get(currentSettings)).toBeNull();
+  it('unlocking → unlocked via unlockSucceeded', () => {
+    beginUnlock(0);
+    unlockSucceeded(MANIFEST, SETTINGS);
+    const s = get(sessionState);
+    expect(s.status).toBe('unlocked');
+    if (s.status === 'unlocked') {
+      expect(s.manifest).toEqual(MANIFEST);
+      expect(s.settings).toEqual(SETTINGS);
+    }
   });
 
-  it('returns the settings object only in the unlocked state', () => {
-    const settings = { autoLockTimeoutMs: 600_000 };
-    const manifest = {
-      vaultUuidHex: 'aa',
-      ownerUserUuidHex: 'bb',
-      blockCount: 0,
-      blockSummaries: [],
-      warnings: []
-    };
-    sessionState.set({ status: 'unlocked', manifest, settings });
-    expect(get(currentSettings)).toEqual(settings);
+  it('unlocking → locked via unlockFailed (carries the error)', () => {
+    beginUnlock(0);
+    unlockFailed(WRONG_PWD);
+    const s = get(sessionState);
+    expect(s.status).toBe('locked');
+    if (s.status === 'locked') {
+      expect(s.lastError).toEqual(WRONG_PWD);
+    }
   });
 
-  it('reverts to null when transitioning unlocked → locked', () => {
-    const settings = { autoLockTimeoutMs: 600_000 };
-    const manifest = {
-      vaultUuidHex: 'aa',
-      ownerUserUuidHex: 'bb',
-      blockCount: 0,
-      blockSummaries: [],
-      warnings: []
-    };
-    sessionState.set({ status: 'unlocked', manifest, settings });
-    expect(get(currentSettings)).not.toBeNull();
-    sessionState.set({ status: 'locked', lastError: { code: 'wrong_password' } });
-    expect(get(currentSettings)).toBeNull();
+  it('unlocked → locking via beginLock (carries startedAt)', () => {
+    beginUnlock(0);
+    unlockSucceeded(MANIFEST, SETTINGS);
+    beginLock(54_321);
+    const s = get(sessionState);
+    expect(s.status).toBe('locking');
+    if (s.status === 'locking') {
+      expect(s.startedAt).toBe(54_321);
+    }
+  });
+
+  it('locking → locked via vaultLocked', () => {
+    beginUnlock(0);
+    unlockSucceeded(MANIFEST, SETTINGS);
+    beginLock(0);
+    vaultLocked('manual', 0);
+    const s = get(sessionState);
+    expect(s.status).toBe('locked');
+    if (s.status === 'locked') {
+      expect(s.lastError).toBeNull();
+    }
+  });
+});
+
+describe('vaultLocked is authoritative — accepts from any state', () => {
+  it('from locked → locked + autoLockNotice fires', () => {
+    vaultLocked('idle', 100);
+    expect(get(sessionState).status).toBe('locked');
+    expect(get(autoLockNotice)).toEqual({ reason: 'idle', at: 100 });
+  });
+
+  it('from unlocking → locked', () => {
+    beginUnlock(0);
+    vaultLocked('idle', 200);
+    expect(get(sessionState).status).toBe('locked');
+    expect(get(autoLockNotice)).toEqual({ reason: 'idle', at: 200 });
+  });
+
+  it('from unlocked → locked', () => {
+    beginUnlock(0);
+    unlockSucceeded(MANIFEST, SETTINGS);
+    vaultLocked('manual', 300);
+    expect(get(sessionState).status).toBe('locked');
+    expect(get(autoLockNotice)).toEqual({ reason: 'manual', at: 300 });
+  });
+
+  it('from locking → locked', () => {
+    beginUnlock(0);
+    unlockSucceeded(MANIFEST, SETTINGS);
+    beginLock(0);
+    vaultLocked('manual', 400);
+    expect(get(sessionState).status).toBe('locked');
+    expect(get(autoLockNotice)).toEqual({ reason: 'manual', at: 400 });
+  });
+});
+
+describe('illegal transitions throw in dev', () => {
+  // Vitest runs with `import.meta.env.DEV === true`, so the dev-build
+  // assertion branch fires. Each variant gets at least one rejection pin
+  // so a regression that loosens the contract surfaces immediately.
+
+  it('beginUnlock from unlocking is rejected', () => {
+    beginUnlock(0);
+    expect(() => beginUnlock(0)).toThrow(/illegal session transition/i);
+    expect(get(sessionState).status).toBe('unlocking');
+  });
+
+  it('beginUnlock from unlocked is rejected', () => {
+    beginUnlock(0);
+    unlockSucceeded(MANIFEST, SETTINGS);
+    expect(() => beginUnlock(0)).toThrow(/illegal session transition/i);
+    expect(get(sessionState).status).toBe('unlocked');
+  });
+
+  it('unlockSucceeded from locked is rejected', () => {
+    expect(() => unlockSucceeded(MANIFEST, SETTINGS)).toThrow(/illegal session transition/i);
+    expect(get(sessionState).status).toBe('locked');
+  });
+
+  it('unlockFailed from unlocked is rejected', () => {
+    beginUnlock(0);
+    unlockSucceeded(MANIFEST, SETTINGS);
+    expect(() => unlockFailed(WRONG_PWD)).toThrow(/illegal session transition/i);
+    expect(get(sessionState).status).toBe('unlocked');
+  });
+
+  it('beginLock from locked is rejected', () => {
+    expect(() => beginLock(0)).toThrow(/illegal session transition/i);
+    expect(get(sessionState).status).toBe('locked');
+  });
+
+  it('beginLock from locking is rejected', () => {
+    beginUnlock(0);
+    unlockSucceeded(MANIFEST, SETTINGS);
+    beginLock(0);
+    expect(() => beginLock(0)).toThrow(/illegal session transition/i);
+    expect(get(sessionState).status).toBe('locking');
+  });
+});
+
+describe('illegal transitions log + no-op in prod', () => {
+  // Mock `import.meta.env.DEV` to false for these tests. Without this
+  // branch the prod-build silent-coerce path goes uncovered and a
+  // regression that swallows ALL illegal edges (instead of just the
+  // dev throw) would slip through.
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.stubEnv('DEV', false);
+    warnSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    warnSpy.mockRestore();
+  });
+
+  it('beginUnlock from unlocking logs + leaves state unchanged', () => {
+    beginUnlock(0);
+    beginUnlock(0); // would-be illegal — must not throw, must log
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(get(sessionState).status).toBe('unlocking');
   });
 });
 
 describe('SessionState shape exhaustiveness', () => {
-  // Verify each declared variant constructs cleanly and the type-narrowing
-  // switch in consumers (App.svelte's router will be the next caller) can
-  // discriminate on `.status` without runtime surprises.
-  it('every variant in the union is constructible and discriminable', () => {
-    const variants: SessionState[] = [
-      { status: 'locked', lastError: null },
-      { status: 'locked', lastError: { code: 'wrong_password' } },
-      { status: 'unlocking' },
-      {
-        status: 'unlocked',
-        manifest: {
-          vaultUuidHex: 'aa',
-          ownerUserUuidHex: 'bb',
-          blockCount: 0,
-          blockSummaries: [],
-          warnings: []
-        },
-        settings: { autoLockTimeoutMs: 600_000 }
-      },
-      { status: 'locking' }
-    ];
-    for (const v of variants) {
-      sessionState.set(v);
-      expect(get(sessionState).status).toBe(v.status);
-    }
+  it('every variant in the union is reachable via legal transitions', () => {
+    // locked (initial)
+    expect(get(sessionState).status).toBe('locked');
+    // unlocking
+    beginUnlock(0);
+    expect(get(sessionState).status).toBe('unlocking');
+    // unlocked
+    unlockSucceeded(MANIFEST, SETTINGS);
+    expect(get(sessionState).status).toBe('unlocked');
+    // locking
+    beginLock(0);
+    expect(get(sessionState).status).toBe('locking');
+    // locked (via vaultLocked)
+    vaultLocked('manual', 0);
+    expect(get(sessionState).status).toBe('locked');
+  });
+});
+
+describe('currentSettings derived selector', () => {
+  it('is null in the locked state', () => {
+    expect(get(currentSettings)).toBeNull();
+  });
+
+  it('is null in the unlocking state', () => {
+    beginUnlock(0);
+    expect(get(currentSettings)).toBeNull();
+  });
+
+  it('is null in the locking state', () => {
+    beginUnlock(0);
+    unlockSucceeded(MANIFEST, SETTINGS);
+    beginLock(0);
+    expect(get(currentSettings)).toBeNull();
+  });
+
+  it('returns the settings object only in the unlocked state', () => {
+    beginUnlock(0);
+    unlockSucceeded(MANIFEST, SETTINGS);
+    expect(get(currentSettings)).toEqual(SETTINGS);
+  });
+
+  it('reverts to null when transitioning unlocked → locked via vaultLocked', () => {
+    beginUnlock(0);
+    unlockSucceeded(MANIFEST, SETTINGS);
+    expect(get(currentSettings)).not.toBeNull();
+    vaultLocked('manual', 0);
+    expect(get(currentSettings)).toBeNull();
   });
 });
 
@@ -106,18 +280,50 @@ describe('autoLockNotice discriminated union', () => {
     expect(get(autoLockNotice)).toBeNull();
   });
 
-  it('accepts each reason variant', () => {
-    const reasons = ['idle', 'manual', 'keep_alive_failing'] as const;
-    for (const reason of reasons) {
-      const at = Date.now();
-      autoLockNotice.set({ reason, at });
-      expect(get(autoLockNotice)).toEqual({ reason, at });
-    }
+  it('keep_alive_failing reason can be set directly (raised by auto_lock.ts, not stores)', () => {
+    // The keep_alive_failing notice is owned by auto_lock.ts's retry logic,
+    // not by the session-state transitions. The writable's direct set
+    // surface stays intentional for that producer.
+    const at = 12_345;
+    autoLockNotice.set({ reason: 'keep_alive_failing', at });
+    expect(get(autoLockNotice)).toEqual({ reason: 'keep_alive_failing', at });
   });
 
   it('can be cleared back to null', () => {
     autoLockNotice.set({ reason: 'idle', at: 0 });
     autoLockNotice.set(null);
     expect(get(autoLockNotice)).toBeNull();
+  });
+});
+
+describe('_resetSessionStateForTest', () => {
+  it('returns sessionState to initial locked state', () => {
+    beginUnlock(0);
+    unlockSucceeded(MANIFEST, SETTINGS);
+    _resetSessionStateForTest();
+    expect(get(sessionState)).toEqual({ status: 'locked', lastError: null });
+  });
+
+  it('also clears autoLockNotice', () => {
+    autoLockNotice.set({ reason: 'idle', at: 100 });
+    _resetSessionStateForTest();
+    expect(get(autoLockNotice)).toBeNull();
+  });
+});
+
+// Re-export of SessionState type stays in scope; ensure the union is
+// still narrowable for downstream component code (App.svelte).
+describe('SessionState type-narrowing pin', () => {
+  it('discriminates on .status', () => {
+    const variants: SessionState[] = [
+      { status: 'locked', lastError: null },
+      { status: 'locked', lastError: { code: 'wrong_password' } },
+      { status: 'unlocking', startedAt: 0 },
+      { status: 'unlocked', manifest: MANIFEST, settings: SETTINGS },
+      { status: 'locking', startedAt: 0 }
+    ];
+    for (const v of variants) {
+      expect(['locked', 'unlocking', 'unlocked', 'locking']).toContain(v.status);
+    }
   });
 });

--- a/desktop/tests/stores.test.ts
+++ b/desktop/tests/stores.test.ts
@@ -204,22 +204,22 @@ describe('illegal transitions log + no-op in prod', () => {
   // branch the prod-build silent-coerce path goes uncovered and a
   // regression that swallows ALL illegal edges (instead of just the
   // dev throw) would slip through.
-  let warnSpy: ReturnType<typeof vi.spyOn>;
+  let errorSpy: ReturnType<typeof vi.spyOn>;
 
   beforeEach(() => {
     vi.stubEnv('DEV', false);
-    warnSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    errorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
   });
 
   afterEach(() => {
     vi.unstubAllEnvs();
-    warnSpy.mockRestore();
+    errorSpy.mockRestore();
   });
 
   it('beginUnlock from unlocking logs + leaves state unchanged', () => {
     beginUnlock(0);
     beginUnlock(0); // would-be illegal — must not throw, must log
-    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(errorSpy).toHaveBeenCalledTimes(1);
     expect(get(sessionState).status).toBe('unlocking');
   });
 });

--- a/desktop/vitest.config.ts
+++ b/desktop/vitest.config.ts
@@ -1,17 +1,23 @@
 import { defineConfig } from 'vitest/config';
 import { svelte } from '@sveltejs/vite-plugin-svelte';
+import { svelteTesting } from '@testing-library/svelte/vite';
 
-// Pure-module + DOM-mock harness for the desktop frontend's TS layer.
-// Loads the svelte plugin so future component tests can import .svelte
-// files without further config; current tests are TS-only.
+// Pure-module + component-rendering harness for the desktop frontend.
 //
-// `environment: 'jsdom'` is required by auto_lock.test.ts which dispatches
-// MouseEvent / KeyboardEvent on the document. The other suites would run
-// fine under 'node' but a single environment is simpler than per-file
-// overrides.
+// `svelte()` lets Vitest compile `.svelte` files so component tests can
+// import them. `svelteTesting()` is the recommended companion from
+// `@testing-library/svelte` v5 — it adds the `browser` resolve
+// condition (so testing-library's runes-mode `.svelte.js` files resolve
+// to their compiled browser bundle rather than raw source), wires the
+// auto-cleanup setup file, and adds the testing-library packages to
+// `ssr.noExternal` so they go through the Svelte plugin's compile pass.
+//
+// `environment: 'jsdom'` is required by both `auto_lock.test.ts` (which
+// dispatches MouseEvent / KeyboardEvent on `document`) and the component
+// tests (which need a DOM to mount into).
 
 export default defineConfig({
-  plugins: [svelte({ hot: false })],
+  plugins: [svelte({ hot: false }), svelteTesting()],
   test: {
     environment: 'jsdom',
     include: ['tests/**/*.test.ts'],

--- a/docs/handoffs/2026-05-28-d11-task-7-shipped.md
+++ b/docs/handoffs/2026-05-28-d11-task-7-shipped.md
@@ -58,6 +58,35 @@ The surplus is intentional; under-counting was a plan-sketch slip.
 - File sizes (all comfortably under the 500-LOC threshold): stores.ts=159, App.svelte=58, Unlock.svelte=92, PathPicker.svelte=39, theme.css=189. Tests: stores.test=276, Unlock.test=146, PathPicker.test=109, App.test=137.
 - Per-module TDD discipline: each new file landed with its test in the same commit. Tests written first → ran red → implementation → ran green. The state-machine wrapper commit alone went red on 31 of 31 before implementation.
 
+### Fixup pass — PR #152 review (this same session)
+
+After the initial five-commit push, an in-review pass surfaced seven small items. Five were fixable in-PR; two are tracked as follow-up issues:
+
+| Item | Fix |
+|---|---|
+| `tauri-plugin-dialog = "2"` (caret range) vs project's exact-pin convention for security-critical deps | Added a comment in [`desktop/src-tauri/Cargo.toml`](../../desktop/src-tauri/Cargo.toml) justifying the caret: UI-only plugin, no key material crosses it (folder-path strings are already inside the trust boundary), no security guarantee rides on a specific 2.x patch. |
+| `INITIAL_STATE` was a shared object reference between the initial writable and `_resetSessionStateForTest` — a test that mutated `.lastError` would have mutated the module-level constant | Replaced with an `initialState()` factory so each call yields a fresh object. |
+| `Unlock.svelte` cleared `password` only on success, leaving the failed-attempt string in DOM state until the next keystroke | Moved `password = ''` into the `finally` block so the binding clears on both paths. Added a Vitest pin for the failure path (`106 / 0` passing, was 105). |
+| `Unlock.test.ts` used a triple `await Promise.resolve()` to flush the IPC chain — brittle if the chain grows another await link | Replaced with `await waitFor(() => expect(...))` from `@testing-library/svelte` across `Unlock.test.ts`, `PathPicker.test.ts` (positive cases), and `App.test.ts`. Negative cases in `PathPicker.test.ts` (cancellation + multi-select misuse) settle the awaited mock promise explicitly via `await openMock.mock.results[0].value` rather than `Promise.resolve()`. |
+| `warnSpy` variable name spied on `console.error`, not `console.warn` | Renamed to `errorSpy` in [`desktop/tests/stores.test.ts`](../../desktop/tests/stores.test.ts). |
+| `theme.css` centralization works around a Vite 6/Vitest bug but spreads visual rules away from their owning components | Filed as #153 (revisit after upstream fix). |
+| Emoji `🔐` icon renders inconsistently across platforms (especially Linux without an emoji font) | Filed as #154 (replace with inline SVG before D.1.1 ships externally). |
+
+Gauntlet after fixup (re-run, fully green):
+
+```
+Rust:           PASSED 1053 FAILED 0 IGNORED 10
+cargo clippy --release --workspace --tests -- -D warnings   → clean
+cargo fmt --all -- --check                                  → clean
+uv run core/tests/python/conformance.py                     → PASS
+uv run core/tests/python/spec_test_name_freshness.py        → PASS
+
+Frontend:       Vitest 106 / 0 (+1 password-clear-on-failure pin)
+pnpm typecheck                                              → clean
+pnpm svelte-check                                           → 224 files, 0 errors, 0 warnings
+pnpm lint                                                   → clean
+```
+
 ## (2) What's next — D.1.1 Task 8 (Vault route + BlockCard + LockButton)
 
 Per the plan, Task 8 lands the second user-visible route — the post-unlock screen with top bar (vault label + settings gear + lock button) + vertical stack of BlockCards. Clicks on cards are stubbed (D.1.2 wires them up). LockButton calls the `lock` IPC; the frontend waits for the `vault-locked` event (already wired by #149 in this PR) before transitioning to locked — backend reality is source of truth per spec §7.
@@ -122,6 +151,11 @@ Per the plan, Task 8 lands the second user-visible route — the post-unlock scr
 - #141 — bridge: `RecordInput` lacks `record_type` field. Status unchanged.
 - #144 — desktop: Argon2id KDF runs under IPC mutex during unlock. Status unchanged; still deferred to D.1.4+.
 - #145 — desktop: no recovery path for unlock-time settings warnings. Status unchanged; still deferred.
+
+### Issues filed during this PR's fixup pass
+
+- **#153** — desktop: re-migrate component styles from `theme.css` back to component `<style>` blocks once the upstream Vite/Vitest `preprocessCSS` bug clears.
+- **#154** — desktop: replace the emoji `🔐` unlock icon with inline SVG before D.1.1 ships externally.
 
 ### Housekeeping (stale worktrees on disk)
 
@@ -192,7 +226,7 @@ pnpm lint
 ## Closing inventory
 
 - **Branch state on close:** `main` at `ca5d0e5` (D.1.1 Task 6 PR #148 merged earlier today). `feature/d11-task-7` carries 5 code commits (one per logical unit: #150 wrapper, backend dialog plugin, theme + PathPicker + harness, Unlock route, App.svelte + #149 listener) + this baton. Squash-merge collapses to one commit on `main`.
-- **Workspace tests on `feature/d11-task-7`:** Rust **1053 passed + 10 ignored** (unchanged — backend touch is a dep addition + plugin registration). Vitest **105 passed** (errors=26, ipc=13, auto_lock=12, stores=31, PathPicker=8, Unlock=8, App=7) — new gauntlet baseline.
+- **Workspace tests on `feature/d11-task-7`:** Rust **1053 passed + 10 ignored** (unchanged — backend touch is a dep addition + plugin registration). Vitest **106 passed** post-fixup (errors=26, ipc=13, auto_lock=12, stores=31, PathPicker=8, Unlock=9, App=7) — new gauntlet baseline.
 - **README.md:** unchanged. Per prior batons, per-task status flips during D.1.1 implementation are noise until D.1.1 ships end-to-end (Task 12). The existing "D.1.1 walking skeleton … in design" covers the implementation phase as a whole.
 - **ROADMAP.md:** unchanged. Same logic as README.
 - **CLAUDE.md:** unchanged this session.

--- a/docs/handoffs/2026-05-28-d11-task-7-shipped.md
+++ b/docs/handoffs/2026-05-28-d11-task-7-shipped.md
@@ -1,0 +1,213 @@
+# NEXT_SESSION.md — D.1.1 Task 7 (Unlock route + PathPicker + vault-locked listener) shipped
+
+**Session date:** 2026-05-28 (fourth D.1.1 slice of the day; continues immediately from the Task 6 session that landed via PR #148 at `ca5d0e5` on `main`. This session lands the first user-visible Svelte components and closes both issues filed during the PR #148 review: #149 (`vault-locked` event listener) and #150 (SessionState state-machine wrapper).)
+**Status:** D.1.1 Task 7 PR open on branch `feature/d11-task-7`. Predecessors on `main`: D.1.1 spec + ADR 0007 (PR #130, `a5d85b9`), D.1.1 Task 1 scaffold (PR #131, `e329087`), D.1.1 Task 2 pure modules (PR #137, `a3ee9e9`), D.1.1 Task 3 VaultSession (PR #142, `6f984d4`), D.1.1 Task 4 IPC commands + DTOs (PR #143, `9217602`), D.1.1 Task 5 auto-lock timer (PR #146, `16721c5`), D.1.1 Task 6 frontend pure modules (PR #148, `ca5d0e5`).
+
+## (1) What we shipped this session
+
+The first three commits land Task 7 proper — the Unlock route, PathPicker leaf, theme.css tokens, and the Tauri dialog plugin backend wiring. The fourth commit closes #149 by wiring the `vault-locked` Tauri event listener into App.svelte's `onMount`, and the fifth (chronologically first) closes #150 by demoting the raw `sessionState` writable to internal and exposing only legal-transition helpers. Both issues were filed during PR #148's review and were deliberately scoped to Task 7 per their authoring (user confirmed both as in-scope for this PR at session start).
+
+| Commit | Subject | What it lands |
+|---|---|---|
+| `681205a` | `refactor(d11): SessionState state-machine wrapper (closes #150)` | Demote `writable<SessionState>` to non-exported `_internal`; expose `Readable<SessionState>` + transition helpers (`beginUnlock`, `unlockSucceeded`, `unlockFailed`, `beginLock`, `vaultLocked`). `unlocking` / `locking` variants now carry `startedAt: number`. Illegal edges throw in dev (`import.meta.env.DEV`), log to `console.error` + no-op in prod. Tests: 31 (was 10) covering every legal transition, illegal-edge rejection per variant, dev-vs-prod branching, the authoritative `vaultLocked` from each state, and the derived/notice stores. `_resetSessionStateForTest` is the underscore-prefixed escape hatch (matches the `_resetActivityTrackingForTest` convention from `auto_lock.ts`). Adds `src/vite-env.d.ts` for `import.meta.env` typing. |
+| `27bdb02` | `feat(d11): Task 7 — wire tauri-plugin-dialog for PathPicker` | Backend half. `desktop/src-tauri/Cargo.toml`: add `tauri-plugin-dialog = "2"` (resolves 2.7.1). `desktop/src-tauri/src/main.rs`: register via `.plugin(tauri_plugin_dialog::init())`. `desktop/src-tauri/capabilities/default.json`: new file; Tauri 2 auto-picks up `capabilities/*.json`. Grants `core:default` + `dialog:allow-open` only — least-privilege per CLAUDE.md security guidance. |
+| `2d56d55` | `feat(d11): Task 7 — theme.css + PathPicker component + Vitest harness for components` | `desktop/src/theme.css`: CSS custom-property tokens (color, spacing, radius, typography, shadow) + dark-mode override block + `.path-picker` component class. `desktop/src/components/PathPicker.svelte`: small leaf wrapping `@tauri-apps/plugin-dialog`'s `open({ directory: true })`; emits the path through `onSelect`. `desktop/tests/PathPicker.test.ts`: 8 tests using `@testing-library/svelte`'s `render()` + `fireEvent.click()` with `vi.hoisted` for the dialog-plugin mock. `vitest.config.ts`: add `svelteTesting()` from `@testing-library/svelte/vite` (wires browser resolve conditions + noExternal + auto-cleanup). devDeps: bump `@sveltejs/vite-plugin-svelte` 4 → 5 (v4 peer-deps Vite 5; we're on Vite 6); add `@testing-library/svelte@^5`, `@testing-library/jest-dom@^6`, `@testing-library/user-event@^14`. |
+| `9b61a68` | `feat(d11): Task 7 — Unlock route + form submission lifecycle` | `desktop/src/routes/Unlock.svelte`: first user-visible route. Renders the folder picker + password field + submit button, threads submission through `beginUnlock` → `unlockWithPassword` → `getSettings` → `unlockSucceeded` / `unlockFailed`. Password cleared from `bind:value` immediately on success (shrinks DOM-residue lifetime; JS can't zeroize but we can shorten). `submit()` short-circuits when invalid or already in-flight, preventing a double Argon2id derivation on stray Enter. Inline error reads `userMessageFor($sessionState.lastError)` so adding a Rust variant without a TS counterpart still breaks tsc compile via the existing exhaustiveness check. Tests: 8 covering initial-render shape, disabled→enabled transition, happy-path IPC sequence, password clearing, `wrong_password` (title) + `vault_path_not_found` (path in detail) error paths, and empty-fields submit guard. `theme.css` grows the `.unlock*` block (~80 LOC). |
+| `b726611` | `feat(d11): App.svelte router + vault-locked event listener (closes #149)` | App.svelte routes on `$sessionState.status` (renders `<Unlock />` when locked / unlocking / locking; placeholder vault view when unlocked — real BlockList lands in Task 8). `onMount` installs `listen('vault-locked', …)` with unmount-race-safe pattern: a closure-local `unmounted` flag lets a late `listen` resolve detach itself if it lands after the cleanup ran. Maps backend reason (`'explicit'` / `'auto'`) to AutoLockNotice reason (`'manual'` / `'idle'`) via a small const table, then calls `vaultLocked(notice)` which transitions + raises the notice in one shot. Tests: 7 covering router rendering, listener installation, the two reason mappings, the mid-flight race (`vaultLocked` from `unlocking` lands safely thanks to the authoritative transition), and the unmount-time detach. |
+
+**Commits on `feature/d11-task-7`** (5 originals + 1 baton):
+
+| SHA | Subject |
+|---|---|
+| `681205a` | `refactor(d11): SessionState state-machine wrapper (closes #150)` |
+| `27bdb02` | `feat(d11): Task 7 — wire tauri-plugin-dialog for PathPicker` |
+| `2d56d55` | `feat(d11): Task 7 — theme.css + PathPicker component + Vitest harness for components` |
+| `9b61a68` | `feat(d11): Task 7 — Unlock route + form submission lifecycle` |
+| `b726611` | `feat(d11): App.svelte router + vault-locked event listener (closes #149)` |
+| TBD | `docs(d11): Task 7 handoff baton` |
+
+Post-squash-merge SHA on `main` will differ.
+
+### Gauntlet (live, performed)
+
+```
+Rust:           PASSED 1053 FAILED 0 IGNORED 10    # unchanged — Task 7 backend touch is Tauri-plugin-dialog dep only
+cargo clippy --release --workspace --tests -- -D warnings   → clean
+cargo fmt --all -- --check                                  → clean
+uv run core/tests/python/conformance.py                     → PASS
+uv run core/tests/python/spec_test_name_freshness.py        → PASS
+
+Frontend:       Vitest 105 / 0 (7 files: errors=26, ipc=13, auto_lock=12, stores=31, PathPicker=8, Unlock=8, App=7)
+pnpm typecheck                                              → clean
+pnpm svelte-check                                           → 224 files, 0 errors, 0 warnings
+pnpm lint                                                   → clean
+```
+
+Plan-vs-actual on Vitest counts: plan predicted **~12** new tests for Task 7 ("4 + 4 + 4" sketch); actual is **44 new** (`stores.test.ts` grew 10 → 31 = +21; new files PathPicker=8, Unlock=8, App=7 = 23). Surplus split:
+
+- `stores.test.ts`: +21 from the #150 state-machine wrapper landing. Every legal transition is pinned plus at least one illegal-edge case per variant plus the dev-vs-prod branching of the assertion plus the authoritative `vaultLocked` from each of four states. None of this surface existed before #150.
+- `PathPicker.test.ts`: 8 — open() options shape pin, string-return → onSelect, null-return (cancel) is no-op, disabled blocks click, non-string array return defensive ignore, plus three rendering pins (placeholder, readonly attribute, current-value rendering).
+- `Unlock.test.ts`: 8 — initial render (heading/label/button), disabled→enabled on field fills, happy-path IPC sequence + state landing, password clearing, two error-path payloads (`wrong_password` title, `vault_path_not_found` path-in-detail), and empty-fields submit guard.
+- `App.test.ts`: 7 — router locked → Unlock, unlocked → placeholder, listener mounted, reason mapping ×2, mid-flight race, unmount-time detach.
+
+The surplus is intentional; under-counting was a plan-sketch slip.
+
+### Plan execution trace (for the reviewer)
+
+- Plan Step 1 (worktree) ✅ executed; Step 2 (backend plugin) ✅; Step 3 (`theme.css`) ✅ with adaptation #1 (component classes in theme.css rather than `<style>` blocks); Step 4 (PathPicker.svelte) ✅; Step 5 (Unlock.svelte) ✅ with adaptation #2 (transition helpers, not direct `.set()`); Step 6 (App.svelte) ✅ extended with #149 listener; Step 7 (manual `pnpm tauri dev` smoke) deliberately skipped — no UI environment available in this session (called out as a follow-up below); Step 8 (gauntlet + commit) ✅.
+- File sizes (all comfortably under the 500-LOC threshold): stores.ts=159, App.svelte=58, Unlock.svelte=92, PathPicker.svelte=39, theme.css=189. Tests: stores.test=276, Unlock.test=146, PathPicker.test=109, App.test=137.
+- Per-module TDD discipline: each new file landed with its test in the same commit. Tests written first → ran red → implementation → ran green. The state-machine wrapper commit alone went red on 31 of 31 before implementation.
+
+## (2) What's next — D.1.1 Task 8 (Vault route + BlockCard + LockButton)
+
+Per the plan, Task 8 lands the second user-visible route — the post-unlock screen with top bar (vault label + settings gear + lock button) + vertical stack of BlockCards. Clicks on cards are stubbed (D.1.2 wires them up). LockButton calls the `lock` IPC; the frontend waits for the `vault-locked` event (already wired by #149 in this PR) before transitioning to locked — backend reality is source of truth per spec §7.
+
+**Files (per the plan):**
+
+- Create: `desktop/src/routes/Vault.svelte` — top bar + vertical stack of BlockCard.
+- Create: `desktop/src/components/BlockCard.svelte` — single block summary card.
+- Create: `desktop/src/components/LockButton.svelte` — calls `beginLock()` then `lock()` IPC; visibly enters "Locking…" pending state until the `vault-locked` event arrives.
+- Create: `desktop/src/components/TopBar.svelte` — vault label + settings gear (stub) + LockButton.
+- Modify: `desktop/src/App.svelte` — render `<Vault />` instead of the placeholder when unlocked.
+- Modify: `desktop/src/theme.css` — append `.vault*`, `.block-card*`, `.lock-button*`, `.top-bar*` blocks.
+- New tests: `desktop/tests/Vault.test.ts`, `desktop/tests/BlockCard.test.ts`, `desktop/tests/LockButton.test.ts`, `desktop/tests/TopBar.test.ts`.
+
+**Acceptance criteria for Task 8:**
+
+- Gauntlet: Rust **1053 / 0 / 10** (unchanged — Task 8 is frontend-only), Vitest **105 + N** where N ≈ 12-16 component tests across the new files.
+- `pnpm tauri dev` smoke: unlock the golden vault → BlockList renders with the block summaries from `listBlocks()` → click LockButton → button shows "Locking…" → `vault-locked` event from backend → screen swaps back to Unlock.
+- LockButton enters `locking` state via `beginLock()` BEFORE awaiting the IPC; the `vault-locked` listener (App.svelte) handles the eventual transition. Rollback path: if `lock()` IPC throws, today's wrapper has no `lockFailed` helper — see decisions §(3) below.
+- ESLint + svelte-check clean.
+
+**Estimate:** ~90–120 min (4 small Svelte components + Vault route + theme.css extensions + 4 Vitest test files).
+
+## (3) Open decisions and risks
+
+### Plan adaptations (worth flagging to the reviewer)
+
+1. **Component styles centralised in `theme.css`, not in component `<style>` blocks.** Vite 6's internal `preprocessCSS` trips a `PartialEnvironment` proxy bug under Vitest (`new Proxy(this, …)` fails because the constructor's `this` isn't fully constructed when called from a partial-config code path). Symptoms: every `.svelte` file with a `<style>` block crashes the test suite at the preprocess step, regardless of style content. Verified across `@sveltejs/vite-plugin-svelte` 4.0.4 AND 5.1.1; the bug is in vite itself. Workarounds considered: pin Vite to 5.x (would block Vite-6-required deps later), patch `@sveltejs/vite-plugin-svelte`, write a vite plugin to short-circuit `preprocessCSS`. The chosen path — moving all component styles into `theme.css` as global `.<component> { … }` classes — is the lowest-risk fix AND has a side-benefit: every visual choice is reviewable in one file rather than spread across components. The convention is documented in a comment at the top of `theme.css`. Trade-off accepted: no per-component scoping → name collisions in theory; mitigated by the `.<component>__<part>` BEM-light convention.
+2. **`Unlock.svelte` uses transition helpers, not raw `sessionState.set(...)`.** The plan's `Unlock.svelte` sketch called `sessionState.set({...})` directly, but #150 demotes the writable to internal. The submit handler now reads `beginUnlock() → unlockWithPassword(...) → getSettings() → unlockSucceeded(manifest, settings)` (or `unlockFailed(err)` on throw). Cleaner anyway — the plan's `sessionState.set({ status: 'unlocking', lastError: null })` would have been a type error (the `unlocking` variant has no `lastError` field).
+3. **`getSettings` imported statically, not via dynamic `import()`.** The plan had a `const { getSettings } = await import('../lib/ipc')` mid-function for some reason. Static `import { getSettings } from '../lib/ipc'` at the top is the obvious choice — Vite tree-shakes either way, and the dynamic form trips the no-loss-of-mockability surface.
+4. **No `pnpm tauri dev` smoke this session.** The plan's Step 7 calls for a manual smoke — open the dialog, unlock the golden vault, etc. This session has no UI environment available, so the smoke is deferred. The component-level Vitest tests cover the form logic + IPC contract; the Tauri-event side is mocked. A `pnpm tauri dev` smoke before merge would close the gap; alternatively, it can ride in Task 8's smoke (which exercises the same unlock path en route to BlockList).
+5. **`@sveltejs/vite-plugin-svelte` 4 → 5.** Vite 6 (already a project dep from Task 1) requires vite-plugin-svelte v5. v4 silently no-ops on certain hooks in Vite 6, which is why the test suite started failing on Svelte rune emission once a real component landed. The bump is a no-op for runtime semantics — purely a peer-dep alignment.
+6. **`@testing-library/svelte` v5 + `svelteTesting()` companion plugin.** v5 of testing-library/svelte ships its runes mode helpers as `.svelte.js` files in node_modules, which the Svelte plugin can't compile without the `svelteTesting()` companion that adds the `browser` resolve condition AND the `ssr.noExternal` list. Documented at the top of `vitest.config.ts`. Required for any future component tests too.
+
+### Decisions settled
+
+- **`vaultLocked` is authoritative — accepts from any state.** The backend's `vault-locked` event is the source of truth (spec §7). Even if the frontend is mid-flight in `unlocking`, an arriving event transitions us to `locked`. The user re-tries from a clean state, which is correct: the backend has decided to lock and the frontend follows.
+- **Illegal transitions throw in dev, log + no-op in prod.** Per the user-authored issue #150 body. Vitest runs with `import.meta.env.DEV === true` so the dev-throw branch is covered by tests; the prod-log branch gets a dedicated test that uses `vi.stubEnv('DEV', false)` to flip the runtime environment. The argument for failing loud everywhere (per [[feedback_security_no_assumptions]]) was weighed against the user's authored guidance — the prod path **does** log at `console.error` so it's not silent; the no-op-instead-of-throw branch keeps a frontend state-machine bug from DOS-ing the user. Backend remains the source of truth either way.
+- **No `lockFailed` rollback helper in the state machine.** The `lock` IPC is infallible by spec (lock is idempotent; it always wipes the session). If a future transport-level error needs handling, add a new helper then. Currently the `locking → unlocked` edge isn't a documented legal transition; deferred until Task 8 surfaces it (if it does).
+- **`startedAt: number` on `unlocking` / `locking` variants** but no consumer yet. Tasks 8–10 will use it to detect stuck transitions and surface a "this is taking longer than usual" toast. Landing the field now means consumers don't need a coordinated schema migration when they wire up the toast.
+- **`@testing-library/svelte` v5 + `svelteTesting()` is the component-test toolchain.** The baton (Task 6) noted the choice between this and `@vitest/browser` (real-browser via Playwright); v5 of testing-library handles Svelte 5 runes well, and jsdom is cheaper for CI. Realism trade-off cashed in at Task 11's e2e suite.
+
+### Risks carried forward
+
+- **`pnpm tauri dev` smoke deferred.** See plan-adaptation #4. The Vitest suite covers the form lifecycle behaviourally but doesn't catch e.g. Tauri capability misconfiguration. Mitigation: Task 8's smoke walks the same unlock path; a regression in the capability setup surfaces there. Manual verification before merge is also straightforward (5 minutes of `pnpm tauri dev` + clicking through the unlock flow).
+- **Vite 6 `preprocessCSS` bug.** See plan-adaptation #1. The workaround (centralised stylesheet) is a permanent restriction on the project — adding a `<style>` block to any future component will break the test suite. Cost of the restriction: low (visual rules co-located in `theme.css` is arguably cleaner than per-component scoping anyway). Cost of fixing the upstream bug: monitor `@sveltejs/vite-plugin-svelte` ≥ 6 + Vite ≥ 7 release notes — when the bug is fixed upstream, per-component styles can land without test-harness penalty.
+- **Carry-forward: password handling at the IPC boundary is not yet zeroize-typed** (Task 4 risk). Unchanged; Unlock.svelte still binds to a JS `string`. The lifetime is shrunk to "from input to submit", but mid-flight Argon2id (the dominant time window) still holds the string in memory.
+- **Carry-forward: `AppError::KdfTooWeak` still has no producer.** Unchanged.
+- **Carry-forward: bridge `RecordInput.record_type` workaround** (issue #141). Unchanged.
+
+### Issues closed by this PR
+
+- **#149** (vault-locked event listener) — App.svelte's `onMount` installs the listener; the `reason` field maps to AutoLockNotice; `sessionState` transitions via authoritative `vaultLocked()`.
+- **#150** (SessionState transition helpers) — `sessionState` demoted to `Readable<SessionState>`; mutations gate through transition helpers; illegal edges throw in dev / log in prod.
+
+### Issues currently open (carry-over)
+
+- #37, #117, #120, #122, #123 — none affected by Task 7.
+- #38, #45, #75, #76, #78, #79, #81, #87, #88, #90, #95, #98 — none affected.
+- #139 — desktop: `AppError` lacks `Deserialize`. Same status as before.
+- #140 — desktop: `parse_settings_field` text-only invariant. Status unchanged.
+- #141 — bridge: `RecordInput` lacks `record_type` field. Status unchanged.
+- #144 — desktop: Argon2id KDF runs under IPC mutex during unlock. Status unchanged; still deferred to D.1.4+.
+- #145 — desktop: no recovery path for unlock-time settings warnings. Status unchanged; still deferred.
+
+### Housekeeping (stale worktrees on disk)
+
+Carry-over from prior batons. After this Task 7 PR merges, the freshly-shipped Task 6 worktree should be cleaned up too.
+
+```bash
+# From /Users/hherb/src/secretary, after the present (Task 7) PR merges:
+git worktree remove .worktrees/c1-1b-sync-merge   && git branch -D feature/c1-1b-task-17
+git worktree remove .worktrees/c2-task-1-spec     && git branch -D feature/c2-task-1-spec
+for n in 1 2 3 4 5 6 7 8 9 10; do
+  git worktree remove .worktrees/c2-task-$n       && git branch -D feature/c2-task-$n
+done
+git worktree remove .worktrees/d11-tauri-spec     && git branch -D feature/d11-tauri-spec
+git worktree remove .worktrees/d11-task-3         && git branch -D feature/d11-task-3
+git worktree remove .worktrees/d11-task-4         && git branch -D feature/d11-task-4
+git worktree remove .worktrees/d11-task-5         && git branch -D feature/d11-task-5
+git worktree remove .worktrees/d11-task-6         && git branch -D feature/d11-task-6   # Task 6 PR #148 merged at ca5d0e5
+# Keep .worktrees/d11-task-7 until this PR merges; remove after.
+```
+
+## (4) Exact commands to resume (Task 8)
+
+```bash
+# After this Task 7 PR (feature/d11-task-7) merges:
+cd /Users/hherb/src/secretary
+git fetch --prune origin
+git status --short              # expect: clean
+git checkout main
+git pull --ff-only origin main
+
+# Re-baseline the gauntlet on fresh main:
+cargo test --release --workspace --no-fail-fast 2>&1 | grep "^test result:" | awk '$3=="ok." {p+=$4; f+=$6; i+=$8} END {printf "Rust totals → PASSED: %d FAILED: %d IGNORED: %d\n", p, f, i}'
+# Expect: PASSED: 1053 FAILED: 0 IGNORED: 10
+
+# Frontend baseline on main:
+cd desktop
+pnpm install                    # picks up the locked devDeps from this PR
+pnpm test                       # expect: 105 passing
+pnpm typecheck                  # clean
+pnpm svelte-check               # 224 files, 0 errors
+pnpm lint                       # clean
+cd ..
+
+# Set up the Task 8 worktree:
+git worktree add .worktrees/d11-task-8 -b feature/d11-task-8 main
+cd .worktrees/d11-task-8/desktop
+pnpm install
+
+# Open the plan and follow Task 8 step-by-step:
+#   docs/superpowers/plans/2026-05-27-d11-tauri-walking-skeleton.md
+# Search for "## Task 8:" — each step block is self-contained.
+
+# After Vault.svelte / BlockCard.svelte / LockButton.svelte / TopBar.svelte
+# + Vitest component tests:
+cd ..   # back to .worktrees/d11-task-8/
+cargo test --release --workspace --no-fail-fast 2>&1 | grep "^test result:" | awk '$3=="ok." {p+=$4; f+=$6; i+=$8} END {printf "Rust totals → PASSED: %d FAILED: %d IGNORED: %d\n", p, f, i}'
+cargo clippy --release --workspace --tests -- -D warnings
+cargo fmt --all -- --check
+uv run core/tests/python/conformance.py
+uv run core/tests/python/spec_test_name_freshness.py
+cd desktop
+pnpm test                       # expect 105 + Task-8 surplus (plan-target ~12-16 new)
+pnpm typecheck
+pnpm svelte-check
+pnpm lint
+```
+
+## Closing inventory
+
+- **Branch state on close:** `main` at `ca5d0e5` (D.1.1 Task 6 PR #148 merged earlier today). `feature/d11-task-7` carries 5 code commits (one per logical unit: #150 wrapper, backend dialog plugin, theme + PathPicker + harness, Unlock route, App.svelte + #149 listener) + this baton. Squash-merge collapses to one commit on `main`.
+- **Workspace tests on `feature/d11-task-7`:** Rust **1053 passed + 10 ignored** (unchanged — backend touch is a dep addition + plugin registration). Vitest **105 passed** (errors=26, ipc=13, auto_lock=12, stores=31, PathPicker=8, Unlock=8, App=7) — new gauntlet baseline.
+- **README.md:** unchanged. Per prior batons, per-task status flips during D.1.1 implementation are noise until D.1.1 ships end-to-end (Task 12). The existing "D.1.1 walking skeleton … in design" covers the implementation phase as a whole.
+- **ROADMAP.md:** unchanged. Same logic as README.
+- **CLAUDE.md:** unchanged this session.
+- **NEXT_SESSION.md:** symlink retargeted to this file.
+- **`docs/adr/`:** unchanged.
+- **`desktop/src/lib/`:** `stores.ts` rewritten for the state-machine wrapper; `vite-env.d.ts` added.
+- **`desktop/src/`:** new `App.svelte` (router + listener), `theme.css`, `components/PathPicker.svelte`, `routes/Unlock.svelte`.
+- **`desktop/tests/`:** new `PathPicker.test.ts`, `Unlock.test.ts`, `App.test.ts`; `stores.test.ts` rewritten for the new API.
+- **`desktop/vitest.config.ts`:** add `svelteTesting()` plugin.
+- **`desktop/package.json`:** +3 devDeps (`@testing-library/svelte`, `@testing-library/jest-dom`, `@testing-library/user-event`), bump `@sveltejs/vite-plugin-svelte` 4 → 5.
+- **`desktop/pnpm-lock.yaml`:** new packages for testing-library + Svelte-5-compat plugin tree.
+- **`desktop/src-tauri/Cargo.toml`:** + `tauri-plugin-dialog = "2"`.
+- **`desktop/src-tauri/src/main.rs`:** + `.plugin(tauri_plugin_dialog::init())`.
+- **`desktop/src-tauri/capabilities/default.json`:** new file (`core:default` + `dialog:allow-open`).
+- **Open issues:** see §(3); **two closed by this PR (#149, #150)**.
+- **Open PRs:** PR for this task being opened now (after baton commit).
+- **Worktrees on disk:** stale worktrees listed in §(3) can be cleaned up at any pause; `feature/d11-task-7` stays until merge.
+- **This file:** the live baton for the Task 7 close. The next slice opens with `docs/handoffs/<date>-d11-task-8-shipped.md`.


### PR DESCRIPTION
## Summary

- Lands the first user-visible Svelte components for D.1.1 — `PathPicker.svelte` leaf + `Unlock.svelte` route + `App.svelte` router. Wires `tauri-plugin-dialog` on the backend (Rust dep + plugin registration + `capabilities/default.json`).
- **Closes #150** — demotes the raw `sessionState` writable to non-exported `_internal`; public surface is a read-only `Readable<SessionState>` + transition helpers (`beginUnlock`, `unlockSucceeded`, `unlockFailed`, `beginLock`, `vaultLocked`). `unlocking` / `locking` variants carry `startedAt: number`. Illegal edges throw in dev (`import.meta.env.DEV`), log + no-op in prod.
- **Closes #149** — App.svelte's `onMount` installs `listen('vault-locked', …)` with unmount-race-safe cleanup; maps backend `reason: 'explicit' | 'auto'` → AutoLockNotice `'manual' | 'idle'`; transitions via authoritative `vaultLocked()` (accepts from any state — backend is source of truth per spec §7).

## Gauntlet

```
Rust:           1053 / 0 / 10            # unchanged — backend touch is dep add + plugin registration only
clippy --tests -- -D warnings            → clean
cargo fmt --all -- --check               → clean
uv run conformance.py                    → PASS
uv run spec_test_name_freshness.py       → PASS

Frontend:       Vitest 105 / 0           # was 61 — +44 (state-machine wrapper +21, PathPicker +8, Unlock +8, App +7)
pnpm typecheck                           → clean
pnpm svelte-check                        → 224 files, 0 errors, 0 warnings
pnpm lint                                → clean
```

## Plan adaptations (called out in the baton)

1. **Component styles centralised in `theme.css`** (not in component `<style>` blocks) — Vite 6's internal `preprocessCSS` trips a `PartialEnvironment` proxy bug under Vitest. Workaround: global `.<component>` classes in `theme.css`. Side benefit: every visual rule is reviewable in one file.
2. **`Unlock.svelte` uses transition helpers**, not raw `sessionState.set(...)` — required by #150. Cleaner anyway (the plan sketch had a type error).
3. **`@sveltejs/vite-plugin-svelte` 4 → 5** — v4 peer-deps Vite 5; we're on Vite 6.
4. **`@testing-library/svelte` v5 + `svelteTesting()` companion plugin** — required for Svelte 5 runes mode component tests.
5. **No `pnpm tauri dev` smoke this session** — Vitest covers the form lifecycle behaviourally; Task 8's smoke walks the same unlock path.

Full plan-vs-actual and decision log in [docs/handoffs/2026-05-28-d11-task-7-shipped.md](docs/handoffs/2026-05-28-d11-task-7-shipped.md).

## Test plan

- [x] cargo test --release --workspace → 1053 / 0 / 10
- [x] cargo clippy --release --workspace --tests -- -D warnings → clean
- [x] cargo fmt --all -- --check → clean
- [x] uv run core/tests/python/conformance.py → PASS
- [x] uv run core/tests/python/spec_test_name_freshness.py → PASS
- [x] pnpm test → 105 passing across 7 files
- [x] pnpm typecheck → clean
- [x] pnpm svelte-check → 224 files / 0 errors / 0 warnings
- [x] pnpm lint → clean
- [ ] Manual: `pnpm tauri dev`, unlock the golden vault, observe the screen swap. Deferred to Task 8 (same code path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)