### PR TITLE
fix(ios): zeroize the transient device-secret Data buffer in SE release (#274)

### DIFF
--- a/NEXT_SESSION.md
+++ b/NEXT_SESSION.md
@@ -1,1 +1,1 @@
-docs/handoffs/2026-06-21-ios-write-reauth-shipped.md
+docs/handoffs/2026-06-21-ios-se-release-zeroize-shipped.md

--- a/docs/handoffs/2026-06-21-ios-se-release-zeroize-shipped.md
+++ b/docs/handoffs/2026-06-21-ios-se-release-zeroize-shipped.md
@@ -1,0 +1,83 @@
+# NEXT_SESSION.md — iOS SE-release device-secret zeroize (#274) ✅ (SHIPPED — gauntlet green; PR open)
+
+**Session date:** 2026-06-21. Flow: `/nextsession` → the prior baton (iOS biometric write re-auth, PR #275) had **already been squash-merged** to `main` @ `53d1a8bf` by a parallel session, and its `feature/ios-write-reauth` worktree/branch were the only cleanup left. With that baton fully discharged, the user chose the well-scoped security-hygiene follow-up filed during #275's review — **#274: `SecureEnclaveDeviceSecretStore.release` leaves the decrypted device secret in an un-zeroized `Data` buffer**.
+
+**Status:** ✅ **code-complete; gauntlet green.** Branch `feature/ios-release-zeroize` (worktree `.worktrees/ios-release-zeroize`), branched from `main` @ `53d1a8bf`. One-line defensive fix; iOS-Swift-only. **`core/`, the crypto/vault spec, all `*.udl`, pyo3, and Android are untouched.**
+
+## (1) What we shipped this session
+
+**The fix (one file):** `SecureEnclaveDeviceSecretStore.release(reason:)` decrypts the wrapped device secret into a `Data` via `SecKeyCreateDecryptedData`, copies it to the returned `[UInt8]`, then previously dropped the `Data` without overwriting it — leaving one transient in-process copy of the 32-byte device secret in that buffer, regardless of any zeroize the caller performs on the returned array. Now a `defer { plain.resetBytes(in: 0..<plain.count) }` (after the `[UInt8]` copy is built) zeroes the decrypt buffer in place, mirroring the `Data.resetBytes` discipline already in `UniffiVaultDeviceSlotPort`/`UniffiVaultCreatePort`. The returned value is unchanged; the caller (`EnclaveBiometricAuthorizer`) still zeroizes its own copy.
+
+This is the **shared device-unlock path** used by both B.3 device unlock and the new write-reauth `EnclaveBiometricAuthorizer`. Low severity (in-process, short-lived, device-secret ≠ master key), but it closes a gap inconsistent with the project's zeroize discipline.
+
+**Housekeeping also done this session:** synced `main`, removed the merged `feature/ios-write-reauth` worktree + branch (`git worktree remove` + `git branch -D`); the other three worktrees (`hardcore-robinson`, `d4-browser-autofill`, `desktop-block-crud-ui`) were left untouched.
+
+| File | Change |
+|---|---|
+| `ios/SecretaryKit/Sources/SecretaryKit/DeviceUnlock/SecureEnclaveDeviceSecretStore.swift` | `let plain` → `var plain`; add `defer { plain.resetBytes(in: 0..<plain.count) }` before the `continuation.resume(returning: [UInt8](plain))`. +7 / −1. |
+
+**Branch commit (squash-merge collapses to one on `main`):**
+`bebeb0e2` fix · plus the handoff commit retargeting this symlink.
+
+### Acceptance (green this session)
+```bash
+# Full iOS gauntlet (host suites + sim XCTest + app build), from the worktree:
+cd /Users/hherb/src/secretary/.worktrees/ios-release-zeroize
+bash ios/scripts/run-ios-tests.sh
+#   → SecretaryDeviceUnlock host 35/35, SecretaryVaultAccess host 205/205,
+#   → ** TEST SUCCEEDED ** (simulator XCTest) + ** BUILD SUCCEEDED ** (app build), exit 0
+
+# Guardrails (both EMPTY this slice):
+git diff main...HEAD --name-only | grep -E 'core/|crypto-design|vault-format|\.udl|secretary-ffi-py|android/'   # empty
+git diff main...HEAD --name-only | grep -E '\.rs$|Cargo'                                                        # empty
+```
+
+### Deliberate decisions (so a future reader doesn't "fix" them)
+- **No dedicated unit test.** The zeroized `plain` is a discarded local `Data` with **no externally observable effect** (the returned `[UInt8]` is identical with or without the zeroize), and the real `release` path requires the Secure Enclave + biometric (untestable on host/simulator — the class header says so). Like the existing `UniffiVaultDeviceSlotPort`/`UniffiVaultCreatePort` `resetBytes` sites, the zeroize itself carries no automated assertion; verification is the no-regression gauntlet (passed) + the #202-style on-device proof.
+- **`defer`, not inline, after the copy.** The `[UInt8](plain)` copy is evaluated and handed to `continuation.resume(returning:)` before the closure scope exits, so the `defer` zeroizes only after the copy is safely made. Matches the codebase's `defer { …resetBytes }` idiom.
+- **No README/ROADMAP row.** Per the brief-status README style, a one-line producer-side `Data`-residue fix on an already-documented path (the iOS write-reauth rows already say the released secret is "zeroized + discarded") doesn't warrant a status row. The fix simply makes that existing statement fully true.
+
+## (2) What's next
+- **Open + squash-merge this PR** (§4 below — push happens at session close), then housekeeping (remove this worktree + branch). `#274` auto-closes on merge (`Closes #274` in the commit + PR body).
+- **On-device proofs (manual, not CI-automatable):**
+  - Face ID write-reauth (#202-parity): on an enrolled device, a mutating write outside the 30s grace window prompts Face ID before committing; within the window it does not re-prompt; a cancel refuses the write and surfaces `.reauthFailed` keeping the dialog open.
+  - Sync veto round-trip still needs a seeded concurrent state ([[project_secretary_sync_veto_needs_seeded_state]]).
+- **Desktop / Android biometric write re-auth** — the write-reauth gate shipped (#275) is **iOS-only**; the other platforms have no write-reauth affordance yet. Natural next feature (full TDD, cross-platform parity).
+
+**Open follow-up issues (carried; #274 now closed):** #224 / #234 / #192 / #193 / #190 / #189 / #186 / #161 / #162 / #167 / #251 / #252 / #255.
+
+## (3) Open decisions and risks
+- **Simulator acceptance depends on Xcode + a booted simulator** ([[project_secretary_ios_toolchain_available]]); `run-ios-tests.sh` resolves the sim (default "iPhone 16", override via `IOS_SIM`). A SpringBoard/CoreSimulator crash during sim boot is environmental (Apple widget-extension assert) and does not fail the headless XCTest.
+- **`ld: warning ... built for newer iOS-simulator version 26.5 than being linked (17.0)`** is pre-existing uniffi-static-lib noise, not from this change.
+- **No cross-language / Rust run needed.** iOS-Swift-only over an already-reviewed device-unlock surface; guardrails empty by construction.
+
+## (4) Exact commands to resume
+```bash
+# 0) Push the branch + open the PR (this session left it committed; push happens at session close):
+cd /Users/hherb/src/secretary/.worktrees/ios-release-zeroize
+git push -u origin feature/ios-release-zeroize
+gh pr create --fill   # base main
+
+# Re-run the gauntlet before merge:
+cd /Users/hherb/src/secretary/.worktrees/ios-release-zeroize && bash ios/scripts/run-ios-tests.sh
+
+# Guardrails (empty this slice):
+git diff main...HEAD --name-only | grep -E 'core/|crypto-design|vault-format|\.udl|secretary-ffi-py|android/'   # empty
+git diff main...HEAD --name-only | grep -E '\.rs$|Cargo'                                                        # empty
+
+# 1) After the PR merges, housekeeping (from the MAIN checkout, not this worktree):
+cd /Users/hherb/src/secretary
+git fetch --prune origin && git checkout main && git pull --ff-only origin main
+git worktree remove .worktrees/ios-release-zeroize && git branch -D feature/ios-release-zeroize
+git worktree prune && git worktree list   # leaves hardcore-robinson + d4-browser-autofill + desktop-block-crud-ui untouched
+```
+
+## (5) Handoff file model
+`NEXT_SESSION.md` is a **relative symlink** to the latest file in `docs/handoffs/` (this file). Authored once; the symlink is the pointer. Both this handoff + the retargeted symlink are committed on the feature branch ([[feedback_next_session_in_pr]]). If you resume this branch for fixups, first `git fetch origin && git merge origin/main` (branch-version-wins on the handoff path) before editing ([[feedback_next_session_main_authoritative]]). `origin/main` was at `53d1a8bf` (the branch point) at close, so no bind was needed this session.
+
+## Closing inventory
+- **Branch on close:** `main` @ `53d1a8bf`; `feature/ios-release-zeroize` committed through the handoff commit (fix = `bebeb0e2`). PR to open per §4. Squash-merge → one commit on `main`.
+- **Acceptance:** green — `run-ios-tests.sh` reaches `** TEST SUCCEEDED **` + `** BUILD SUCCEEDED **` (host 35/35 + 205/205, simulator XCTest, app build), exit 0. Guardrails empty.
+- **Reviews:** trivial one-line defensive fix mirroring an existing reviewed pattern; no per-task review dispatched.
+- **README.md / ROADMAP.md:** intentionally unchanged (see §1 decision).
+- **NEXT_SESSION.md:** symlink retargeted to this file.

--- a/ios/SecretaryKit/Sources/SecretaryKit/DeviceUnlock/SecureEnclaveDeviceSecretStore.swift
+++ b/ios/SecretaryKit/Sources/SecretaryKit/DeviceUnlock/SecureEnclaveDeviceSecretStore.swift
@@ -59,10 +59,16 @@ public final class SecureEnclaveDeviceSecretStore: DeviceSecretEnclave {
         return try await withCheckedThrowingContinuation { continuation in
             // SecKeyCreateDecryptedData on an SE key triggers the biometric prompt.
             var error: Unmanaged<CFError>?
-            guard let plain = SecKeyCreateDecryptedData(key, algorithm, blob as CFData, &error) as Data? else {
+            guard var plain = SecKeyCreateDecryptedData(key, algorithm, blob as CFData, &error) as Data? else {
                 continuation.resume(throwing: mapDecryptError(error))
                 return
             }
+            // Zero the transient decrypt buffer in place once the returned `[UInt8]`
+            // copy is built, so no residue of the device secret lingers in this
+            // `Data` after release — mirrors the `Data.resetBytes` discipline in
+            // `UniffiVaultDeviceSlotPort`/`UniffiVaultCreatePort`. The caller (e.g.
+            // `EnclaveBiometricAuthorizer`) zeroizes the returned `[UInt8]` copy.
+            defer { plain.resetBytes(in: 0..<plain.count) }
             continuation.resume(returning: [UInt8](plain))
         }
     }


### PR DESCRIPTION
## What

`SecureEnclaveDeviceSecretStore.release(reason:)` decrypts the wrapped device secret into a `Data` via `SecKeyCreateDecryptedData`, copies it to the returned `[UInt8]`, then previously dropped the `Data` without overwriting it — leaving **one transient in-process copy of the 32-byte device secret** in that buffer, regardless of any zeroize the caller performs on the returned array.

This adds `defer { plain.resetBytes(in: 0..<plain.count) }` after the `[UInt8]` copy is built, so the decrypt buffer is zeroed in place — mirroring the `Data.resetBytes` discipline already used in `UniffiVaultDeviceSlotPort`/`UniffiVaultCreatePort`. The returned value is unchanged; the caller (`EnclaveBiometricAuthorizer`) still zeroizes its own copy.

## Why

This is the **shared device-unlock path** used by both B.3 device unlock and the write-reauth `EnclaveBiometricAuthorizer` (#275). Low severity (in-process, short-lived, device-secret ≠ master key), but inconsistent with the project's zeroize discipline. Found during #275's review, filed as #274, deferred out of that PR's scope.

## Test

No dedicated unit test: the zeroized `plain` is a discarded local `Data` with **no externally observable effect** (the returned `[UInt8]` is identical with/without the zeroize), and the real `release` path requires the Secure Enclave + biometric (untestable on host/simulator, per the class header). Like the existing `resetBytes` sites, the zeroize carries no automated assertion. Verification is the full no-regression gauntlet:

- `run-ios-tests.sh` → SecretaryDeviceUnlock host **35/35**, SecretaryVaultAccess host **205/205**, `** TEST SUCCEEDED **` (simulator XCTest) + `** BUILD SUCCEEDED **` (app build), exit 0.

## Scope

iOS-Swift-only (+7 / −1, one file). No Rust / crypto-design / vault-format / `.udl` / pyo3 / Android change — guardrails empty by construction.

Closes #274

🤖 Generated with [Claude Code](https://claude.com/claude-code)