### PR TITLE
docs: D.4 browser autofill — ADR 0010, threat-model §6, design spec, D.4.1 plan

### DIFF
--- a/NEXTSESSION_BROWSER_PLUGIN.md
+++ b/NEXTSESSION_BROWSER_PLUGIN.md
@@ -1,0 +1,86 @@
+# NEXTSESSION_BROWSER_PLUGIN.md — start here for D.4 (browser autofill)
+
+> **Standalone handoff for the browser-plugin track.** This file is deliberately **not** the
+> `NEXT_SESSION.md` symlink (that points at the latest `docs/handoffs/` entry for the main
+> line of work). The browser-plugin track runs **parallel** to other Secretary sessions; keep
+> its handoff here so the two don't collide. Do a worktree (`.worktrees/`) per CLAUDE.md
+> "Working directory discipline" so a parallel window can't switch branches under you.
+
+## TL;DR
+
+Planning is done and merged. The next session **implements D.4.1** — a native-messaging
+*walking skeleton*: a browser extension + a small Rust host that complete one
+`query → available{count:0}` **no-op** round trip. **No crypto, no vault, no `secretary-core`
+dependency, no fill.** It exists only to prove the channel before any feature work.
+
+## Read these first (all on `main`)
+
+1. `docs/adr/0010-browser-autofill-native-messaging.md` — **the decision** (why thin-courier +
+   native messaging + per-fill open + cryptographic vault tiering).
+2. `docs/threat-model.md` **§6** — the browser-extension adversary model + the structural
+   invariants D.4.1 must preserve.
+3. `docs/superpowers/specs/2026-06-15-d4-browser-autofill-design.md` — **the build plan** for the
+   whole sub-project. §10 records every resolved decision (fill-only for v1, helper-local
+   binding default, Safari = App-Extension, TOTP in v1, etc.).
+4. `docs/superpowers/specs/2026-06-16-d41-native-messaging-skeleton-plan.md` — **the slice you
+   are building.** Layout, framing codec, host manifest, the 6-task breakdown, and the DoD.
+
+## What D.4.1 ships (from the plan §1)
+
+- `browser/secretary-browser-host/` — a **new Rust crate, a workspace member** (so it inherits
+  `#![forbid(unsafe_code)]` + clippy `-D warnings`). stdin/stdout framed read→handle→write loop.
+  **No `secretary-core` dep yet** (D.4.2 adds it).
+- `browser/extension/` — Chromium MV3 extension that `connectNative`s, sends `query`, logs
+  `available`.
+- `browser/host-manifest/` — dev manifest binding host ↔ extension ID + per-OS install notes.
+
+## Task order (plan §6) — start with 1–2, the load-bearing core
+
+1. **Host crate + `frame.rs` framing codec** — 4-byte native-endian length prefix, **1 MiB
+   cap**, **no panic on malformed input** (return `Result`, mirroring the fuzz "assert Result,
+   not panic" contract). Unit-test every branch: round-trip, oversize→`TooLarge`, truncated
+   length, non-JSON body, EOF→clean shutdown.
+2. **`protocol.rs` + `main.rs` loop** — serde `query`/`available`/`error`; no-op handler returns
+   `available{count:0}` + a fresh `request_id` UUID. `tests/echo.rs`: pipe a `query` frame in,
+   assert an `available` frame out; unknown type → `error`.
+3. Chromium MV3 extension scaffold (reuse `desktop/` pnpm/tsconfig conventions).
+4. `host-manifest/` dev manifest + macOS/Linux install README.
+5. Wire the host crate into `cargo test --release --workspace`; clippy `-D warnings` clean.
+6. `browser/README.md` + a `docs/handoffs/2026-..-d41-shipped.md` handoff, then update **this
+   file** to point at D.4.2.
+
+Tasks 1, 2, 5 are fully CI-gated in Rust. Tasks 3–4 carry a **documented manual browser smoke**
+(load-unpacked + installed manifest → console shows the round trip) — same posture as the iOS
+on-device proof; automated browser-driver e2e is a later optional add, not D.4.1.
+
+## Guardrails (must hold — these are the DoD, plan §8)
+
+- **No `core/`, `ffi/`, `ios/`, `android/`, or on-disk-format change.** D.4.1 is purely additive
+  under `browser/` + `docs/`. Guardrail grep before you push:
+  `git diff main...HEAD --name-only | grep -vE '^(browser/|docs/|Cargo\.(toml|lock)|README\.md|ROADMAP\.md|NEXTSESSION_BROWSER_PLUGIN\.md)'` → expect empty.
+  (The only root touch allowed is adding the new crate to the workspace members in `Cargo.toml`.)
+- **No listening socket** — the host speaks only over the browser-provided stdio. This is the
+  whole point of the slice (threat-model §6 invariant 3).
+- **No key material, no vault open** — trivially true (no `secretary-core` dep). Don't add one;
+  that's D.4.2's job, and it must go through the same `open_with_device_secret`
+  verify-before-decrypt path.
+- **Framing codec never panics** and caps at 1 MiB.
+- `#![forbid(unsafe_code)]` holds in the new crate; `cargo clippy --release --workspace --tests
+  -- -D warnings` clean.
+
+## How to start
+
+```bash
+# from a clean main (these docs are merged):
+cd /path/to/secretary && git fetch --prune origin && git checkout main && git pull --ff-only origin main
+pwd && git branch --show-current && git worktree list        # CLAUDE.md discipline check
+git worktree add .worktrees/d41-native-messaging -b feature/d41-native-messaging main
+# then implement plan §6 task 1 (browser/secretary-browser-host + frame.rs) first.
+```
+
+## What this slice hands D.4.2
+
+A working channel to attach crypto to: add the `secretary-core` dep, the casual-vault
+per-fill `open_with_device_secret`, native-app device-slot enrollment, and replace the
+`count:0` no-op with a real candidate count (still **no secrets crossing** — that waits for
+D.4.4's native-confirmation gate). See design §9 / plan §9.

--- a/docs/adr/0010-browser-autofill-native-messaging.md
+++ b/docs/adr/0010-browser-autofill-native-messaging.md
@@ -1,0 +1,161 @@
+# ADR 0010 — Browser autofill via native messaging, scoped to a casual vault
+
+**Status:** Proposed (2026-06-15)
+**Supersedes:** none
+**Superseded by:** none
+
+Refines the **D.4** slice reserved in ADR 0007 ("The original D.4 (browser autofill
+extensions) remains unchanged in scope — separate slice, post-D.3"). This ADR fixes the
+security architecture of that slice before any code is written; the on-disk format and the
+core crypto are untouched.
+
+## Context
+
+Sub-project D.4 lets the user fill saved credentials into web pages from a browser
+extension. Autofill is valuable but it deliberately moves a subset of secrets into the
+browser — a far larger and more hostile trusted computing base than the native Tauri app
+(ADR 0007) or the native mobile apps (ADR 0008). The browser carries a constant stream of
+renderer RCEs, a JIT, a coarse extension-permission model with auto-updating supply chain,
+and the page content itself is adversarial (`threat-model.md §6`).
+
+Users are not a monolith. Three postures must all be served by one design:
+
+- **Convenience-first** — wants frictionless fill everywhere.
+- **Paranoid** — would rather autofill never touched a browser at all.
+- **Grayscale (the canonical case)** — "I don't care if a hobby-mailing-list password leaks,
+  but my email is an auth backchannel for password resets across dozens of sites and must
+  *never* be reachable from a browser extension."
+
+The grayscale user is the design driver. The requirement is not merely "let the user choose
+what to expose" but "make it *cryptographically impossible* for the extension to reach the
+high-value secrets, regardless of how thoroughly the browser or the extension is
+compromised." A UI toggle is not sufficient; the wall must be the absence of key material.
+
+The vault concept already supports more than one vault, and ADR 0009 already gives us a
+third, additive unlock path — the per-device wrap slot (`devices/<uuid>.wrap`,
+`file_kind 0x0004`) that releases the Identity Block Key under a `device_kek` derived from a
+device secret held in the OS keystore. Those two facts make the wall expressible in the
+existing model rather than as a new mechanism.
+
+## Decision
+
+### 1. Two-tier (N-tier) vaults; the wall is cryptographic
+
+A user runs at least two vaults: a **high-value** vault and a **casual** vault. The casual
+vault is enrolled with a browser **device slot** (ADR 0009); the high-value vault is
+**never** enrolled with one. The browser helper therefore holds no key material capable of
+opening the high-value vault — the separation is the *absence of a wrap file*, not a flag
+that code could be tricked into ignoring. Revoking the browser is `remove_device_slot` on
+the casual vault and leaves the master password, the recovery mnemonic, and every other
+device untouched.
+
+### 2. Thin-courier extension; native messaging over stdio
+
+The extension holds **no IBK, no master password, no vault, and no plaintext at rest**. It
+sends `{top-frame origin, field descriptor}` to a native helper and renders the result; all
+cryptography and all policy run in the helper. Transport is **native messaging** — the
+browser spawns the helper as a subprocess and talks over stdin/stdout. There is **no
+localhost socket**, preserving the closed-surface property ADR 0007 valued when it removed
+NiceGUI's `127.0.0.1` server. The per-OS native-messaging manifest binds the extension ID
+to the helper path on both ends.
+
+### 3. Per-fill open via the device slot; no long-running daemon
+
+On a fill request the helper opens the casual vault with `open_with_device_secret`, the
+device secret released from the OS keystore (optionally behind a biometric gate), serves the
+single requested credential, then re-locks. Because the device slot derives its KEK with
+HKDF rather than Argon2id (ADR 0009), a per-fill open is cheap, so no unlocked vault and no
+daemon needs to persist between fills. The open goes through the **same B.2 manifest
+verify-before-decrypt** as every other path — the browser path is not a weaker open.
+
+### 4. Click-to-fill only
+
+There is **no autofill on page load**. A fill requires a genuine (`isTrusted`) user gesture;
+scripted/synthetic events do not trigger a fill.
+
+### 5. Confirmation in a native OS dialog
+
+The click-to-fill confirmation is presented by the helper in **native UI, outside web
+content** — not a page-injected overlay and not a web-rendered surface. It is therefore not
+clickjackable by the page and not reachable by a co-resident extension. The dialog names the
+de-confused destination origin (see §6) so the user authorizes a specific target.
+
+### 6. Origin matching in the helper, per-credential binding
+
+All origin matching runs in the helper, never in a content script. Each stored credential
+carries an **`origin_binding`** field chosen by the user, with a user-settable default
+(honoring the grayscale philosophy — the user picks per item according to that item's value):
+
+- **`registrable_domain`** — match on eTLD+1 via the Public Suffix List. Fills across
+  subdomains of the same site. The PSL is essential, not a string-suffix shortcut: it
+  correctly makes `foo.github.io` its own registrable domain, defeating shared-suffix
+  hosting confusion.
+- **`exact_origin`** — match on scheme + host + port. Tighter; more "why won't it fill?"
+  friction on multi-subdomain sites, which is the paranoid user's accepted trade.
+
+Cross-cutting rules that hold under **both** bindings:
+
+- **Top-frame origin governs.** Never fill into a cross-origin iframe. If the form's frame
+  origin differs from the credential's origin, refuse — or require an explicit per-fill
+  confirmation that names the iframe origin.
+- **HTTPS required.** Refuse `http:`, `file:`, `data:`, `blob:`, `about:`, and
+  extension-internal pages.
+- **De-confused origin display** in the confirmation: render punycode/ASCII form and flag
+  mixed-script IDN.
+- The page never learns the credential list — only whether a fill occurred.
+
+### 7. Tiering guard-rails
+
+The casual vault warns when the user files a recovery-channel domain (email, SSO, or
+financial) into it, and discourages reuse of a password across the tier boundary — a reused
+password makes the cryptographic wall illusory.
+
+## Consequences
+
+- **High-value secrets are unreachable from the browser by construction.** Full compromise
+  of the renderer *and* the extension *and* the helper yields, at worst, casual-vault items
+  one fill at a time — never the IBK, the master password, or the high-value vault.
+- **No new always-listening local surface.** Native-messaging stdio + per-fill open means no
+  daemon and no socket; the ADR 0007 win is preserved.
+- **Revocation is a folder op.** Lose a laptop or retire a browser → `remove_device_slot`.
+- **The format stays frozen.** D.4 reuses ADR 0009's `file_kind 0x0004`; no new on-disk
+  structure and no change to `identity.bundle.enc` or `golden_vault_001`.
+- **Costs.** A native helper + native confirmation dialog must be built per desktop OS
+  (macOS / Linux / Windows), and the extension must ship for each browser engine. `origin_binding`
+  is new per-credential metadata to thread through the record model and the UI. The Public
+  Suffix List becomes a maintained, versioned data dependency.
+- **Residual, eyes-open.** Once a credential is filled it lives in page DOM; a compromised
+  renderer or a malicious co-extension can read it. Tiering bounds this to casual items. The
+  user, not the tool, classifies value — guard-rails mitigate but cannot remove
+  misclassification risk.
+
+## Alternatives considered
+
+- **Extension-resident vault (keys in the browser).** Rejected: puts the IBK and bulk
+  plaintext inside the browser TCB; a single renderer/extension compromise exposes a whole
+  vault rather than one credential, and there is no cryptographic wall to a high-value tier.
+- **Long-running app + local IPC for the helper.** A thin stdio shim forwarding to an
+  always-running desktop app over a separate authenticated local IPC. Rejected: lower
+  per-fill latency but reintroduces exactly the local listening surface ADR 0007 removed,
+  for a latency win the cheap HKDF per-fill open already makes unnecessary.
+- **Web-rendered / page-injected confirmation UI.** Rejected: lives in the browser TCB and
+  is exposed to clickjacking and co-extension interference; the native dialog moves the trust
+  decision out of web content.
+- **Autofill on page load with heuristics.** Rejected: silent fill is the single most
+  exploited password-manager surface (lookalike origins, injected forms). Click-to-fill with
+  a genuine gesture removes the class.
+- **Single vault with a per-item "browser-allowed" flag.** Rejected: a flag is enforced by
+  code that a compromise could bypass; only the absence of a device wrap is a real wall.
+
+## Related
+
+- ADR 0009 — per-device wrap slot (the key-release foundation for the casual-vault device
+  enrollment).
+- ADR 0007 — Tauri universal client; reserves D.4 and establishes the "no localhost server"
+  posture this ADR preserves. The native helper may reuse `secretary-core` directly or the
+  uniffi bindings (ADR 0007 notes "Android AutoFill Service" as a uniffi consumer).
+- ADR 0008 — native mobile via uniffi; mobile autofill (iOS AutoFill credential provider /
+  Android AutoFill Service) is a sibling of this slice and should follow the same
+  thin-courier + per-fill-open + tiering shape.
+- ADR 0006 — mandatory recovery key (an unrelated wrap slot; named for completeness).
+- `threat-model.md §6` — the browser-extension adversary model this ADR defends against.

--- a/docs/superpowers/specs/2026-06-15-d4-browser-autofill-design.md
+++ b/docs/superpowers/specs/2026-06-15-d4-browser-autofill-design.md
@@ -1,0 +1,234 @@
+# D.4 — Browser autofill (design)
+
+**Date:** 2026-06-15
+**Status:** Draft (brainstorm) — pending review of ADR 0010
+**Sub-project:** D.4 (browser autofill extensions), reserved in ADR 0007, architected in ADR 0010
+**Scope:** the browser extension + native helper + the security-critical origin-matching
+engine + the `origin_binding` record metadata. Reuses `secretary-core` and the ADR 0009
+device slot; **no on-disk format change** and no new core crypto.
+
+## 1. Context & motivation
+
+ADR 0010 froze the security architecture of browser autofill: a thin-courier extension over
+native-messaging stdio, per-fill open of a *casual* vault via the ADR 0009 device slot (no
+daemon), click-to-fill only, a native OS confirmation dialog, and helper-side origin matching
+with a per-credential `origin_binding`. The high-value vault is never enrolled with a browser
+device slot, so the separation is the **absence of key material**, not a UI toggle. The
+adversary model is `threat-model.md §6`.
+
+This spec turns that ADR into a buildable shape: the trust boundary, the extension↔helper
+protocol, where `origin_binding` lives, the origin-matching rules (the security core), and a
+walking-skeleton-first slicing.
+
+The design driver remains the **grayscale user**: "I don't care if a hobby-mailing-list
+password leaks, but my email is an auth backchannel and must never be reachable from a
+browser." Everything below serves making that wall real and the casual path ergonomic.
+
+## 2. Architecture & trust boundary
+
+```
+  ┌─ browser process (HOSTILE TCB, threat-model §6) ──────────────┐
+  │  web page (adversary §6.1.1)                                  │
+  │      ▲ inject single approved credential into DOM (residual)  │
+  │  content script ──────────┐                                   │
+  │  extension service worker │  thin courier: NO keys, NO vault, │
+  │      ▲                     │  NO plaintext at rest             │
+  └──────┼─────────────────────┼──────────────────────────────────┘
+         │ native messaging (stdio; NO socket)
+  ┌──────▼─────────────────────▼──────── native helper (trusted) ─┐
+  │  origin-matching engine (PSL, §5)                             │
+  │  per-fill open: open_with_device_secret (ADR 0009)           │
+  │      → casual vault only; device secret from OS keystore      │
+  │  NATIVE confirmation dialog (outside web content, §7)        │
+  └───────────────────────────────────────────────────────────────┘
+                  high-value vault: NO device slot → unreachable
+```
+
+The helper is the trust boundary. Everything browser-side is treated as the §6 hostile TCB:
+the extension is a courier that learns *whether* a fill is available and, only after native
+approval, receives *one* credential to inject. It never holds keys, never holds the vault,
+and never sees the credential list.
+
+## 3. Extension ↔ helper protocol
+
+Transport is **native messaging**: the browser spawns the helper as a subprocess and exchanges
+length-prefixed JSON over stdin/stdout. There is **no listening socket** (preserves the
+ADR 0007 "no localhost server" posture). The per-OS native-messaging manifest binds the
+extension ID to the helper executable path; only the named extension can launch the named
+helper, and the helper speaks only over the browser-provided pipe.
+
+Message flow for one fill (secrets minimized to a single credential, crossing only post-approval):
+
+| # | Direction | Message | Carries |
+|---|---|---|---|
+| 1 | ext → helper | `query` | `{ top_origin, frame_origin, https }` — **no secrets** |
+| 2 | helper → ext | `available` | `{ request_id, count }` — whether to show the affordance; **no secrets, no labels** |
+| 3 | ext → helper | `request_fill` | `{ request_id }` — sent only from a genuine (`isTrusted`) user gesture |
+| 4 | helper (local) | — | open casual vault, run §5 match, show **native** picker+confirm dialog naming the de-confused origin |
+| 5 | helper → ext | `fill` | `{ request_id, fields:[{field_hint, value}] }` — **one** credential, only on approval |
+| 6 | ext (content script) | — | inject into DOM, then drop/overwrite the message buffer |
+
+Design points:
+
+- **The native dialog (step 4) is the authoritative security gate, not the `isTrusted` check.**
+  Even if a hostile page synthesizes a `request_fill`, nothing is released without the user
+  approving in native UI. The `isTrusted` gating in step 3 only reduces prompt-spam; it is
+  defense-in-depth UX, not the boundary. State this explicitly so no reviewer mistakes the
+  gesture check for the control.
+- **Disambiguation is native.** If `count > 1`, the picker (labels, username previews) lives in
+  the native dialog, so usernames are not bulk-streamed into the browser. Only the chosen
+  credential's fillable fields cross back in step 5.
+- **One credential per approval.** The list never crosses; `query` returns only a count.
+- **Residual, acknowledged (§6.3.1):** the injected credential lands in page DOM, where a
+  compromised renderer or co-extension can read it. Tiering bounds this to casual items; it is
+  the inherent cost of autofill, not a defect.
+
+## 4. Per-fill open & device-slot enrollment
+
+The helper holds no unlocked vault between fills. On `request_fill` it calls
+`open_with_device_secret` (B.2) with the casual vault's device secret, released from the OS
+keystore (optionally behind a biometric gate), serves the approved credential, then re-locks.
+HKDF-derived `device_kek` (not Argon2id) makes per-fill opens cheap (ADR 0009), so no daemon
+is needed. The open goes through the **same manifest verify-before-decrypt** as every other
+path — the browser open is not a weaker open.
+
+**Enrollment** ("let this browser fill from my casual vault") is a native-app action, not an
+extension action: the desktop app (ADR 0007) mints a device slot on the *casual* vault
+(`add_device_slot`), stores the device secret in the OS keystore scoped to the helper, and
+records that this is the browser-helper device. **Revocation** is `remove_device_slot` on the
+casual vault — master password, recovery mnemonic, and all other devices untouched. The
+high-value vault is simply never offered for browser enrollment.
+
+## 5. Origin-matching engine (security core)
+
+All matching runs in the helper, never in a content script. This is the most exploited surface
+in password managers, so it gets the project's KAT discipline: a pinned
+`origin_match_kat.json` corpus of `(top_origin, frame_origin, stored_origin, binding) →
+{fill | refuse}` vectors, replayed in Rust and (since the helper reuses `secretary-core` /
+generic logic) ideally cross-checked clean-room, mirroring the §5-verification-trace pattern.
+
+Per-credential `origin_binding` (stored per §6), user-chosen with a user-settable default:
+
+- **`registrable_domain`** — match on eTLD+1 via the **Public Suffix List**. Fills across
+  subdomains of one site. PSL is mandatory, not a string-suffix shortcut: it correctly makes
+  `foo.github.io` its own registrable domain, defeating shared-suffix hosting confusion.
+- **`exact_origin`** — match on scheme + host + port. Tighter; more "why won't it fill?"
+  friction, which is the paranoid user's accepted trade.
+
+Rules holding under **both** bindings (each a KAT vector):
+
+1. **Top-frame origin governs.** Never fill into a cross-origin iframe. If `frame_origin ≠`
+   the credential's origin under the active binding, **refuse** (or require an explicit per-fill
+   confirmation that *names the iframe origin* — a separate, louder dialog).
+2. **HTTPS required.** Refuse `http:`, `file:`, `data:`, `blob:`, `about:`, and
+   extension-internal pages.
+3. **De-confused origin display.** The dialog renders punycode/ASCII form and flags
+   mixed-script IDN, so the user authorizes a target they can actually read.
+4. **No credential-list leak.** The page learns only whether a fill occurred.
+
+The PSL becomes a **versioned, security-critical data dependency** — pin it exactly with a
+rationale comment and a deliberate-bump review, mirroring the `tempfile =3.27.0` discipline
+(CLAUDE.md "Atomic-write contract"). A stale PSL silently changes match boundaries.
+
+## 6. `origin_binding` record metadata (zero format change)
+
+`origin_binding` is **non-secret policy**, so it must *not* go into `RecordFieldValue` (which is
+secret-only: `Text(SecretString)`/`Bytes(SecretBytes)` per CLAUDE.md "zeroize discipline"). Its
+home is the **record-level `unknown` map** under a reserved key (e.g. `d4_origin_binding`):
+
+- **No on-disk format change** — the `unknown` map is the existing §6.3.2 forward-compat
+  channel; `golden_vault_001` and every v1 vault stay byte-identical.
+- **Syncs with the credential** — it travels in the record across devices.
+- **Correct merge semantics for free** — unknown keys are LWW-merged by `py_merge_unknown_map`
+  / `merge_record`, so a policy change is last-writer-wins, which is the right semantic for a
+  per-item setting.
+
+The credential's URL/origin itself is an ordinary login-record field (already present); the
+engine reads that field plus the `d4_origin_binding` policy. The **global default** binding
+(used when a record has no `d4_origin_binding`) is a D.4-layer setting; whether it lives in
+`vault.toml` or in helper-local config is an open question (§10).
+
+> Alternative considered: a first-class typed `origin_binding` field on `Record`. Rejected for
+> v1 — it mutates the frozen record struct for a D.4-only concern the `unknown` map already
+> carries safely. Revisit only if a v2 format opens for other reasons.
+
+## 7. Click-to-fill & native confirmation
+
+No autofill on page load. A fill requires a genuine user gesture in the extension (§3 step 3),
+and the **native OS dialog** (§3 step 4) is the authoritative gate: it lives outside web
+content, so it is not clickjackable by the page and not reachable by a co-resident extension.
+The dialog names the de-confused destination origin (§5 rule 3) and, when `count > 1`, hosts the
+picker. Per-desktop-OS native dialog implementations are required (macOS / Linux / Windows).
+
+## 8. Tiering guard-rails
+
+Advisory, in the native app / helper, not enforced by the core:
+
+- **Recovery-channel warning** — warn when filing an email / SSO / financial domain into the
+  *casual* vault (these are auth backchannels; §1).
+- **Cross-tier reuse warning** — a password present in both vaults makes the cryptographic wall
+  illusory for that secret; flag it. (`threat-model.md §6.3` limitations 2–3.)
+
+## 9. Proposed slicing (walking-skeleton first)
+
+| Slice | Deliverable | Crypto? |
+|---|---|---|
+| **D.4.0** | This design doc → approved; ADR 0010 accepted. | — |
+| **D.4.1** | **Native-messaging walking skeleton.** One engine (Chromium MV3) + helper that round-trips `query`→`available` as a no-op ("no match"). Proves the stdio channel, manifest install, no socket. | none |
+| **D.4.2** | **Per-fill open.** Helper opens the casual vault via `open_with_device_secret`; native-app enrollment mints the browser device slot; helper returns a *count* of candidate records (still no secrets cross). | reuses B.2 |
+| **D.4.3** | **Origin-matching engine + KAT corpus.** PSL integration, `registrable_domain` / `exact_origin`, top-frame-governs, iframe refusal, HTTPS-only, IDN de-confusion. Pure, host-tested, pinned `origin_match_kat.json`. **The security-critical slice.** | none |
+| **D.4.4** | **Click-to-fill + native confirmation dialog.** Genuine gesture → native picker+confirm → single credential injected. macOS first, then Linux/Windows. | none |
+| **D.4.5** | **`origin_binding` metadata + guard-rails.** Read/write `d4_origin_binding` in the record `unknown` map; global-default setting; recovery-channel + reuse warnings. | none |
+| **D.4.6** | **Browser & OS breadth.** Firefox (native messaging), Safari (App-Extension model — different, §11), extension signing/store submission, packaging. | none |
+
+D.4.3 is the slice that earns the most review; D.4.1/D.4.2 are scaffolding; D.4.4 is per-OS UI.
+
+## 10. Open questions
+
+1. **Global-default `origin_binding` location** — `vault.toml` (syncs, but widens a frozen-ish
+   cleartext file) vs helper-local config (per-install, doesn't sync). Leaning helper-local +
+   per-record override, since the binding default is a user-posture choice, not vault data.
+2. **Safari** — Safari Web Extensions do not use classic stdio native messaging; they ship
+   inside a containing macOS/iOS app and message it. D.4.6 likely routes Safari through the
+   native app directly rather than a separate helper. Confirm before committing the abstraction.
+3. **TOTP autofill** — login records can carry a TOTP seed (`Bytes` field). Filling a *generated
+   code* (not the seed) is in natural scope for D.4.4/D.4.5; decide whether v1 includes it.
+4. **Mobile autofill** — iOS AutoFill credential provider / Android AutoFill Service are
+   *siblings*, not part of D.4 (different OS frameworks, ADR 0008 native apps). Same
+   thin-courier + per-fill-open + tiering shape; likely a separate sub-project. Flag, don't
+   absorb.
+5. **WebAuthn / passkeys** — the phishing-resistant long-term answer for "casual web login,"
+   and the browser is its natural home. Explicitly out of D.4 v1 scope; noted so the autofill
+   abstraction doesn't foreclose it.
+
+## 11. Cross-platform notes
+
+- **Chromium (MV3) + Firefox** — classic native messaging over stdio; the §3 protocol applies
+  directly. Firefox uses the same model with a different manifest location.
+- **Safari** — App-Extension model (see §10.2); different transport, same trust boundary and
+  same origin-matching engine.
+- **Mobile** — sibling sub-project (§10.4); reuses §5 and §6, different host integration.
+
+## 12. Security invariants (D.4 Definition-of-Done checklist)
+
+Each must be demonstrable before D.4 ships, and each maps to a `threat-model.md §6` row:
+
+1. The extension holds no IBK, no master password, no vault, and no plaintext at rest.
+2. The helper opens only the casual vault; the high-value vault has no browser device slot, so
+   no key material capable of opening it ever exists browser-side.
+3. No listening socket anywhere; transport is browser-spawned stdio with manifest-bound IDs.
+4. No fill without a native-dialog approval; the `isTrusted` gesture check is not relied on as
+   the boundary.
+5. Origin matching runs only in the helper, passes the pinned `origin_match_kat.json`, never
+   fills a cross-origin iframe, and is HTTPS-only.
+6. Only one credential crosses per approval; the credential list never crosses.
+7. The per-fill open uses the same manifest verify-before-decrypt as every other open path.
+8. PSL is exact-pinned with a deliberate-bump review.
+
+## 13. Related
+
+- ADR 0010 — browser autofill via native messaging (the decision this spec implements).
+- ADR 0009 — per-device wrap slot (the casual-vault enrollment foundation).
+- ADR 0007 — Tauri universal client; reserves D.4, establishes the no-localhost-server posture.
+- ADR 0008 — native mobile via uniffi (the mobile-autofill sibling's foundation).
+- `threat-model.md §6` — browser-extension adversary model and defense matrix.

--- a/docs/superpowers/specs/2026-06-15-d4-browser-autofill-design.md
+++ b/docs/superpowers/specs/2026-06-15-d4-browser-autofill-design.md
@@ -211,11 +211,10 @@ D.4.3 is the slice that earns the most review; D.4.1/D.4.2 are scaffolding; D.4.
 
 These need a decision before the slices that depend on them; recommendations noted.
 
-1. **Save / update path (biggest scope call).** D.4 as specified is **fill-only** (read). Do we
-   also offer the classic "save this new password?" / "update changed password?" capture prompt?
-   That is a *write* into the casual vault from the browser — a materially larger surface (the
-   helper would need a record-create/update path and its own confirmation). *Recommendation:*
-   ship D.4 v1 fill-only; spec the capture path as a follow-on (D.4.7) once fill is proven.
+1. **Save / update path → RESOLVED (2026-06-16): fill-only for v1.** D.4 v1 is read-only;
+   the "save this new password?" / "update changed password?" *capture* prompt is a separate
+   **extended-scope** slice (D.4.7), specced and built only after fill is proven. v1 introduces
+   no browser-side write path into the casual vault.
 2. **Field-detection strategy.** How the content script identifies username / password / TOTP
    fields to inject into (autocomplete attributes vs heuristics). Mis-detection is a
    security-relevant failure (right credential, wrong field). *Recommendation:* prefer

--- a/docs/superpowers/specs/2026-06-15-d4-browser-autofill-design.md
+++ b/docs/superpowers/specs/2026-06-15-d4-browser-autofill-design.md
@@ -145,8 +145,9 @@ home is the **record-level `unknown` map** under a reserved key (e.g. `d4_origin
 
 The credential's URL/origin itself is an ordinary login-record field (already present); the
 engine reads that field plus the `d4_origin_binding` policy. The **global default** binding
-(used when a record has no `d4_origin_binding`) is a D.4-layer setting; whether it lives in
-`vault.toml` or in helper-local config is an open question (§10).
+(used when a record has no `d4_origin_binding`) is **helper-local config** (§10.1.1) — a
+per-install user-posture choice that does not sync — defaulting to `registrable_domain`
+(§10.6.5), with the per-record `d4_origin_binding` overriding it.
 
 > Alternative considered: a first-class typed `origin_binding` field on `Record`. Rejected for
 > v1 — it mutates the frozen record struct for a D.4-only concern the `unknown` map already
@@ -183,30 +184,71 @@ Advisory, in the native app / helper, not enforced by the core:
 
 D.4.3 is the slice that earns the most review; D.4.1/D.4.2 are scaffolding; D.4.4 is per-OS UI.
 
-## 10. Open questions
+## 10. Decisions & open questions
 
-1. **Global-default `origin_binding` location** — `vault.toml` (syncs, but widens a frozen-ish
-   cleartext file) vs helper-local config (per-install, doesn't sync). Leaning helper-local +
-   per-record override, since the binding default is a user-posture choice, not vault data.
-2. **Safari** — Safari Web Extensions do not use classic stdio native messaging; they ship
-   inside a containing macOS/iOS app and message it. D.4.6 likely routes Safari through the
-   native app directly rather than a separate helper. Confirm before committing the abstraction.
-3. **TOTP autofill** — login records can carry a TOTP seed (`Bytes` field). Filling a *generated
-   code* (not the seed) is in natural scope for D.4.4/D.4.5; decide whether v1 includes it.
-4. **Mobile autofill** — iOS AutoFill credential provider / Android AutoFill Service are
-   *siblings*, not part of D.4 (different OS frameworks, ADR 0008 native apps). Same
-   thin-courier + per-fill-open + tiering shape; likely a separate sub-project. Flag, don't
-   absorb.
-5. **WebAuthn / passkeys** — the phishing-resistant long-term answer for "casual web login,"
-   and the browser is its natural home. Explicitly out of D.4 v1 scope; noted so the autofill
-   abstraction doesn't foreclose it.
+### 10.1 Resolved (2026-06-16)
+
+1. **Global-default `origin_binding` location → helper-local config.** The default binding is a
+   user-posture choice per install, not vault data; it does not sync, and a per-record
+   `d4_origin_binding` overrides it. Keeps `vault.toml` untouched.
+2. **Safari → App-Extension model, confirmed.** Safari Web Extensions ship inside a containing
+   macOS/iOS app and message it rather than using stdio native messaging. D.4.6 routes Safari
+   through the native app directly; the §5 origin-matching engine and the §2 trust boundary are
+   shared, only the transport differs. **Chromium + Firefox use stdio native messaging on all
+   desktop OSes** (Win/macOS/Linux), differing only in manifest-registration location — no
+   separate transport needed (Firefox-for-Android has no native messaging, but Android is the
+   §10.5 mobile sibling regardless).
+3. **TOTP autofill → in v1.** The helper computes the *current code* from the record's TOTP seed
+   (`Bytes` field) at fill time and returns the **6-digit code, never the seed**, as a fill
+   field (§3 step 5). Covered by D.4.4/D.4.5. (See §10.6 open items on TOTP UX.)
+4. **Mobile autofill → sibling sub-project, not D.4.** iOS AutoFill credential provider /
+   Android AutoFill Service reuse §5 and §6 with a different host integration; tracked
+   separately.
+5. **WebAuthn / passkeys → out of D.4 v1, not foreclosed.** Noted so the autofill abstraction
+   leaves room for the phishing-resistant path later.
+
+### 10.6 Still open
+
+These need a decision before the slices that depend on them; recommendations noted.
+
+1. **Save / update path (biggest scope call).** D.4 as specified is **fill-only** (read). Do we
+   also offer the classic "save this new password?" / "update changed password?" capture prompt?
+   That is a *write* into the casual vault from the browser — a materially larger surface (the
+   helper would need a record-create/update path and its own confirmation). *Recommendation:*
+   ship D.4 v1 fill-only; spec the capture path as a follow-on (D.4.7) once fill is proven.
+2. **Field-detection strategy.** How the content script identifies username / password / TOTP
+   fields to inject into (autocomplete attributes vs heuristics). Mis-detection is a
+   security-relevant failure (right credential, wrong field). *Recommendation:* prefer
+   `autocomplete=` attributes; fall back to conservative heuristics; never inject into a field
+   the user didn't focus for the click-to-fill gesture. Needs its own mini-spec in D.4.4.
+3. **Per-browser vs shared device slot.** If the user runs Chrome *and* Firefox, is that one
+   browser-helper device slot or one per browser? Affects revocation granularity.
+   *Recommendation:* one device slot **per browser** (per-browser revoke; matches the ADR 0009
+   "multi-device = multiple files" grain).
+4. **Biometric gate on per-fill open: required or optional?** The casual vault's per-fill
+   `open_with_device_secret` can be gated by biometric or just OS-login. *Recommendation:* make
+   it a helper-local setting, default **on** (biometric per fill) — cheap given HKDF opens, and
+   it raises the bar for a stolen unlocked session.
+5. **Shipped default binding value.** Helper-local default (10.1.1) needs a shipped value:
+   `registrable_domain` (casual-vault ergonomics) vs `exact_origin` (safer).
+   *Recommendation:* `registrable_domain` as the casual-vault default, with the per-record
+   override for items the user wants pinned.
+6. **TOTP fill UX / auto-submit.** Since TOTP is in v1 (10.1.3): is the code filled together with
+   username+password in one approval or as a separate gesture, and does D.4 ever auto-submit the
+   form? *Recommendation:* one approval fills all matched fields incl. the TOTP code; **never
+   auto-submit** in v1 (auto-submit is a known foot-gun and removes the user's last look).
+7. **Reserved-key namespace in `unknown`.** `d4_origin_binding` (and any future `d4_*` keys) must
+   be documented as reserved so later format work doesn't collide. *Recommendation:* reserve a
+   `d4_` prefix in the record-format notes when D.4.5 lands.
 
 ## 11. Cross-platform notes
 
-- **Chromium (MV3) + Firefox** — classic native messaging over stdio; the §3 protocol applies
-  directly. Firefox uses the same model with a different manifest location.
-- **Safari** — App-Extension model (see §10.2); different transport, same trust boundary and
-  same origin-matching engine.
+- **Chromium (MV3) + Firefox** — classic native messaging over stdio on **all desktop OSes**
+  (Win/macOS/Linux); the §3 protocol applies directly. Firefox uses the same model, differing
+  only in host-manifest registration location. (Firefox-for-Android has no native messaging →
+  handled by the §10.5 mobile sibling, not here.)
+- **Safari** — App-Extension model (§10.1.2); different transport, same trust boundary and same
+  origin-matching engine.
 - **Mobile** — sibling sub-project (§10.4); reuses §5 and §6, different host integration.
 
 ## 12. Security invariants (D.4 Definition-of-Done checklist)

--- a/docs/superpowers/specs/2026-06-16-d41-native-messaging-skeleton-plan.md
+++ b/docs/superpowers/specs/2026-06-16-d41-native-messaging-skeleton-plan.md
@@ -1,0 +1,178 @@
+# D.4.1 — Native-messaging walking skeleton (implementation plan)
+
+**Date:** 2026-06-16
+**Status:** Plan (pending implementation)
+**Sub-project:** D.4 (browser autofill), first slice
+**Design:** [2026-06-15-d4-browser-autofill-design.md](2026-06-15-d4-browser-autofill-design.md)
+**Scope:** the transport skeleton **only** — a browser extension and a native-messaging host
+that complete one `query → available` round trip as a **no-op** ("no match"). **No crypto, no
+vault, no `secretary-core` dependency, no fill.** This slice exists to prove the channel, the
+manifest binding, and the framing codec in isolation, exactly as D.1.1 proved the Tauri IPC
+shell before any feature work.
+
+## 1. What this slice ships
+
+- A **native-messaging host** binary that reads length-prefixed JSON frames from stdin, and for
+  a `query` message replies with `available { count: 0 }` on stdout. Nothing else.
+- A **Chromium (Manifest V3) extension** that, on a page, calls `runtime.connectNative`, sends a
+  `query` carrying the page's origins, and logs the `available` reply.
+- A dev-time **host manifest** + install notes registering the host for the extension ID on
+  macOS/Linux.
+- Host **unit + integration tests** that exercise the framing codec and the `query→available`
+  handler over an in-process pipe — **no browser required in CI**.
+
+### Explicit non-goals (later slices)
+
+| Deferred | Slice |
+|---|---|
+| Opening any vault / device-slot enrollment | D.4.2 |
+| Real origin matching (PSL, bindings, iframe rules) | D.4.3 |
+| Click-to-fill, native confirmation dialog, credential injection | D.4.4 |
+| `origin_binding` record metadata, guard-rails | D.4.5 |
+| Firefox + Safari + signing/packaging | D.4.6 |
+| Any write/capture path | D.4.7 |
+
+This slice deliberately carries **no secret material**, so the §6 invariants it can prove are
+the *structural* ones (no socket, manifest-bound IDs, no-panic framing), not the crypto ones.
+
+## 2. Layout
+
+A new top-level `browser/` home (sibling of `desktop/`, `ios/`, `android/`):
+
+```
+browser/
+  extension/                     WebExtension (Chromium first; Firefox shares it in D.4.6)
+    manifest.json                MV3: nativeMessaging permission, no host_permissions beyond test page
+    src/background.ts            service worker: connectNative, send query, log available
+    src/content.ts               content script: collect {top_origin, frame_origin, https}, post to bg
+    package.json / tsconfig      reuse desktop/ pnpm toolchain conventions
+  secretary-browser-host/        native-messaging host — a Rust crate, NEW workspace member
+    Cargo.toml                   no secretary-core dep yet (added in D.4.2)
+    src/main.rs                  stdin/stdout framed read→handle→write loop
+    src/frame.rs                 length-prefix codec (encode/decode), the testable core
+    src/protocol.rs              serde message types for the D.4.1 subset
+    tests/echo.rs                pipe a query frame in, assert an available frame out
+  host-manifest/                 dev manifest + per-OS install notes
+    com.secretary.browser_host.json
+    README.md
+```
+
+The host is a **workspace member** (not excluded like `core/fuzz`): it is production code and
+must hold the workspace lints — `#![forbid(unsafe_code)]`, clippy `-D warnings`. It depends on
+`secretary-core` only from D.4.2 onward; in D.4.1 it is pure transport.
+
+## 3. Native-messaging mechanics
+
+Native messaging is the browser spawning the host as a subprocess and exchanging messages over
+the host's stdin/stdout. **There is no socket** — that is the property this slice locks in.
+
+**Framing** (`frame.rs`): each message is UTF-8 JSON prefixed by a **4-byte length in the
+host's native byte order**. Per the platform contract, a host→extension message is capped at
+1 MiB; we additionally cap extension→host at **1 MiB** and reject anything larger as a typed
+error rather than allocating. The codec:
+
+- `decode`: read 4 length bytes → validate `len ≤ 1 MiB` (else `FrameError::TooLarge`) → read
+  exactly `len` bytes → `serde_json` parse. EOF on the length read = clean shutdown.
+- `encode`: `serde_json` to bytes → write 4-byte native-endian length → write body.
+- **Never panics** on malformed input — returns `Result`, mirroring the fuzz-harness
+  "assert `Result`, not panic" contract (CLAUDE.md). A short read, a bad length, or non-JSON
+  body is a typed error, not a crash.
+
+**The loop** (`main.rs`): read frame → dispatch → write frame, until stdin EOF. Single-threaded,
+synchronous; no global state.
+
+## 4. Walking-skeleton protocol subset
+
+Only two message types in D.4.1 (the full set is in the design §3):
+
+```jsonc
+// extension → host
+{ "type": "query", "top_origin": "https://example.com",
+  "frame_origin": "https://example.com", "https": true }
+
+// host → extension
+{ "type": "available", "request_id": "<uuid>", "count": 0 }
+```
+
+The host **always** replies `count: 0` in this slice (no matching exists yet). `request_id` is a
+fresh UUID the host generates per query, so the D.4.4 `request_fill` correlation is already
+threaded. Unknown `type` values are answered with a typed `error` frame, never a panic.
+
+## 5. Host manifest
+
+`com.secretary.browser_host.json` (dev form):
+
+```jsonc
+{
+  "name": "com.secretary.browser_host",
+  "description": "Secretary native-messaging host (D.4.1 skeleton)",
+  "path": "/abs/path/to/secretary-browser-host",      // built binary, abs path
+  "type": "stdio",
+  "allowed_origins": ["chrome-extension://<EXTENSION_ID>/"]  // binds host ↔ extension ID
+}
+```
+
+`allowed_origins` is the **manifest binding**: only the named extension may launch this host.
+Install location is per-OS (dev notes in `host-manifest/README.md`): the user-scoped
+NativeMessagingHosts directory for the target Chromium channel on macOS/Linux. Windows registry
+registration is a D.4.6 concern.
+
+## 6. Task breakdown
+
+| Task | Deliverable | Test gate |
+|---|---|---|
+| **1** | Scaffold `browser/secretary-browser-host` crate; add to workspace members; `frame.rs` length-prefix codec. | `frame.rs` unit tests: round-trip, oversize→`TooLarge`, truncated length→error, non-JSON body→error, EOF→clean. |
+| **2** | `protocol.rs` serde types (`query`, `available`, `error`); `main.rs` read→dispatch→write loop; no-op handler returning `count:0` + fresh `request_id`. | `tests/echo.rs`: feed a `query` frame to a `Cursor`/pipe, assert an `available{count:0}` frame out; unknown-type→`error`. |
+| **3** | Scaffold `browser/extension` MV3 (manifest, background SW, content script); `connectNative` → send `query` → log `available`. | `tsc` builds clean; lint clean under desktop/ conventions. |
+| **4** | `host-manifest/` dev manifest + per-OS install README (macOS/Linux). | Manual: install manifest, load unpacked extension, visit a test page, observe the round trip in the extension console. |
+| **5** | Wire host crate into `cargo test --release --workspace`; clippy `-D warnings`; confirm `#![forbid(unsafe_code)]` holds. | `cargo test --release --workspace` green incl. new crate; `cargo clippy --release --workspace --tests -- -D warnings` clean. |
+| **6** | `browser/README.md` (architecture pointer to design §2, dev-run steps) + a `2026-..-d41-shipped.md` handoff. | Docs reviewed; handoff lists what D.4.2 picks up. |
+
+Tasks 1–2 are the load-bearing slice (the host codec + loop); 3–4 are the browser scaffold; 5–6
+are integration + handoff. Tasks 1, 2, 5 are fully CI-gated in Rust; tasks 3–4 carry a
+**documented manual smoke** (the browser e2e is manual at this stage, the same posture as the
+iOS on-device proof in CLAUDE.md — automated browser-driver e2e is a later, optional add).
+
+## 7. Testing strategy
+
+- **Host codec (L1, CI).** `frame.rs` unit tests cover encode/decode round-trip and every
+  malformed-input branch (oversize, truncated, non-JSON, EOF). The no-panic contract is
+  asserted, not assumed.
+- **Host handler (L2, CI).** `tests/echo.rs` drives the loop over an in-memory pipe: a `query`
+  frame in → an `available{count:0}` frame out; an unknown type → an `error` frame; a truncated
+  stream → clean shutdown. No browser, no network.
+- **Browser round trip (L3, manual).** Load-unpacked extension + installed manifest; a test page
+  triggers a `query` and the console shows the `available` reply. Documented in
+  `host-manifest/README.md`; promoted to an automated driver test only if a later slice needs it.
+
+## 8. Definition of Done
+
+The slice is done when, with **no crypto and no secrets in play**, these hold:
+
+1. `cargo test --release --workspace` (incl. the new host crate) and
+   `cargo clippy --release --workspace --tests -- -D warnings` are green.
+2. The host completes a `query → available{count:0}` round trip both in `tests/echo.rs` and in a
+   manual browser load-unpacked smoke.
+3. **No listening socket exists** — the host communicates only over the browser-provided stdio
+   (structural §6 invariant 3).
+4. The manifest's `allowed_origins` binds the host to the extension ID (§6 invariant 3).
+5. The framing codec **never panics** on malformed input and caps message size at 1 MiB
+   (DoS bound; fuzz-discipline parity).
+6. The host holds **no key material and opens no vault** (§6 invariant 1) — trivially true here
+   because it has no `secretary-core` dependency yet, which D.4.2 will add behind the same
+   verify-before-decrypt open path.
+7. `#![forbid(unsafe_code)]` holds in the new crate.
+
+## 9. What D.4.2 picks up
+
+The handoff (task 6) hands D.4.2 a working channel to attach crypto to: add the `secretary-core`
+dependency, the casual-vault `open_with_device_secret` per-fill open, native-app device-slot
+enrollment, and replace the `count: 0` no-op with a real candidate count (still no secrets
+crossing — that waits for D.4.4's native-confirmation gate).
+
+## 10. Related
+
+- D.4 design — [2026-06-15-d4-browser-autofill-design.md](2026-06-15-d4-browser-autofill-design.md) (this plan implements §3 transport + §2 boundary).
+- ADR 0010 — browser autofill via native messaging.
+- D.1.1 — Tauri walking-skeleton spec (the precedent for "prove the shell before features").
+- `threat-model.md §6` — the structural invariants (3) this slice locks in.

--- a/docs/threat-model.md
+++ b/docs/threat-model.md
@@ -201,3 +201,46 @@ Each defense in §3 must correspond to either a specific test or a specific desi
 - **`tempfile` exact-pinned (`=3.27.0`)** → atomic-write path dependency; pinned at `core/Cargo.toml` so a `cargo update` cannot move the resolved version inside the 3.x range without a deliberate edit.
 
 Each test name and KAT-file name above is a contract; renaming or removing requires a corresponding update here.
+
+---
+
+## 6. Browser extension adversaries (Sub-project D.4 scope)
+
+The browser autofill extension (D.4; design in [adr/0010-browser-autofill-native-messaging.md](adr/0010-browser-autofill-native-messaging.md)) introduces adversaries the v1 core model (§2) does not cover, because it *deliberately* moves a subset of secrets into the browser — a far larger and more hostile trusted computing base than the native clients. This section is **scoped to D.4**: it adds adversaries and defenses for that slice and does **not** relax any §2–§5 guarantee for the native apps. The defenses below are design commitments for an unbuilt sub-project; unlike §3, they do not yet have a §5 verification trace (that is a Definition-of-Done item for D.4, not Sub-project A).
+
+The organizing principle is **containment, not in-browser hardening**: the browser is assumed to be a weaker environment that we do not try to make as strong as the native app. Instead, the design caps what is reachable from it — long-term keys and the high-value vault never enter the browser process at all.
+
+### 6.1 Adversaries
+
+#### 6.1.1 Hostile / lookalike web page (in scope, primary for D.4)
+Any page the user visits. Goal: induce a fill into the wrong origin, or read a value that was legitimately filled. Capabilities:
+- Present a login form on a punycode/IDN lookalike domain, a confusable subdomain, or inside a nested cross-origin iframe.
+- Clickjack or overlay the fill affordance; synthesize "user gesture" events via script.
+- Read the filled value from its own DOM after a fill.
+
+#### 6.1.2 Malicious / compromised extension (in scope)
+A second extension with broad host permissions, or a supply-chain compromise / hostile auto-update of Secretary's own extension. Capabilities: read page DOM (hence any filled secret), and probe any local IPC the helper exposes.
+
+#### 6.1.3 Browser / renderer as expanded TCB (containment, not defense)
+Renderer RCE and similar. Secretary does **not** claim to protect a secret once it has been filled into a compromised renderer — this is the §2.7 "active malware on an unlocked device" case carried into the browser. The D.4 response is architectural containment (§6.2), not in-renderer protection.
+
+#### 6.1.4 Native-messaging channel attacker (in scope)
+A local process attempting to impersonate the extension to the native helper, or the helper to the extension.
+
+### 6.2 Defense matrix (D.4-specific)
+
+| Attack | Defense |
+|---|---|
+| Fill into the wrong origin (lookalike / confusable subdomain / cross-origin iframe) | Origin matching runs in the **native helper**, never in a content script. Per-credential `origin_binding` (`registrable_domain` via Public Suffix List, or `exact_origin` = scheme+host+port). Top-frame origin governs; a cross-origin iframe is never silently filled. HTTPS-only. The confirmation displays the de-confused (punycode-flagged, mixed-script-flagged) destination origin. (ADR 0010 §6) |
+| Silent autofill on page load | **Click-to-fill only.** A fill requires a genuine (`isTrusted`) user gesture; synthetic/scripted events do not trigger a fill. (ADR 0010 §4) |
+| Clickjacked / spoofed confirmation, or co-extension hijack of the prompt | The confirmation gesture is a **native OS dialog outside web content** — not page-injected, not web-rendered. (ADR 0010 §5) |
+| Extension reads the bulk credential set | The extension holds no vault and no keys. Matching happens in the helper; only the **single approved credential** crosses the boundary, never the credential list. (ADR 0010 §2) |
+| Compromise of the browser/extension/helper reaches high-value secrets | **Vault tiering is cryptographic, not a toggle:** the high-value vault is never enrolled with a browser device slot (ADR 0009), so the helper holds no key material capable of opening it. Worst case is casual-vault items, one fill at a time. (ADR 0010 §1, §3) |
+| Impersonation on the native-messaging channel | Native messaging is a browser-spawned **stdio** subprocess — no listening socket (preserves the §3.1 / ADR 0007 "no localhost server" posture). The per-OS native-messaging manifest binds extension ID ⟷ helper path on both ends. (ADR 0010 §2) |
+| Weaker open on the browser path | The per-fill `open_with_device_secret` goes through the **same B.2 manifest verify-before-decrypt** as the password / recovery / device paths; the browser open is not a weaker open. (ADR 0010 §3) |
+
+### 6.3 Known limitations of D.4 (acknowledged tradeoffs)
+
+1. **Filled secrets live in page DOM.** Once a credential is filled, a compromised renderer or a malicious co-resident extension can read it. Tiering bounds the loss to casual-vault items; it does not eliminate it.
+2. **The user classifies value, not the tool.** "Casual" vs "high-value" is a human judgement. Guard-rails (a warning when filing a recovery-channel domain — email / SSO / financial — into the casual vault, and discouraging cross-tier password reuse) mitigate but cannot remove misclassification risk.
+3. **A reused password defeats the wall.** If the same secret sits in both the casual and high-value vaults, the cryptographic separation is illusory for that secret. The cross-tier-reuse guard-rail is the only mitigation; it is advisory, not enforced.


### PR DESCRIPTION
Planning-only PR (docs, no code) that freezes the security architecture of the **D.4 browser-autofill** slice before any implementation, opened for traceability.

## What's here

| Doc | Role |
|---|---|
| `docs/adr/0010-browser-autofill-native-messaging.md` | **Decision** — thin-courier extension over native-messaging stdio, per-fill open of a *casual* vault via the ADR 0009 device slot, click-to-fill only, native OS confirmation dialog, helper-side origin matching. High-value vault is **never** enrolled with a browser device slot, so the separation is the *absence of key material*, not a UI toggle. |
| `docs/threat-model.md` §6 | **Adversaries** — hostile/lookalike page, malicious/compromised extension, renderer-as-TCB, native-messaging channel — with a D.4-scoped defense matrix and acknowledged limitations. Does not relax any §2–§5 guarantee. |
| `docs/superpowers/specs/2026-06-15-d4-browser-autofill-design.md` | **Build plan** — trust boundary, extension↔helper protocol (one credential crosses, only post-approval; the native dialog is the gate, not the `isTrusted` check), origin-matching engine (PSL `registrable_domain`/`exact_origin`, top-frame-governs, iframe refusal, HTTPS-only, IDN de-confusion), `origin_binding` stored in the record `unknown` map (zero format change), slicing D.4.1–D.4.7, DoD checklist, and §10 resolved decisions. |
| `docs/superpowers/specs/2026-06-16-d41-native-messaging-skeleton-plan.md` | **First slice (D.4.1)** — Chromium MV3 extension + new `browser/secretary-browser-host` Rust crate completing one `query → available{count:0}` no-op round trip. No crypto, no vault, no `secretary-core` dep. Framing codec, host manifest, 6-task breakdown, CI-gated host tests + manual browser smoke. |
| `NEXTSESSION_BROWSER_PLUGIN.md` | Standalone handoff to start D.4.1 in a parallel session (intentionally separate from the `NEXT_SESSION.md` symlink). |

## Key decisions recorded

- **Fill-only for v1.** Password capture (a browser-side write path) is deferred to an extended-scope slice (D.4.7).
- **Cryptographic vault tiering.** The wall between casual and high-value is the absence of a device wrap (ADR 0009), not a flag.
- **No new local listening surface.** Native-messaging stdio + per-fill open (HKDF, no daemon) preserves ADR 0007's "no localhost server" posture.
- **`origin_binding` in the record `unknown` map.** Non-secret policy, so not a secret-only `RecordFieldValue`; zero on-disk format change, LWW merge for free.
- **Resolved open questions:** helper-local default binding (`registrable_domain`), Safari = App-Extension model (Chromium + Firefox share stdio on all desktop OSes), TOTP in v1 (code not seed), mobile autofill = sibling sub-project, passkeys parked.

## Scope

Additive under `docs/` + one new root file; **no `core/` / `ffi/` / format change**. All four docs are Proposed/Draft status — the contract for the implementation slices that follow.

https://claude.ai/code/session_01K7zGpfDxcoJdvoGbwEtKaf

---
_Generated by [Claude Code](https://claude.ai/code/session_01K7zGpfDxcoJdvoGbwEtKaf)_