### PR TITLE
chore(desktop): silence 3 intentional Svelte state_referenced_locally warnings

### DIFF
--- a/desktop/src/components/create/FolderStep.svelte
+++ b/desktop/src/components/create/FolderStep.svelte
@@ -12,6 +12,7 @@
   // seedPath is read ONCE to seed the picker; thereafter `picked` is
   // user-driven. The svelte-check `state_referenced_locally` note is expected
   // and intentional — the seed is deliberately not reactive after mount.
+  // svelte-ignore state_referenced_locally
   let picked = $state(seedPath);
   let probed = $state<{ exists: boolean; isEmpty: boolean } | null>(null);
   let subfolderName = $state('');

--- a/desktop/src/components/edit/RecordEditor.svelte
+++ b/desktop/src/components/edit/RecordEditor.svelte
@@ -24,6 +24,7 @@
   // loading=true from the very first render in edit mode and avoids a flash of
   // the empty form before revealRecord resolves. The svelte-check
   // state_referenced_locally note here is expected and intentional.
+  // svelte-ignore state_referenced_locally
   let loading = $state(record !== null);
   let errMsg = $state<ReturnType<typeof userMessageFor> | null>(null);
 

--- a/desktop/src/routes/Unlock.svelte
+++ b/desktop/src/routes/Unlock.svelte
@@ -16,6 +16,7 @@
   // is expected — the read is intentionally a one-time mount-time capture.
   const created = get(createdVaultPath);
   if (created.length > 0) {
+    // svelte-ignore state_referenced_locally
     if (folderPath.length === 0) {
       folderPath = created;
     }


### PR DESCRIPTION
## What

Adds a `// svelte-ignore state_referenced_locally` directive at each of the three
sites that print a `state_referenced_locally` warning under `pnpm tauri dev` /
`pnpm svelte-check`:

- `src/routes/Unlock.svelte` — `folderPath` (one-shot prefill from the just-created-vault store)
- `src/components/edit/RecordEditor.svelte` — `record` (seeds `loading = $state(record !== null)`)
- `src/components/create/FolderStep.svelte` — `seedPath` (seeds `picked = $state(seedPath)`)

## Why

All three are **deliberate one-time mount-time captures** — and each already had a
prose comment from the original author saying so, but no actual directive, so the
warning kept printing. These are not stale-value bugs: each component remounts when
its seeding input changes (Unlock per appRoute/lock, RecordEditor per edit session,
FolderStep per wizard entry). Pure annotation — **no behaviour change**.

Surfaced during the D.1.5 (#171) manual GUI smoke; kept out of that PR to keep it
scoped to delete/trash.

## Verification

- `pnpm svelte-check` → **0 errors / 0 warnings** (was 0 / 3)
- `eslint` → clean
- `vitest` → 331 / 331 pass

Closes #173.

🤖 Generated with [Claude Code](https://claude.com/claude-code)