### PR TITLE
#196 — honest resurrect for no-content tombstones (desktop)

### DIFF
--- a/NEXT_SESSION.md
+++ b/NEXT_SESSION.md
@@ -1,1 +1,1 @@
-docs/handoffs/2026-06-08-interactive-conflict-resolution-shipped.md
+docs/handoffs/2026-06-08-honest-resurrect-shipped.md

--- a/desktop/src/components/RecordList.svelte
+++ b/desktop/src/components/RecordList.svelte
@@ -12,6 +12,7 @@
   import RecordRow from './RecordRow.svelte';
   import BlockRecipients from './BlockRecipients.svelte';
   import ConfirmDialog from './delete/ConfirmDialog.svelte';
+  import { isContentlessTombstone } from '../lib/records';
 
   type Props = { block: BlockSummaryDto };
   let { block }: Props = $props();
@@ -21,6 +22,9 @@
   let showDeleted = $state(false);
   // Record awaiting delete confirmation; the ConfirmDialog mounts while set.
   let pendingDelete = $state<RecordDto | null>(null);
+  // Record awaiting resurrect confirmation (only set for a contentless
+  // tombstone — a resurrect that would bring back an empty shell).
+  let pendingRestore = $state<RecordDto | null>(null);
 
   // Monotonic generation counter guarding against out-of-order fetches: each
   // load() bumps it and only writes state if it is still the newest call. One
@@ -73,7 +77,18 @@
     }
   }
 
-  async function onRestore(record: RecordDto) {
+  function onRestore(record: RecordDto) {
+    // A contentless tombstone resurrects to an empty shell — confirm first so
+    // the empty result is expected, not a surprise. A still-filled tombstone
+    // resurrects one-click (lossless undelete, unchanged behaviour).
+    if (isContentlessTombstone(record)) {
+      pendingRestore = record;
+      return;
+    }
+    void doRestore(record);
+  }
+
+  async function doRestore(record: RecordDto) {
     error = null;
     try {
       await resurrectRecord(block.blockUuidHex, record.recordUuidHex);
@@ -81,6 +96,13 @@
     } catch (e) {
       error = isAppError(e) ? e : { code: 'internal' };
     }
+  }
+
+  async function confirmRestore() {
+    const target = pendingRestore;
+    if (!target) return;
+    pendingRestore = null;
+    await doRestore(target);
   }
 </script>
 
@@ -110,10 +132,20 @@
 
 {#if pendingDelete}
   <ConfirmDialog
-    title="Delete this record?"
-    body="It moves to deleted and can be restored via “Show deleted”."
-    confirmLabel="Delete"
+    title=”Delete this record?”
+    body=”It moves to deleted and can be restored via “Show deleted”.”
+    confirmLabel=”Delete”
     onConfirm={confirmDelete}
     onCancel={() => (pendingDelete = null)}
+  />
+{/if}
+
+{#if pendingRestore}
+  <ConfirmDialog
+    title=”Resurrect an empty record?”
+    body=”This record has no stored contents to recover — resurrecting brings it back with only its type and tags. Contents are discarded when a record&apos;s deletion is merged from another device.”
+    confirmLabel=”Resurrect”
+    onConfirm={confirmRestore}
+    onCancel={() => (pendingRestore = null)}
   />
 {/if}

--- a/desktop/src/components/RecordList.svelte
+++ b/desktop/src/components/RecordList.svelte
@@ -60,7 +60,7 @@
     void load();
   });
 
-  async function onDelete(record: RecordDto) {
+  function onDelete(record: RecordDto) {
     pendingDelete = record;
   }
 

--- a/desktop/src/components/RecordList.svelte
+++ b/desktop/src/components/RecordList.svelte
@@ -132,9 +132,9 @@
 
 {#if pendingDelete}
   <ConfirmDialog
-    title=”Delete this record?”
-    body=”It moves to deleted and can be restored via “Show deleted”.”
-    confirmLabel=”Delete”
+    title="Delete this record?"
+    body="It moves to deleted and can be restored via “Show deleted”."
+    confirmLabel="Delete"
     onConfirm={confirmDelete}
     onCancel={() => (pendingDelete = null)}
   />
@@ -142,9 +142,9 @@
 
 {#if pendingRestore}
   <ConfirmDialog
-    title=”Resurrect an empty record?”
-    body=”This record has no stored contents to recover — resurrecting brings it back with only its type and tags. Contents are discarded when a record&apos;s deletion is merged from another device.”
-    confirmLabel=”Resurrect”
+    title="Resurrect an empty record?"
+    body="This record has no stored contents to recover — resurrecting brings it back with only its type and tags. Contents are discarded when a record's deletion is merged from another device."
+    confirmLabel="Resurrect"
     onConfirm={confirmRestore}
     onCancel={() => (pendingRestore = null)}
   />

--- a/desktop/src/components/RecordRow.svelte
+++ b/desktop/src/components/RecordRow.svelte
@@ -18,9 +18,7 @@
   let deleted = $derived(record.tombstoned === true);
   let contentless = $derived(isContentlessTombstone(record));
   let ariaLabel = $derived(
-    contentless
-      ? `${record.recordType} record, ${countLabel}, no recoverable contents`
-      : `${record.recordType} record, ${countLabel}`
+    `${record.recordType} record, ${countLabel}${contentless ? ', no recoverable contents' : ''}`
   );
 </script>
 

--- a/desktop/src/components/RecordRow.svelte
+++ b/desktop/src/components/RecordRow.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import type { RecordDto } from '../lib/ipc';
   import { formatShortDate } from '../lib/format';
+  import { isContentlessTombstone } from '../lib/records';
 
   // onDelete / onRestore are optional so existing call sites that only
   // browse (no write actions wired) keep working unchanged. When supplied,
@@ -15,13 +16,19 @@
 
   let countLabel = $derived(`${record.fieldCount} field${record.fieldCount === 1 ? '' : 's'}`);
   let deleted = $derived(record.tombstoned === true);
+  let contentless = $derived(isContentlessTombstone(record));
+  let ariaLabel = $derived(
+    contentless
+      ? `${record.recordType} record, ${countLabel}, no recoverable contents`
+      : `${record.recordType} record, ${countLabel}`
+  );
 </script>
 
 <div class="record-row-wrap" class:record-row--deleted={deleted}>
   <button
     type="button"
     class="record-row"
-    aria-label={`${record.recordType} record, ${countLabel}`}
+    aria-label={ariaLabel}
     disabled={deleted}
     onclick={() => onClick(record)}
   >
@@ -30,6 +37,9 @@
       <span class="record-row__tag">{tag}</span>
     {/each}
     <span class="record-row__meta">{countLabel} · modified {formatShortDate(record.lastModMs)}</span>
+    {#if contentless}
+      <span class="record-row__no-content">· no recoverable contents</span>
+    {/if}
   </button>
 
   {#if deleted && onRestore}

--- a/desktop/src/lib/records.ts
+++ b/desktop/src/lib/records.ts
@@ -1,0 +1,13 @@
+import type { RecordDto } from './ipc';
+
+/**
+ * True iff resurrecting this record would yield an empty shell — a tombstoned
+ * record whose fields were dropped. The §11.3 merge-tombstone path empties a
+ * record's fields; a local delete preserves them. We key on content-emptiness
+ * (not tombstone provenance) because that is exactly the user-facing fact —
+ * "there is nothing to restore" — and it needs no provenance flag on the
+ * frozen on-disk format.
+ */
+export function isContentlessTombstone(record: RecordDto): boolean {
+  return record.tombstoned === true && record.fieldCount === 0;
+}

--- a/desktop/src/theme.css
+++ b/desktop/src/theme.css
@@ -468,6 +468,11 @@ body {
   font-size: var(--font-size-xs);
   color: var(--color-text-muted);
 }
+.record-row__no-content {
+  color: var(--color-text-muted);
+  font-style: italic;
+  margin-left: 0.25rem;
+}
 
 /* SettingsDialog — native <dialog> modal. backdrop is the auto
    pseudo-element rendered by the platform when showModal() is called. */

--- a/desktop/tests/RecordListRestore.test.ts
+++ b/desktop/tests/RecordListRestore.test.ts
@@ -1,0 +1,107 @@
+// Tests for the RecordList resurrect gate: a contentless tombstone
+// (fieldCount 0) routes through a ConfirmDialog before resurrect_record;
+// a tombstone that still has fields resurrects one-click.
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, fireEvent, waitFor } from '@testing-library/svelte';
+
+const { invokeMock } = vi.hoisted(() => ({ invokeMock: vi.fn() }));
+vi.mock('@tauri-apps/api/core', () => ({ invoke: invokeMock }));
+
+import RecordList from '../src/components/RecordList.svelte';
+import type { BlockSummaryDto } from '../src/lib/ipc';
+
+const BLOCK: BlockSummaryDto = { blockUuidHex: 'ab', blockName: 'Personal logins', createdAtMs: 1, lastModifiedMs: 2 };
+
+const EMPTY_TOMBSTONE = {
+  recordUuidHex: 'cd', recordType: 'login', tags: [] as string[],
+  fieldCount: 0, lastModMs: 5, tombstoned: true, fields: []
+};
+const FILLED_TOMBSTONE = {
+  recordUuidHex: 'ef', recordType: 'login', tags: [] as string[],
+  fieldCount: 2, lastModMs: 5, tombstoned: true, fields: []
+};
+
+function mockReadReturning(record: unknown) {
+  invokeMock.mockImplementation((cmd: string) => {
+    if (cmd === 'read_block') {
+      return Promise.resolve({ blockUuidHex: 'ab', blockName: 'Personal logins', records: [record] });
+    }
+    return Promise.resolve(null); // resurrect_record + any teardown invoke
+  });
+}
+
+const calledResurrect = () => invokeMock.mock.calls.some(([c]) => c === 'resurrect_record');
+
+describe('RecordList — contentless resurrect confirm gate', () => {
+  beforeEach(() => invokeMock.mockReset());
+
+  it('opens a confirm and does NOT resurrect until confirmed', async () => {
+    mockReadReturning(EMPTY_TOMBSTONE);
+    const { getByLabelText, container } = render(RecordList, { props: { block: BLOCK } });
+
+    const restoreBtn = await waitFor(() => getByLabelText('Restore record'));
+    await fireEvent.click(restoreBtn);
+
+    // ConfirmDialog mounts; resurrect must not have fired yet.
+    await waitFor(() => {
+      if (!container.querySelector('.confirm-dialog__button--danger')) {
+        throw new Error('confirm dialog not yet mounted');
+      }
+    });
+    expect(calledResurrect()).toBe(false);
+  });
+
+  it('confirming invokes resurrect_record and reloads', async () => {
+    mockReadReturning(EMPTY_TOMBSTONE);
+    const { getByLabelText, container } = render(RecordList, { props: { block: BLOCK } });
+
+    const restoreBtn = await waitFor(() => getByLabelText('Restore record'));
+    await fireEvent.click(restoreBtn);
+
+    const confirmBtn = await waitFor(() => {
+      const el = container.querySelector('.confirm-dialog__button--danger');
+      if (!el) throw new Error('confirm dialog not yet mounted');
+      return el as HTMLButtonElement;
+    });
+    await fireEvent.click(confirmBtn);
+
+    await waitFor(() =>
+      expect(invokeMock).toHaveBeenCalledWith('resurrect_record', { blockUuidHex: 'ab', recordUuidHex: 'cd' })
+    );
+    await waitFor(() =>
+      expect(invokeMock.mock.calls.filter(([c]) => c === 'read_block').length).toBeGreaterThanOrEqual(2)
+    );
+  });
+
+  it('cancelling closes the dialog without resurrecting', async () => {
+    mockReadReturning(EMPTY_TOMBSTONE);
+    const { getByLabelText, getByText, container } = render(RecordList, { props: { block: BLOCK } });
+
+    const restoreBtn = await waitFor(() => getByLabelText('Restore record'));
+    await fireEvent.click(restoreBtn);
+
+    const cancelBtn = await waitFor(() => getByText('Cancel'));
+    await fireEvent.click(cancelBtn);
+
+    await waitFor(() => {
+      if (container.querySelector('.confirm-dialog__button--danger')) {
+        throw new Error('confirm dialog still mounted');
+      }
+    });
+    expect(calledResurrect()).toBe(false);
+  });
+
+  it('resurrects a still-filled tombstone one-click (no confirm)', async () => {
+    mockReadReturning(FILLED_TOMBSTONE);
+    const { getByLabelText, container } = render(RecordList, { props: { block: BLOCK } });
+
+    const restoreBtn = await waitFor(() => getByLabelText('Restore record'));
+    await fireEvent.click(restoreBtn);
+
+    await waitFor(() =>
+      expect(invokeMock).toHaveBeenCalledWith('resurrect_record', { blockUuidHex: 'ab', recordUuidHex: 'ef' })
+    );
+    expect(container.querySelector('.confirm-dialog__button--danger')).toBeNull();
+  });
+});

--- a/desktop/tests/RecordRow.test.ts
+++ b/desktop/tests/RecordRow.test.ts
@@ -22,4 +22,23 @@ describe('RecordRow', () => {
     await fireEvent.click(getByRole('button'));
     expect(onClick).toHaveBeenCalledWith(REC);
   });
+
+  it('shows a "no recoverable contents" hint for a contentless tombstone', () => {
+    const rec: RecordDto = { ...REC, tombstoned: true, fieldCount: 0 };
+    const { getByText, getByRole } = render(RecordRow, { props: { record: rec, onClick: () => {} } });
+    expect(getByText(/no recoverable contents/i)).toBeTruthy();
+    // The main row button folds the hint into its accessible name.
+    expect(getByRole('button', { name: /no recoverable contents/i })).toBeTruthy();
+  });
+
+  it('shows no hint for a tombstone that still has fields', () => {
+    const rec: RecordDto = { ...REC, tombstoned: true, fieldCount: 4 };
+    const { queryByText } = render(RecordRow, { props: { record: rec, onClick: () => {} } });
+    expect(queryByText(/no recoverable contents/i)).toBeNull();
+  });
+
+  it('shows no hint for a live record', () => {
+    const { queryByText } = render(RecordRow, { props: { record: REC, onClick: () => {} } });
+    expect(queryByText(/no recoverable contents/i)).toBeNull();
+  });
 });

--- a/desktop/tests/records.test.ts
+++ b/desktop/tests/records.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from 'vitest';
+import { isContentlessTombstone } from '../src/lib/records';
+import type { RecordDto } from '../src/lib/ipc';
+
+const base: RecordDto = {
+  recordUuidHex: 'cd',
+  recordType: 'login',
+  tags: [],
+  createdAtMs: 1,
+  lastModMs: 2,
+  fieldCount: 0,
+  fields: []
+};
+
+describe('isContentlessTombstone', () => {
+  it('is true for a tombstoned record with zero fields', () => {
+    expect(isContentlessTombstone({ ...base, tombstoned: true, fieldCount: 0 })).toBe(true);
+  });
+
+  it('is false for a tombstoned record that still has fields', () => {
+    expect(isContentlessTombstone({ ...base, tombstoned: true, fieldCount: 3 })).toBe(false);
+  });
+
+  it('is false for a live record with zero fields', () => {
+    expect(isContentlessTombstone({ ...base, tombstoned: false, fieldCount: 0 })).toBe(false);
+  });
+
+  it('is false for a live record with fields', () => {
+    expect(isContentlessTombstone({ ...base, tombstoned: false, fieldCount: 3 })).toBe(false);
+  });
+
+  it('is false when tombstoned is undefined', () => {
+    expect(isContentlessTombstone({ ...base, fieldCount: 0 })).toBe(false);
+  });
+});

--- a/docs/handoffs/2026-06-08-honest-resurrect-shipped.md
+++ b/docs/handoffs/2026-06-08-honest-resurrect-shipped.md
@@ -1,0 +1,107 @@
+# NEXT_SESSION.md — #196 ✅ honest resurrect for no-content tombstones
+
+**Session date:** 2026-06-08 (follow-on to D.1.15; closes the data-loss-UX bug the D.1.15 GUI smoke surfaced). Brainstormed via `superpowers:brainstorming` → spec via `superpowers:writing-plans` → executed via `superpowers:subagent-driven-development` (fresh implementer per task + spec-compliance + code-quality review after each + a final whole-branch review).
+**Status:** ✅ code-complete on branch `feature/honest-resurrect`. **PR: see §4.** Full **desktop gauntlet green** (478 tests / typecheck / svelte-check / lint). Final whole-branch review: **APPROVE TO MERGE**, zero Critical/Important.
+**⚠️ One outstanding gate — the manual GUI smoke** (this slice ships UI). Not automatable here (macOS Tauri e2e blocked — [#161](https://github.com/hherb/secretary/issues/161)). Needs a real merge-tombstone (the #195 `stage_smoke_vault` helper produces one). Run on a **`cp -R` temp copy** before merging — see §3/§4.
+
+## (1) What we shipped this session
+
+Issue **[#196](https://github.com/hherb/secretary/issues/196)**: resurrecting a record that was tombstoned by a sync merge ("Accept delete") silently brought back an **empty** record (the §11.3 merge-tombstone path drops a record's fields), whereas resurrecting a *locally*-deleted record restores its content — same "Restore" button, different outcome, no signal. Reads as data loss / a broken undelete.
+
+**Key reframe (why this is desktop-only):** the issue feared we'd have to *distinguish merge- vs local-tombstone provenance*, which would mean a new flag on the **frozen** on-disk format + CRDT-proptest risk. Not needed. The user-facing fact is *"will resurrect give back anything?"* — answerable directly from data the desktop **already has on the wire**: `RecordDto` carries `tombstoned` and `fieldCount`, and a merge-tombstoned record arrives with `fieldCount === 0`. So the signal is just **`tombstoned === true && fieldCount === 0`**. No `core`, no FFI, no on-disk-format change, no CRDT-proptest risk → **no cross-language conformance run required.**
+
+**Three UI layers** (all `desktop/`):
+- **`src/lib/records.ts`** (new) — pure predicate `isContentlessTombstone(record)`.
+- **`src/components/RecordRow.svelte`** — a muted italic "· no recoverable contents" hint on contentless-tombstone rows, folded into the row button's `aria-label` (pre-empts the surprise before the click). Style lives in `theme.css` (the component has no scoped styles).
+- **`src/components/RecordList.svelte`** — a `ConfirmDialog` gate: resurrecting a contentless tombstone confirms first ("Resurrect an empty record?"); a still-filled tombstone resurrects one-click (lossless undelete, **unchanged**). Mirrors the existing `pendingDelete`/`confirmDelete` pattern (`pendingRestore`/`confirmRestore`/`doRestore`).
+
+Copy is **content-based, not provenance-asserting** ("This record has no stored contents to recover — … Contents are discarded when a record's deletion is merged from another device."): honest even for the degenerate case of a locally-deleted genuinely-empty record (which also matches the predicate and would equally yield an empty shell).
+
+Commits on `feature/honest-resurrect` (branched from `main` @ `273c79a`):
+
+| Commit | What it landed |
+|---|---|
+| `4a14b13` | design spec |
+| `76a9ba3` | 4-task TDD plan |
+| `5a578c6` | Task 1 — `isContentlessTombstone` predicate + 5 tests |
+| `2449300` / `92e5efa` | Task 2 — RecordRow hint + aria-label (+ DRY ariaLabel review nit) |
+| `862155b` / `81ff69c` | Task 3 — RecordList confirm gate (+ **fix**: a stray editor smart-quote pass had swapped the ASCII `"` ConfirmDialog attribute delimiters for U+201D on **both** dialog blocks, breaking svelte-check — restored ASCII) |
+| `7f5b5d7` | Task 4 — muted italic hint style in `theme.css` |
+| `0d6cc9e` | final-review nit — drop needless `async` on `RecordList.onDelete` (symmetry with the new sync `onRestore`) |
+| _(ship)_ | this handoff + symlink retarget |
+
+**Process note (worth carrying forward):** the editor/disk-desync gremlin in these worktrees struck again — a Task-3 edit silently converted straight `"`/`'` into curly Unicode quotes and broke `svelte-check` (it mis-parsed words inside the attribute strings as unknown component props). Caught by the code-quality reviewer running `svelte-check` (lint alone did NOT catch it — eslint doesn't type-check templates). **Always run `svelte-check`, not just lint, after editing `.svelte` attribute strings**; grep for U+2018/2019/201C/201D delimiters if a parse error names a word-inside-a-string as a bad prop.
+
+### Desktop gauntlet (re-run clean on the branch @ HEAD)
+```
+cd desktop
+pnpm test         → 62 files, 478 tests, 0 failed
+pnpm typecheck    → clean
+pnpm svelte-check → 311 files, 0 errors, 0 warnings
+pnpm lint         → clean
+```
+Rust workspace untouched (no `core`/FFI change) → still green; cross-language conformance **not required** (no FFI-surface change).
+
+## (2) What's next
+
+No slice is pre-committed. Honest next-deferred (pick one → brainstorm → plan → execute):
+
+- **Background auto-sync** — the `notify`-driven daemon loop (C.2 `secretary-sync run`) surfaced in-app so sync happens without a manual click; the pill reflects live status. Acceptance: a vault syncs on file-change with a debounce; the pill updates; must coordinate with `SyncInProgress` (lockfile) so a daemon + a manual click (or an open resolution/resurrect modal) don't fight. Interacts with the D.1.15 resolution flow — a background pass that hits a veto must surface it without stomping an open modal.
+- **[#187](https://github.com/hherb/secretary/issues/187)** — project `sync_vault`/`sync_status`/`sync_commit_decisions` + the conflict DTOs onto uniffi+pyo3 (mobile/Python; pairs with #167). Pure FFI-surface slice; **triggers the full workspace gauntlet + Swift/Kotlin conformance** ([[project_secretary_ffivaulterror_workspace_match]]).
+- **Reveal-to-decide** — let the user inspect the actual winner/loser field values (reveal-gated) to decide a veto/collision. `FieldCollision` already preserves both values; separate reveal-gated feature (out of D.1.15 scope).
+
+**Acceptance criteria for whichever is chosen:** author via `superpowers:brainstorming` → `superpowers:writing-plans`. If it touches `core`/`ffi`/`FfiVaultError`/UDL, the full workspace gauntlet **and** the Swift+Kotlin conformance runs are mandatory; a pure-desktop slice does not need them. Any mutation path needs the confirm + strict typed-error-surfacing care, and a manual GUI smoke on a **`cp -R` temp copy** of the golden vault ([[feedback_smoke_test_temp_copy_golden_vault]]).
+
+**Open follow-up issues:** **#192** (collision-population test), **#193** (pipeline.rs refactor/real-race/orphaned-pass), plus carried **#186/#189/#190/#161/#162/#167/#187**.
+
+## (3) Open decisions and risks
+
+- **⚠️ Outstanding gate: the manual GUI smoke (do before merge).** Build a real merge-tombstone on a temp golden copy via the #195 `stage_smoke_vault` helper; verify: deleted-list row shows the "no recoverable contents" badge → Restore opens the confirm with the empty-record copy → Confirm brings back the empty record (expected now, explained) and the badge is gone → on a fresh run, Cancel/Esc closes without writing. See §4.
+- **Predicate matches a degenerate local case too.** A genuinely-empty *locally*-deleted record (fieldCount 0) also trips the hint+confirm. Accepted: resurrect *would* yield an empty shell, so the warning is honest; the body's first sentence ("no stored contents to recover") is the operative truth, the "merged from another device" sentence is the common-cause explanation. Near-zero-probability workflow; the tradeoff buys "no provenance flag on the frozen format". Documented in the `isContentlessTombstone` JSDoc.
+- **No core/format/CRDT change** — the §11.3 field-drop on merge-tombstone is correct and unchanged; this slice is purely how the *desktop* presents the consequence.
+
+### Verified non-issues (don't re-investigate)
+- **Delete-confirm flow intact:** `pendingDelete`/`confirmDelete`/the delete dialog are byte-identical to `main` after the encoding fix; reviewer confirmed.
+- **Accessibility:** `aria-label` overrides the button's inner text for the accessible name, so the visible hint span does **not** double-announce; the "Restore record" label is on the separate action button.
+- **Encoding:** ConfirmDialog attribute delimiters are ASCII `"` on both blocks (`grep -nP '=[\x{201C}\x{201D}]' desktop/src/components/RecordList.svelte` → empty). The em-dash and the pre-existing curly "Show deleted" are content, not delimiters.
+
+## (4) Exact commands to resume
+
+```bash
+# 0) Manual GUI smoke BEFORE merging (the one outstanding gate). Build a real merge-tombstone:
+cd /Users/hherb/src/secretary/.worktrees/honest-resurrect
+SMOKE_OUT=/tmp/veto_smoke cargo test --release -p secretary-cli --test sync_pass_integration -- --ignored stage_smoke_vault --nocapture
+cd desktop && pnpm tauri dev
+#   open /tmp/veto_smoke → Sync now → Accept delete (merge-tombstones the record)
+#   → Show deleted → row shows "no recoverable contents" badge
+#   → Restore → confirm dialog with the empty-record copy
+#   → Confirm → empty record returns (expected, explained); badge gone
+#   → (fresh run) Cancel/Esc → no change, dialog closes. Record in the PR.
+
+# 1) PR (created this session — confirm / review):
+cd /Users/hherb/src/secretary && gh pr list --head feature/honest-resurrect
+
+# 2) Merge once the smoke passes (squash), then housekeeping:
+git fetch --prune origin && git checkout main && git pull --ff-only origin main
+git worktree remove .worktrees/honest-resurrect && git branch -D feature/honest-resurrect
+git worktree prune && git worktree list
+
+# 3) Next slice: brainstorm → plan → execute (see §2). First worktree:
+git worktree add .worktrees/<slug> -b feature/<slug> main
+```
+
+## (5) Handoff file model
+
+`NEXT_SESSION.md` at the repo root is a **relative symlink** to the latest file in `docs/handoffs/` (this file). Author the handoff once; the symlink is a pointer. To open the next slice: author `docs/handoffs/<date>-<slug>-shipped.md` and `ln -snf docs/handoffs/<new>.md NEXT_SESSION.md`, committing both on the feature branch (per [[feedback_next_session_in_pr]]). main did NOT move during this session (branch point == origin/main == `273c79a`), so the symlink retarget merges cleanly.
+
+## Closing inventory
+
+- **Branch on close:** `main` @ `273c79a`; `feature/honest-resurrect` carries spec + plan + 6 task/review/style commits + this ship commit. Squash-merge collapses to one commit on `main`.
+- **Desktop gauntlet:** green — 478 tests / typecheck / svelte-check (0/0) / lint. Rust untouched; no conformance run needed.
+- **Final whole-branch review:** **APPROVE TO MERGE** — zero Critical/Important; one Minor (`onDelete` async nit) fixed in `0d6cc9e`.
+- **Outstanding gate:** the manual GUI smoke (§3/§4) — this slice ships UI; needs a real merge-tombstone fixture.
+- **README.md / ROADMAP.md:** unchanged — neither tracks individual bug-fix PR numbers, and both already cover D.1.15; nothing became inaccurate. (Deliberate no-op, not an oversight.)
+- **CLAUDE.md / `docs/adr/`:** unchanged (no new on-disk-format/crypto decision).
+- **Issues:** #196 fixed by this branch (close on merge). #192/#193 + #186/#189/#190/#161/#162/#167/#187 remain open.
+- **NEXT_SESSION.md:** symlink retargeted to this file.
+- **This file:** the live #196 ship baton. The next slice opens with `docs/handoffs/<date>-<slug>-shipped.md`.

--- a/docs/superpowers/plans/2026-06-08-honest-resurrect.md
+++ b/docs/superpowers/plans/2026-06-08-honest-resurrect.md
@@ -1,0 +1,498 @@
+# Honest Resurrect for No-Content Tombstones — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Stop the silent "empty record" surprise when resurrecting a merge-tombstoned record — pre-empt it with a row hint and a confirm dialog, keyed on content-emptiness.
+
+**Architecture:** Desktop-only. `RecordDto` already carries `tombstoned` and `fieldCount`, so a no-content tombstone (`tombstoned && fieldCount === 0`) is detectable in the UI with no `core`/FFI/on-disk-format change. A pure predicate drives both a `RecordRow` badge and a `RecordList` confirm gate; has-content resurrect stays one-click.
+
+**Tech Stack:** Svelte 5 (runes), TypeScript, Vitest + `@testing-library/svelte`, jsdom. All work under `desktop/`.
+
+**Spec:** [`docs/superpowers/specs/2026-06-08-honest-resurrect-design.md`](../specs/2026-06-08-honest-resurrect-design.md)
+
+**Working directory:** `/Users/hherb/src/secretary/.worktrees/honest-resurrect` on branch `feature/honest-resurrect`. All `pnpm`/`git` commands below assume you have `cd`'d into `desktop/` for `pnpm` and the worktree root for `git` — chain `cd` in each Bash call (shell state does not persist between calls).
+
+---
+
+### Task 1: Pure predicate `isContentlessTombstone`
+
+**Files:**
+- Create: `desktop/src/lib/records.ts`
+- Test: `desktop/tests/records.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `desktop/tests/records.test.ts`:
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { isContentlessTombstone } from '../src/lib/records';
+import type { RecordDto } from '../src/lib/ipc';
+
+const base: RecordDto = {
+  recordUuidHex: 'cd',
+  recordType: 'login',
+  tags: [],
+  createdAtMs: 1,
+  lastModMs: 2,
+  fieldCount: 0,
+  fields: []
+};
+
+describe('isContentlessTombstone', () => {
+  it('is true for a tombstoned record with zero fields', () => {
+    expect(isContentlessTombstone({ ...base, tombstoned: true, fieldCount: 0 })).toBe(true);
+  });
+
+  it('is false for a tombstoned record that still has fields', () => {
+    expect(isContentlessTombstone({ ...base, tombstoned: true, fieldCount: 3 })).toBe(false);
+  });
+
+  it('is false for a live record with zero fields', () => {
+    expect(isContentlessTombstone({ ...base, tombstoned: false, fieldCount: 0 })).toBe(false);
+  });
+
+  it('is false for a live record with fields', () => {
+    expect(isContentlessTombstone({ ...base, tombstoned: false, fieldCount: 3 })).toBe(false);
+  });
+
+  it('is false when tombstoned is undefined', () => {
+    expect(isContentlessTombstone({ ...base, fieldCount: 0 })).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd desktop && pnpm vitest run tests/records.test.ts`
+Expected: FAIL — `Failed to resolve import "../src/lib/records"` (module does not exist yet).
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `desktop/src/lib/records.ts`:
+
+```ts
+import type { RecordDto } from './ipc';
+
+/**
+ * True iff resurrecting this record would yield an empty shell — a tombstoned
+ * record whose fields were dropped. The §11.3 merge-tombstone path empties a
+ * record's fields; a local delete preserves them. We key on content-emptiness
+ * (not tombstone provenance) because that is exactly the user-facing fact —
+ * "there is nothing to restore" — and it needs no provenance flag on the
+ * frozen on-disk format.
+ */
+export function isContentlessTombstone(record: RecordDto): boolean {
+  return record.tombstoned === true && record.fieldCount === 0;
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd desktop && pnpm vitest run tests/records.test.ts`
+Expected: PASS — 5 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /Users/hherb/src/secretary/.worktrees/honest-resurrect
+git add desktop/src/lib/records.ts desktop/tests/records.test.ts
+git commit -m "feat(desktop): isContentlessTombstone predicate (#196)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: `RecordRow` — no-recoverable-contents badge + aria-label
+
+**Files:**
+- Modify: `desktop/src/components/RecordRow.svelte`
+- Test: `desktop/tests/RecordRow.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Append these cases to `desktop/tests/RecordRow.test.ts` inside the existing `describe('RecordRow', ...)` block (after the existing `it(...)` calls). Also add `queryByText`/`getByRole` usage — they come from the same `render` return:
+
+```ts
+  it('shows a "no recoverable contents" hint for a contentless tombstone', () => {
+    const rec: RecordDto = { ...REC, tombstoned: true, fieldCount: 0 };
+    const { getByText, getByRole } = render(RecordRow, { props: { record: rec, onClick: () => {} } });
+    expect(getByText(/no recoverable contents/i)).toBeTruthy();
+    // The main row button folds the hint into its accessible name.
+    expect(getByRole('button', { name: /no recoverable contents/i })).toBeTruthy();
+  });
+
+  it('shows no hint for a tombstone that still has fields', () => {
+    const rec: RecordDto = { ...REC, tombstoned: true, fieldCount: 4 };
+    const { queryByText } = render(RecordRow, { props: { record: rec, onClick: () => {} } });
+    expect(queryByText(/no recoverable contents/i)).toBeNull();
+  });
+
+  it('shows no hint for a live record', () => {
+    const { queryByText } = render(RecordRow, { props: { record: REC, onClick: () => {} } });
+    expect(queryByText(/no recoverable contents/i)).toBeNull();
+  });
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd desktop && pnpm vitest run tests/RecordRow.test.ts`
+Expected: FAIL — the new `getByText(/no recoverable contents/i)` finds nothing.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Edit `desktop/src/components/RecordRow.svelte`.
+
+In the `<script>` block, add the import and two derived values. After the existing import lines (lines 2-3) add:
+
+```ts
+  import { isContentlessTombstone } from '../lib/records';
+```
+
+After the existing `let deleted = $derived(record.tombstoned === true);` line, add:
+
+```ts
+  let contentless = $derived(isContentlessTombstone(record));
+  let ariaLabel = $derived(
+    contentless
+      ? `${record.recordType} record, ${countLabel}, no recoverable contents`
+      : `${record.recordType} record, ${countLabel}`
+  );
+```
+
+Change the main button's `aria-label` from:
+
+```svelte
+    aria-label={`${record.recordType} record, ${countLabel}`}
+```
+
+to:
+
+```svelte
+    aria-label={ariaLabel}
+```
+
+Then, inside the main button, immediately after the meta `<span>` (the `record-row__meta` line), add the visible hint:
+
+```svelte
+    {#if contentless}
+      <span class="record-row__no-content">· no recoverable contents</span>
+    {/if}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd desktop && pnpm vitest run tests/RecordRow.test.ts`
+Expected: PASS — all original + 3 new tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /Users/hherb/src/secretary/.worktrees/honest-resurrect
+git add desktop/src/components/RecordRow.svelte desktop/tests/RecordRow.test.ts
+git commit -m "feat(desktop): RecordRow no-recoverable-contents hint (#196)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 3: `RecordList` — confirm gate on contentless resurrect
+
+**Files:**
+- Modify: `desktop/src/components/RecordList.svelte`
+- Test: `desktop/tests/RecordListRestore.test.ts` (new)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `desktop/tests/RecordListRestore.test.ts` (mirrors the structure of `RecordListDelete.test.ts`):
+
+```ts
+// Tests for the RecordList resurrect gate: a contentless tombstone
+// (fieldCount 0) routes through a ConfirmDialog before resurrect_record;
+// a tombstone that still has fields resurrects one-click.
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, fireEvent, waitFor } from '@testing-library/svelte';
+
+const { invokeMock } = vi.hoisted(() => ({ invokeMock: vi.fn() }));
+vi.mock('@tauri-apps/api/core', () => ({ invoke: invokeMock }));
+
+import RecordList from '../src/components/RecordList.svelte';
+import type { BlockSummaryDto } from '../src/lib/ipc';
+
+const BLOCK: BlockSummaryDto = { blockUuidHex: 'ab', blockName: 'Personal logins', createdAtMs: 1, lastModifiedMs: 2 };
+
+const EMPTY_TOMBSTONE = {
+  recordUuidHex: 'cd', recordType: 'login', tags: [] as string[],
+  fieldCount: 0, lastModMs: 5, tombstoned: true, fields: []
+};
+const FILLED_TOMBSTONE = {
+  recordUuidHex: 'ef', recordType: 'login', tags: [] as string[],
+  fieldCount: 2, lastModMs: 5, tombstoned: true, fields: []
+};
+
+function mockReadReturning(record: unknown) {
+  invokeMock.mockImplementation((cmd: string) => {
+    if (cmd === 'read_block') {
+      return Promise.resolve({ blockUuidHex: 'ab', blockName: 'Personal logins', records: [record] });
+    }
+    return Promise.resolve(null); // resurrect_record + any teardown invoke
+  });
+}
+
+const calledResurrect = () => invokeMock.mock.calls.some(([c]) => c === 'resurrect_record');
+
+describe('RecordList — contentless resurrect confirm gate', () => {
+  beforeEach(() => invokeMock.mockReset());
+
+  it('opens a confirm and does NOT resurrect until confirmed', async () => {
+    mockReadReturning(EMPTY_TOMBSTONE);
+    const { getByLabelText, container } = render(RecordList, { props: { block: BLOCK } });
+
+    const restoreBtn = await waitFor(() => getByLabelText('Restore record'));
+    await fireEvent.click(restoreBtn);
+
+    // ConfirmDialog mounts; resurrect must not have fired yet.
+    await waitFor(() => {
+      if (!container.querySelector('.confirm-dialog__button--danger')) {
+        throw new Error('confirm dialog not yet mounted');
+      }
+    });
+    expect(calledResurrect()).toBe(false);
+  });
+
+  it('confirming invokes resurrect_record and reloads', async () => {
+    mockReadReturning(EMPTY_TOMBSTONE);
+    const { getByLabelText, container } = render(RecordList, { props: { block: BLOCK } });
+
+    const restoreBtn = await waitFor(() => getByLabelText('Restore record'));
+    await fireEvent.click(restoreBtn);
+
+    const confirmBtn = await waitFor(() => {
+      const el = container.querySelector('.confirm-dialog__button--danger');
+      if (!el) throw new Error('confirm dialog not yet mounted');
+      return el as HTMLButtonElement;
+    });
+    await fireEvent.click(confirmBtn);
+
+    await waitFor(() =>
+      expect(invokeMock).toHaveBeenCalledWith('resurrect_record', { blockUuidHex: 'ab', recordUuidHex: 'cd' })
+    );
+    await waitFor(() =>
+      expect(invokeMock.mock.calls.filter(([c]) => c === 'read_block').length).toBeGreaterThanOrEqual(2)
+    );
+  });
+
+  it('cancelling closes the dialog without resurrecting', async () => {
+    mockReadReturning(EMPTY_TOMBSTONE);
+    const { getByLabelText, getByText, container } = render(RecordList, { props: { block: BLOCK } });
+
+    const restoreBtn = await waitFor(() => getByLabelText('Restore record'));
+    await fireEvent.click(restoreBtn);
+
+    const cancelBtn = await waitFor(() => getByText('Cancel'));
+    await fireEvent.click(cancelBtn);
+
+    await waitFor(() => {
+      if (container.querySelector('.confirm-dialog__button--danger')) {
+        throw new Error('confirm dialog still mounted');
+      }
+    });
+    expect(calledResurrect()).toBe(false);
+  });
+
+  it('resurrects a still-filled tombstone one-click (no confirm)', async () => {
+    mockReadReturning(FILLED_TOMBSTONE);
+    const { getByLabelText, container } = render(RecordList, { props: { block: BLOCK } });
+
+    const restoreBtn = await waitFor(() => getByLabelText('Restore record'));
+    await fireEvent.click(restoreBtn);
+
+    await waitFor(() =>
+      expect(invokeMock).toHaveBeenCalledWith('resurrect_record', { blockUuidHex: 'ab', recordUuidHex: 'ef' })
+    );
+    expect(container.querySelector('.confirm-dialog__button--danger')).toBeNull();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd desktop && pnpm vitest run tests/RecordListRestore.test.ts`
+Expected: FAIL — the first two tests fail because today `onRestore` resurrects immediately (no confirm dialog mounts; `resurrect_record` fires before any confirm).
+
+- [ ] **Step 3: Write minimal implementation**
+
+Edit `desktop/src/components/RecordList.svelte`.
+
+Add the import to the existing `../lib/ipc` import group is not needed; instead add a new import after the `ConfirmDialog` import (line 14):
+
+```ts
+  import { isContentlessTombstone } from '../lib/records';
+```
+
+After the existing `let pendingDelete = $state<RecordDto | null>(null);` line, add:
+
+```ts
+  // Record awaiting resurrect confirmation (only set for a contentless
+  // tombstone — a resurrect that would bring back an empty shell).
+  let pendingRestore = $state<RecordDto | null>(null);
+```
+
+Replace the existing `onRestore` function:
+
+```ts
+  async function onRestore(record: RecordDto) {
+    error = null;
+    try {
+      await resurrectRecord(block.blockUuidHex, record.recordUuidHex);
+      await load();
+    } catch (e) {
+      error = isAppError(e) ? e : { code: 'internal' };
+    }
+  }
+```
+
+with this gate + shared worker + confirm handler:
+
+```ts
+  function onRestore(record: RecordDto) {
+    // A contentless tombstone resurrects to an empty shell — confirm first so
+    // the empty result is expected, not a surprise. A still-filled tombstone
+    // resurrects one-click (lossless undelete, unchanged behaviour).
+    if (isContentlessTombstone(record)) {
+      pendingRestore = record;
+      return;
+    }
+    void doRestore(record);
+  }
+
+  async function doRestore(record: RecordDto) {
+    error = null;
+    try {
+      await resurrectRecord(block.blockUuidHex, record.recordUuidHex);
+      await load();
+    } catch (e) {
+      error = isAppError(e) ? e : { code: 'internal' };
+    }
+  }
+
+  async function confirmRestore() {
+    const target = pendingRestore;
+    if (!target) return;
+    pendingRestore = null;
+    await doRestore(target);
+  }
+```
+
+Finally, after the existing `{#if pendingDelete} ... {/if}` ConfirmDialog block (lines 111-119), add a second dialog:
+
+```svelte
+{#if pendingRestore}
+  <ConfirmDialog
+    title="Resurrect an empty record?"
+    body="This record has no stored contents to recover — resurrecting brings it back with only its type and tags. Contents are discarded when a record's deletion is merged from another device."
+    confirmLabel="Resurrect"
+    onConfirm={confirmRestore}
+    onCancel={() => (pendingRestore = null)}
+  />
+{/if}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd desktop && pnpm vitest run tests/RecordListRestore.test.ts`
+Expected: PASS — 4 tests. Also re-run the sibling delete suite to confirm no regression: `cd desktop && pnpm vitest run tests/RecordListDelete.test.ts` → PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /Users/hherb/src/secretary/.worktrees/honest-resurrect
+git add desktop/src/components/RecordList.svelte desktop/tests/RecordListRestore.test.ts
+git commit -m "feat(desktop): confirm gate on resurrecting an empty-shell tombstone (#196)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 4: Style the hint + full desktop gauntlet + docs
+
+**Files:**
+- Modify: `desktop/src/components/RecordRow.svelte` (CSS only — the `.record-row__no-content` style)
+- Modify: `ROADMAP.md` (note #196 fixed, if it tracks D.1.x desktop items)
+
+- [ ] **Step 1: Add a muted style for the hint**
+
+In `desktop/src/components/RecordRow.svelte`, inside the existing `<style>` block, add a rule consistent with the existing `record-row__meta` muting (match the surrounding palette — find the `.record-row__meta` rule and mirror its muted color):
+
+```css
+  .record-row__no-content {
+    color: var(--color-text-muted, #888);
+    font-style: italic;
+    margin-left: 0.25rem;
+  }
+```
+
+If the file uses a different muted-color token, use that token instead — grep the file's `<style>` for the color used by `.record-row__meta` and reuse it. This is cosmetic; no new test.
+
+- [ ] **Step 2: Run the full desktop gauntlet**
+
+```bash
+cd desktop
+pnpm test
+pnpm typecheck
+pnpm svelte-check
+pnpm lint
+```
+
+Expected: all green. (`pnpm test` runs the whole suite including the three new/edited files; `svelte-check` must report 0 errors / 0 warnings.)
+
+- [ ] **Step 3: Update ROADMAP / README if they track this**
+
+Run: `cd /Users/hherb/src/secretary/.worktrees/honest-resurrect && grep -n "196\|resurrect\|D.1.15\|tombstone" ROADMAP.md README.md`
+
+- If `ROADMAP.md` has a desktop/D.1.x bug-tracking line where a "#196 honest resurrect" entry belongs, add a one-line entry noting it shipped 2026-06-08.
+- `README.md` status sections stay brief (per the project's README style) — only touch it if it enumerates desktop record-management features and would now be inaccurate. If neither needs a change, skip this step (do not invent content).
+
+- [ ] **Step 4: Commit any doc/style changes**
+
+```bash
+cd /Users/hherb/src/secretary/.worktrees/honest-resurrect
+git add desktop/src/components/RecordRow.svelte ROADMAP.md README.md
+git commit -m "docs+style(desktop): muted resurrect hint + ROADMAP #196 (#196)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+(If only `RecordRow.svelte` changed, stage just that file.)
+
+---
+
+## Manual GUI smoke (pre-merge gate — not automatable here)
+
+Per the spec §5. Run on a `cp -R` temp copy; reuses the #195 helper:
+
+```bash
+cd /Users/hherb/src/secretary/.worktrees/honest-resurrect
+SMOKE_OUT=/tmp/veto_smoke cargo test --release -p secretary-cli --test sync_pass_integration -- --ignored stage_smoke_vault --nocapture
+cd desktop && pnpm tauri dev
+# open /tmp/veto_smoke → Sync now → Accept delete (merge-tombstones the record)
+# → Show deleted → row shows "no recoverable contents" badge
+# → Restore → confirm dialog with the empty-record copy
+# → Confirm → empty record returns (expected, explained); badge gone
+# → (fresh run) Cancel → no change, dialog closes
+```
+
+Record the result in the PR description.
+
+---
+
+## Self-Review
+
+- **Spec coverage:** §1 predicate → Task 1; §2 row hint → Task 2 (+ Task 4 style); §3 confirm gate → Task 3; §4 tests → distributed across Tasks 1-3; §5 manual smoke → dedicated section. ✓
+- **Type consistency:** `isContentlessTombstone(record: RecordDto): boolean` defined Task 1, imported identically in Tasks 2 & 3. `pendingRestore` / `doRestore` / `confirmRestore` introduced together in Task 3 and self-consistent. `RecordDto` fields used (`tombstoned`, `fieldCount`, `recordType`, `tags`, `recordUuidHex`, `lastModMs`, `fields`) all exist in `desktop/src/lib/ipc.ts`. ✓
+- **No placeholders:** every code/edit step shows full content; the only conditional step (Task 4 docs) has an explicit "skip if not applicable, do not invent" instruction. ✓
+- **Scope:** single subsystem (desktop), one plan. No FFI/core change → no cross-language conformance required. ✓

--- a/docs/superpowers/specs/2026-06-08-honest-resurrect-design.md
+++ b/docs/superpowers/specs/2026-06-08-honest-resurrect-design.md
@@ -1,0 +1,149 @@
+# Honest resurrect for no-content tombstones — design (#196)
+
+**Date:** 2026-06-08
+**Issue:** [#196](https://github.com/hherb/secretary/issues/196)
+**Scope:** desktop-only (no `core`, no FFI, no on-disk-format change)
+
+## Problem
+
+The per-record **resurrect** control (the D.1.5 "Show deleted" → Restore surface)
+behaves differently depending on how the record was tombstoned, with no signal to
+the user:
+
+- **Local delete** keeps the record's fields (`tombstone_record` in
+  `ffi/secretary-ffi-bridge/src/edit/tombstone.rs`: *"Fields are NOT cleared — the
+  record stays fully resurrectable."*). Resurrect restores the content — lossless.
+- **Merge tombstone** (accepting a sync delete) empties the fields per §11.3
+  (`core/src/vault/conflict.rs`: *"a tombstoned merged record carries empty `fields`
+  regardless of either input's fields"* → `(BTreeMap::new(), Vec::new())`).
+  Resurrect then brings back an **empty shell** (uuid + type + tags only).
+
+The same Restore button yields content in one case and an empty record in the other,
+and the user can't tell which they are looking at. An empty result with no explanation
+reads as data loss / a broken undelete. This is **§11.3-correct** behavior — "Accept
+delete" means the other device's deletion wins and the local payload is intentionally
+discarded — but the UX hides that from the user.
+
+## Key reframe: detect content-emptiness, not tombstone provenance
+
+The issue frames the hard part as *distinguishing a merge-tombstone from a local
+tombstone* — which would require recording provenance on the **frozen** on-disk record
+format and risk perturbing the CRDT merge proptests.
+
+That distinction is not actually needed. What we want to tell the user is *"will
+resurrect give you back something useful?"* — and that is answerable directly from data
+the desktop **already has on the wire**. `RecordDto` carries both `tombstoned` and
+`fieldCount`:
+
+- a merge-tombstoned record arrives with `fieldCount === 0` (§11.3 dropped its fields);
+- a locally-deleted record keeps `fieldCount > 0`.
+
+So the signal is simply **`tombstoned === true && fieldCount === 0`**. No `core` change,
+no on-disk-format perturbation, no CRDT proptest risk. The slice is desktop-only, and
+therefore does **not** require the cross-language conformance run (Swift/Kotlin/Python) —
+only the desktop gauntlet.
+
+> Edge note: a genuinely-empty record that was *locally* deleted also matches this
+> predicate. That is acceptable and in fact correct — resurrecting it would equally yield
+> an empty shell, so warning is honest. The user-facing copy is therefore phrased around
+> *content-emptiness*, not around an asserted "deleted on another device" provenance.
+
+## Design
+
+### 1. Pure predicate — new reusable module `desktop/src/lib/records.ts`
+
+A new one-concept module for record-display derivations (keeps the predicate free,
+side-effect-free, and independently testable — per the project's "pure functions in
+reusable modules" principle, and avoids bloating `editor.ts`/`browse.ts`, which own
+unrelated concerns):
+
+```ts
+import type { RecordDto } from './ipc';
+
+/**
+ * True iff resurrecting this record would yield an empty shell — a tombstoned
+ * record whose fields were dropped. The §11.3 merge-tombstone path empties a
+ * record's fields; a local delete preserves them. We key on content-emptiness
+ * (not tombstone provenance) because that is exactly the user-facing fact —
+ * "there is nothing to restore" — and it needs no provenance flag on the
+ * frozen on-disk format.
+ */
+export function isContentlessTombstone(record: RecordDto): boolean {
+  return record.tombstoned === true && record.fieldCount === 0;
+}
+```
+
+### 2. Row hint — `RecordRow.svelte`
+
+When `isContentlessTombstone(record)`, render a muted badge after the meta line
+(e.g. `· no recoverable contents`) and fold the same text into the row's `aria-label`
+so assistive tech receives it. The Restore button itself is unchanged. This pre-empts
+the surprise *before* the user clicks.
+
+### 3. Confirm gate on resurrect — `RecordList.svelte`
+
+`onRestore(record)` branches:
+
+- **contentless tombstone** → set `pendingRestore = record`, mounting a second
+  `ConfirmDialog` (the same component the delete flow already uses).
+- **has content** → resurrect immediately (today's one-click behavior, unchanged).
+
+A new `confirmRestore()` performs the actual `resurrectRecord` + `load()` (mirroring
+`confirmDelete`). `pendingRestore` is nulled on confirm and on cancel.
+
+Confirm copy (content-based, honest, not provenance-asserting):
+
+> **Resurrect an empty record?**
+> This record has no stored contents to recover — resurrecting brings it back with only
+> its type and tags. (Contents are discarded when a record's deletion is merged from
+> another device.)
+>
+> confirmLabel: **Resurrect**
+
+### 4. Tests (vitest)
+
+- `desktop/src/lib/records.test.ts` — predicate truth table:
+  tombstoned + 0 fields → `true`; tombstoned + N fields → `false`;
+  live + 0 fields → `false`; live + N fields → `false`;
+  `tombstoned` undefined → `false`.
+- `RecordRow` test — the badge renders **iff** contentless tombstone, and the
+  `aria-label` includes the hint text; a has-content tombstone and a live row do not.
+- `RecordList` test —
+  - resurrecting a contentless tombstone opens the confirm and does **not** call
+    `resurrectRecord` until confirmed;
+  - confirm → calls `resurrectRecord` + reloads;
+  - cancel → no IPC call, dialog closes;
+  - resurrecting a has-content tombstone → immediate `resurrectRecord`, no confirm.
+
+### 5. Manual GUI smoke (the one gate)
+
+Reuse the #195 `stage_smoke_vault` helper on a `cp -R` temp copy of the golden vault to
+produce a real merge-tombstone, then verify end-to-end:
+
+1. `SMOKE_OUT=/tmp/veto_smoke cargo test --release -p secretary-cli --test sync_pass_integration -- --ignored stage_smoke_vault --nocapture`
+2. `cd desktop && pnpm tauri dev`, open `/tmp/veto_smoke`, **Sync now** → resolution
+   modal → **Accept delete** (merge-tombstones the record).
+3. Enable **Show deleted** → the row shows the `no recoverable contents` badge.
+4. Click **Restore** → the confirm appears with the empty-record copy.
+5. Confirm → the empty record comes back (expected now, and explained); the badge is
+   gone (it is live). Cancel on a fresh run → no change, dialog closes.
+
+## Out of scope (YAGNI)
+
+- No provenance flag, no `core` / bridge / on-disk-format change.
+- No reveal of winner/loser field values (that is the separate "reveal-to-decide" slice).
+- No change to has-content (local-delete) resurrect — it stays one-click.
+
+## Verification
+
+Desktop gauntlet only (Rust workspace untouched, so still green):
+
+```
+cd desktop
+pnpm test         # records.test.ts + RecordRow + RecordList assertions
+pnpm typecheck
+pnpm svelte-check
+pnpm lint
+```
+
+Cross-language conformance is **not** required (no FFI surface change).


### PR DESCRIPTION
Fixes #196.

## What & why

Resurrecting a record tombstoned by a sync merge ("Accept delete") silently brought back an **empty** record — the §11.3 merge-tombstone path drops a record's fields — while resurrecting a *locally*-deleted record restores its content. Same "Restore" button, different outcome, no signal → reads as data loss / a broken undelete.

## Key reframe (keeps it desktop-only)

The issue feared we'd need to record merge- vs local-tombstone **provenance** on the frozen on-disk format (CRDT-proptest risk). Not needed: the user-facing fact is *"will resurrect give back anything?"*, which is just **`tombstoned === true && fieldCount === 0`** — data the desktop already has on the wire (`RecordDto`). **No `core` / FFI / on-disk-format / CRDT change → no cross-language conformance run required.**

## Changes (all `desktop/`)

- `src/lib/records.ts` (new) — pure predicate `isContentlessTombstone`.
- `src/components/RecordRow.svelte` — muted italic "· no recoverable contents" hint on contentless-tombstone rows, folded into the row button's `aria-label` (pre-empts the surprise before the click).
- `src/components/RecordList.svelte` — a `ConfirmDialog` gate: a contentless tombstone confirms first ("Resurrect an empty record?"); a still-filled tombstone resurrects one-click (lossless undelete, **unchanged**). Mirrors the existing delete-confirm pattern.
- `src/theme.css` — muted style for the hint.

Copy is content-based, not provenance-asserting (honest even for the degenerate locally-deleted-empty case, which also matches the predicate).

## Verification

Desktop gauntlet green: **478 tests** / typecheck / svelte-check (0/0) / lint. Rust untouched. Built via brainstorm → spec → 4-task TDD plan → subagent-driven execution (spec + code-quality review per task + a final whole-branch review: **APPROVE TO MERGE**, zero Critical/Important).

## ⚠️ Outstanding pre-merge gate — manual GUI smoke (not run yet)

This slice ships UI; macOS Tauri e2e is blocked (#161), so the visual smoke is **not** automated. Before merging, on a `cp -R` temp copy, build a real merge-tombstone via the #195 `stage_smoke_vault` helper and verify the badge → confirm → empty-record-returns → cancel-no-write flow. Commands in `NEXT_SESSION.md` §4. **Do not merge until this is recorded.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)