### PR TITLE
fix(cli): harden daemon manifest-rollback defense (#207/#208/#209)

### DIFF
--- a/NEXT_SESSION.md
+++ b/NEXT_SESSION.md
@@ -1,1 +1,1 @@
-docs/handoffs/2026-06-24-trash-content-commitment-shipped.md
+docs/handoffs/2026-06-24-daemon-rollback-hardening-shipped.md

--- a/cli/src/daemon.rs
+++ b/cli/src/daemon.rs
@@ -38,6 +38,7 @@ use secretary_core::unlock::UnlockedIdentity;
 use secretary_core::vault::block::VectorClockEntry;
 
 use crate::pipeline::{run_one, RunOutcome};
+use crate::state::{self, StateError};
 use crate::veto::VetoUx;
 use crate::watcher::debounce::step as debounce_step;
 use crate::watcher::notify_driver::NotifyWatcher;
@@ -255,6 +256,31 @@ fn log_outcome(outcome: &RunOutcome) {
     }
 }
 
+/// Handle the result of one `run_one` pass: log the operator-visible
+/// outcome (#207) and persist `state` (#208) whenever it advanced. `save`
+/// is injected (not a direct `state::save` call) so the loop body is
+/// unit-testable without a real watcher or filesystem. A save failure is
+/// logged and swallowed — the in-memory clock has still advanced, and a
+/// transient FS error must not kill a daemon that may run for weeks; the
+/// next advancing pass retries the persist.
+fn after_sync(
+    result: Result<RunOutcome, SyncError>,
+    state: &SyncState,
+    save: &mut dyn FnMut(&SyncState) -> Result<(), StateError>,
+) {
+    match result {
+        Ok(outcome) => {
+            log_outcome(&outcome);
+            if outcome.advanced_state() {
+                if let Err(e) = save(state) {
+                    tracing::warn!("state persist after sync failed (continuing): {e}");
+                }
+            }
+        }
+        Err(e) => tracing::warn!("pipeline error (continuing): {e}"),
+    }
+}
+
 /// Threshold of consecutive `wait_for_ready` → `Ok(false)` returns that
 /// triggers a single operator-visible warn log. After this many
 /// debounce-fired or periodic-fired cycles in a row where the folder
@@ -282,9 +308,11 @@ pub const READY_NOT_READY_WARN_THRESHOLD: u32 = 5;
 ///    returns a warn-level log fires once so operators notice when
 ///    something external is continuously modifying the folder and
 ///    starving the sync; the counter resets on the next `Ok(true)`.
-/// 2. Calls [`run_one`] for one sync attempt; any [`SyncError`] is
-///    logged at warn level and the loop continues per spec §"Daemon
-///    loop sketch" ("on pipeline error: log + continue").
+/// 2. Calls [`run_one`] for one sync attempt, then calls
+///    [`after_sync`] to log the outcome and persist state if it
+///    advanced (#208). A save failure is logged and swallowed;
+///    any pipeline [`SyncError`] is logged at warn level and the loop
+///    continues per spec §"Daemon loop sketch".
 ///
 /// # Errors
 ///
@@ -298,12 +326,14 @@ pub const READY_NOT_READY_WARN_THRESHOLD: u32 = 5;
 /// against `golden_vault_001`. Each individual piece (`NotifyWatcher`,
 /// `debounce_step`, `wait_for_ready`, `run_one`) is unit-tested in
 /// place.
+#[allow(clippy::too_many_arguments)] // production seam — all params are distinct, non-groupable
 pub fn run_against_vault(
     vault_folder: &Path,
     identity: &UnlockedIdentity,
     password: &SecretBytes,
     state: &mut SyncState,
     veto_ux: &mut dyn VetoUx,
+    state_dir: &Path,
     config: DaemonConfig,
     ready_window: Duration,
 ) -> Result<(), SyncError> {
@@ -345,10 +375,9 @@ pub fn run_against_vault(
                     return;
                 }
             }
-            match run_one(vault_folder, identity, password, state, veto_ux, now_ms()) {
-                Ok(outcome) => log_outcome(&outcome),
-                Err(e) => tracing::warn!("pipeline error (continuing): {e}"),
-            }
+            let result = run_one(vault_folder, identity, password, state, veto_ux, now_ms());
+            let mut save = |s: &SyncState| state::save(state_dir, s);
+            after_sync(result, state, &mut save);
         },
     );
     Ok(())
@@ -405,9 +434,13 @@ mod tests {
     //! Debounce windows are kept short (~50 ms) so the suite stays
     //! under a second of real time.
 
+    use std::collections::VecDeque;
+    use std::sync::atomic::AtomicBool;
+    use std::sync::Arc;
+
     use super::*;
     use crate::pipeline::RunOutcome;
-    use secretary_core::sync::RollbackEvidence;
+    use secretary_core::sync::{RollbackEvidence, SyncError, SyncState};
 
     #[test]
     fn outcome_log_rollback_carries_clocks() {
@@ -437,9 +470,58 @@ mod tests {
         assert_eq!(outcome_log(&RunOutcome::AppliedAutomatically), None);
         assert_eq!(outcome_log(&RunOutcome::SilentMerge), None);
     }
-    use std::collections::VecDeque;
-    use std::sync::atomic::AtomicBool;
-    use std::sync::Arc;
+
+    #[test]
+    fn after_sync_saves_on_advancing_arms() {
+        let state = SyncState::empty([1; 16]);
+        for outcome in [
+            RunOutcome::AppliedAutomatically,
+            RunOutcome::SilentMerge,
+            RunOutcome::MergedAndCommitted { vetoes_resolved: 0 },
+        ] {
+            let mut saves = 0u32;
+            let mut sink = |_: &SyncState| {
+                saves += 1;
+                Ok(())
+            };
+            after_sync(Ok(outcome), &state, &mut sink);
+            assert_eq!(saves, 1);
+        }
+    }
+
+    #[test]
+    fn after_sync_skips_save_on_non_advancing_arms() {
+        let state = SyncState::empty([2; 16]);
+        let ev = RollbackEvidence {
+            disk_vector_clock: Vec::new(),
+            local_highest_seen: Vec::new(),
+        };
+        for outcome in [RunOutcome::NothingToDo, RunOutcome::RollbackRejected(ev)] {
+            let mut saves = 0u32;
+            let mut sink = |_: &SyncState| {
+                saves += 1;
+                Ok(())
+            };
+            after_sync(Ok(outcome), &state, &mut sink);
+            assert_eq!(saves, 0);
+        }
+    }
+
+    #[test]
+    fn after_sync_does_not_save_on_err() {
+        let state = SyncState::empty([3; 16]);
+        let mut saves = 0u32;
+        let mut sink = |_: &SyncState| {
+            saves += 1;
+            Ok(())
+        };
+        let err = SyncError::Vault(secretary_core::vault::VaultError::Io {
+            context: "test",
+            source: std::io::Error::other("boom"),
+        });
+        after_sync(Err(err), &state, &mut sink);
+        assert_eq!(saves, 0);
+    }
 
     /// Short debounce window used across daemon tests. Tuned to be
     /// comfortably larger than typical iteration overhead (sub-ms)

--- a/cli/src/daemon.rs
+++ b/cli/src/daemon.rs
@@ -35,8 +35,9 @@ use std::time::{Duration, Instant};
 use secretary_core::crypto::secret::SecretBytes;
 use secretary_core::sync::{SyncError, SyncState};
 use secretary_core::unlock::UnlockedIdentity;
+use secretary_core::vault::block::VectorClockEntry;
 
-use crate::pipeline::run_one;
+use crate::pipeline::{run_one, RunOutcome};
 use crate::veto::VetoUx;
 use crate::watcher::debounce::step as debounce_step;
 use crate::watcher::notify_driver::NotifyWatcher;
@@ -200,6 +201,60 @@ fn compute_wait(
     wait
 }
 
+/// What (if anything) a successful [`RunOutcome`] should announce to the
+/// operator. Pure classification — the caller maps it to a `tracing`
+/// call. Kept separate from the emission so the decision is unit-testable
+/// without a subscriber, and so `pipeline.rs` stays free of logging.
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum OutcomeLog {
+    /// Manifest-rollback attack indicator (threat-model §3.1). Carries
+    /// the two clocks an operator needs for forensics.
+    RollbackRejected {
+        disk: Vec<VectorClockEntry>,
+        local: Vec<VectorClockEntry>,
+    },
+    /// `n > 0` tombstone vetoes were auto-resolved — a peer record
+    /// deletion was overridden this pass.
+    VetoesResolved(usize),
+}
+
+/// Classify an `Ok(RunOutcome)` into the operator-visible log event, if
+/// any. The silent arms (`NothingToDo`, `AppliedAutomatically`,
+/// `SilentMerge`, and `MergedAndCommitted { vetoes_resolved: 0 }`) return
+/// `None`.
+fn outcome_log(outcome: &RunOutcome) -> Option<OutcomeLog> {
+    match outcome {
+        RunOutcome::RollbackRejected(ev) => Some(OutcomeLog::RollbackRejected {
+            disk: ev.disk_vector_clock.clone(),
+            local: ev.local_highest_seen.clone(),
+        }),
+        RunOutcome::MergedAndCommitted { vetoes_resolved } if *vetoes_resolved > 0 => {
+            Some(OutcomeLog::VetoesResolved(*vetoes_resolved))
+        }
+        RunOutcome::NothingToDo
+        | RunOutcome::AppliedAutomatically
+        | RunOutcome::SilentMerge
+        | RunOutcome::MergedAndCommitted { .. } => None,
+    }
+}
+
+/// Emit the operator-visible log line (if any) for a successful sync
+/// outcome. The side-effecting edge over the pure [`outcome_log`].
+fn log_outcome(outcome: &RunOutcome) {
+    match outcome_log(outcome) {
+        Some(OutcomeLog::RollbackRejected { disk, local }) => tracing::warn!(
+            disk_clock = ?disk,
+            local_clock = ?local,
+            "manifest rollback rejected (threat-model §3.1 attack indicator); daemon continues",
+        ),
+        Some(OutcomeLog::VetoesResolved(n)) => tracing::warn!(
+            vetoes_resolved = n,
+            "auto-resolved {n} tombstone veto(es): a peer record deletion was overridden",
+        ),
+        None => {}
+    }
+}
+
 /// Threshold of consecutive `wait_for_ready` → `Ok(false)` returns that
 /// triggers a single operator-visible warn log. After this many
 /// debounce-fired or periodic-fired cycles in a row where the folder
@@ -290,8 +345,9 @@ pub fn run_against_vault(
                     return;
                 }
             }
-            if let Err(e) = run_one(vault_folder, identity, password, state, veto_ux, now_ms()) {
-                tracing::warn!("pipeline error (continuing): {e}");
+            match run_one(vault_folder, identity, password, state, veto_ux, now_ms()) {
+                Ok(outcome) => log_outcome(&outcome),
+                Err(e) => tracing::warn!("pipeline error (continuing): {e}"),
             }
         },
     );
@@ -350,6 +406,37 @@ mod tests {
     //! under a second of real time.
 
     use super::*;
+    use crate::pipeline::RunOutcome;
+    use secretary_core::sync::RollbackEvidence;
+
+    #[test]
+    fn outcome_log_rollback_carries_clocks() {
+        let ev = RollbackEvidence {
+            disk_vector_clock: Vec::new(),
+            local_highest_seen: Vec::new(),
+        };
+        let log = outcome_log(&RunOutcome::RollbackRejected(ev));
+        assert!(matches!(log, Some(OutcomeLog::RollbackRejected { .. })));
+    }
+
+    #[test]
+    fn outcome_log_vetoes_only_when_nonzero() {
+        assert_eq!(
+            outcome_log(&RunOutcome::MergedAndCommitted { vetoes_resolved: 3 }),
+            Some(OutcomeLog::VetoesResolved(3))
+        );
+        assert_eq!(
+            outcome_log(&RunOutcome::MergedAndCommitted { vetoes_resolved: 0 }),
+            None
+        );
+    }
+
+    #[test]
+    fn outcome_log_silent_arms_are_none() {
+        assert_eq!(outcome_log(&RunOutcome::NothingToDo), None);
+        assert_eq!(outcome_log(&RunOutcome::AppliedAutomatically), None);
+        assert_eq!(outcome_log(&RunOutcome::SilentMerge), None);
+    }
     use std::collections::VecDeque;
     use std::sync::atomic::AtomicBool;
     use std::sync::Arc;

--- a/cli/src/daemon.rs
+++ b/cli/src/daemon.rs
@@ -324,8 +324,8 @@ pub const READY_NOT_READY_WARN_THRESHOLD: u32 = 5;
 /// unit-tested because its only logic is the closure composition —
 /// the integration test suite (Task 10) will exercise it end-to-end
 /// against `golden_vault_001`. Each individual piece (`NotifyWatcher`,
-/// `debounce_step`, `wait_for_ready`, `run_one`) is unit-tested in
-/// place.
+/// `debounce_step`, `wait_for_ready`, `run_one`, `after_sync`) is
+/// unit-tested in place.
 #[allow(clippy::too_many_arguments)] // production seam — all params are distinct, non-groupable
 pub fn run_against_vault(
     vault_folder: &Path,
@@ -505,6 +505,26 @@ mod tests {
             after_sync(Ok(outcome), &state, &mut sink);
             assert_eq!(saves, 0);
         }
+    }
+
+    /// `after_sync` swallows a save-sink failure on an advancing arm.
+    /// The in-memory clock still advanced; a transient FS error must not
+    /// propagate — the next advancing pass will retry the persist.
+    #[test]
+    fn after_sync_swallows_save_error() {
+        let state = SyncState::empty([4; 16]);
+        let mut sink_called = false;
+        let mut sink = |_: &SyncState| {
+            sink_called = true;
+            Err(StateError::Io(std::io::Error::other("disk full")))
+        };
+        // AppliedAutomatically is an advancing arm — the sink is invoked
+        // but its Err must be swallowed (after_sync returns (), not a panic).
+        after_sync(Ok(RunOutcome::AppliedAutomatically), &state, &mut sink);
+        assert!(sink_called, "sink must be invoked on an advancing arm");
+        // No assertion needed for the return value: if after_sync propagated
+        // the error it would not compile (returns ()), and if it panicked
+        // the test would fail.
     }
 
     #[test]

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -27,7 +27,7 @@ use std::process::ExitCode as ProcExitCode;
 use std::time::Duration;
 
 use clap::Parser;
-use tracing::{error, warn};
+use tracing::error;
 
 use secretary_cli::args::{Cli, Command, CommonArgs, RunArgs};
 use secretary_cli::daemon::{self, DaemonConfig, DEFAULT_SHUTDOWN_POLL_INTERVAL};
@@ -141,14 +141,25 @@ fn run(cli: Cli) -> ExitCode {
             &identity,
             &password,
             &mut state,
+            &state_dir,
             interactive,
         ),
         None => dispatch_once_subcommand(vault, &identity, &password, &mut state, interactive),
     };
 
-    if let Err(e) = state::save(&state_dir, &state) {
-        warn!("final state save failed: {e}");
-    }
+    let exit_code = match state::save(&state_dir, &state) {
+        Ok(()) => exit_code,
+        Err(e) => {
+            error!("final state save failed: {e}");
+            // Don't override a more specific non-success code (e.g.
+            // RollbackRejected, LockfileHeld); only escalate a Success.
+            if matches!(exit_code, ExitCode::Success) {
+                ExitCode::GenericError
+            } else {
+                exit_code
+            }
+        }
+    };
 
     exit_code
 }
@@ -278,6 +289,7 @@ fn dispatch_run_subcommand(
     identity: &UnlockedIdentity,
     password: &SecretBytes,
     state: &mut SyncState,
+    state_dir: &Path,
     interactive: bool,
 ) -> ExitCode {
     let guard = match cli_signal::install_shutdown_handlers() {
@@ -303,6 +315,7 @@ fn dispatch_run_subcommand(
             password,
             state,
             &mut ux,
+            state_dir,
             config,
             ready_window,
         )
@@ -314,6 +327,7 @@ fn dispatch_run_subcommand(
             password,
             state,
             &mut ux,
+            state_dir,
             config,
             ready_window,
         )

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -22,7 +22,7 @@
 //! [`secretary_cli::pipeline::run_one`]'s state-mutation contract.
 
 use std::io;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 use std::process::ExitCode as ProcExitCode;
 use std::time::Duration;
 
@@ -48,12 +48,6 @@ const VAULT_TOML_FILENAME: &str = "vault.toml";
 /// folder. Spec: `docs/vault-format.md` §5 (note the `.enc` extension —
 /// AEAD-sealed, not raw CBOR).
 const IDENTITY_BUNDLE_FILENAME: &str = "identity.bundle.enc";
-/// Fallback `--state-dir` when neither `--state-dir` nor
-/// `dirs::data_dir()` produces a path. The current working directory is
-/// a safe last-resort that lets minimal headless installs (no `$HOME`,
-/// no XDG vars) at least run; the operator can pin a better location
-/// via `--state-dir` once they notice the state-file sprawl.
-const STATE_DIR_FALLBACK: &str = ".";
 
 fn main() -> ProcExitCode {
     let cli = Cli::parse();
@@ -110,7 +104,15 @@ fn run(cli: Cli) -> ExitCode {
         Err(e) => return fail_generic(format_args!("decode vault.toml failed: {e}")),
     };
 
-    let state_dir = resolve_state_dir(common);
+    let state_dir =
+        match state::resolve_state_dir(common.state_dir.clone(), state::default_state_dir(), vault)
+        {
+            Ok(d) => d,
+            Err(e) => {
+                error!("{e}");
+                return ExitCode::UsageError;
+            }
+        };
     let mut state = match state::load(&state_dir, vault_uuid) {
         Ok(s) => s,
         Err(e) => return fail_generic(format_args!("state load failed: {e}")),
@@ -180,20 +182,6 @@ fn decompose(cmd: &Command) -> (&CommonArgs, &Path, Option<&RunArgs>) {
             vault_folder,
         } => (common, vault_folder.as_path(), Some(run_args)),
     }
-}
-
-/// Resolve the state directory using the documented precedence:
-/// `--state-dir` ⟶ `dirs::data_dir()`-derived default ⟶
-/// [`STATE_DIR_FALLBACK`]. Falling back to `.` rather than erroring
-/// keeps minimal headless installs (no `$HOME`, no XDG vars) at least
-/// runnable; the operator can pin a real location via `--state-dir`
-/// once they notice the sprawl.
-fn resolve_state_dir(common: &CommonArgs) -> PathBuf {
-    common
-        .state_dir
-        .clone()
-        .or_else(state::default_state_dir)
-        .unwrap_or_else(|| PathBuf::from(STATE_DIR_FALLBACK))
 }
 
 /// Extract the 16-byte `vault_uuid` from already-read `vault.toml`

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -154,7 +154,8 @@ fn run(cli: Cli) -> ExitCode {
         Err(e) => {
             error!("final state save failed: {e}");
             // Don't override a more specific non-success code (e.g.
-            // RollbackRejected, LockfileHeld); only escalate a Success.
+            // RollbackRejected, EvidenceStale); only escalate a Success.
+            // (LockfileHeld returns earlier at line ~133 and never reaches here.)
             if matches!(exit_code, ExitCode::Success) {
                 ExitCode::GenericError
             } else {
@@ -353,4 +354,34 @@ fn now_ms() -> u64 {
         .duration_since(UNIX_EPOCH)
         .map(|d| u64::try_from(d.as_millis()).unwrap_or(u64::MAX))
         .unwrap_or(0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use secretary_core::sync::RollbackEvidence;
+
+    /// `RollbackRejected` (with empty evidence) must map to the
+    /// `RollbackRejected` exit code, not `Success`.
+    #[test]
+    fn outcome_to_exit_code_rollback_rejected_returns_rollback_code() {
+        let ev = RollbackEvidence {
+            disk_vector_clock: Vec::new(),
+            local_highest_seen: Vec::new(),
+        };
+        assert!(matches!(
+            outcome_to_exit_code(RunOutcome::RollbackRejected(ev)),
+            ExitCode::RollbackRejected
+        ));
+    }
+
+    /// Non-rollback arms (e.g. `AppliedAutomatically`) must map to
+    /// `Success` — the disk state advanced normally.
+    #[test]
+    fn outcome_to_exit_code_applied_automatically_returns_success() {
+        assert!(matches!(
+            outcome_to_exit_code(RunOutcome::AppliedAutomatically),
+            ExitCode::Success
+        ));
+    }
 }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -333,7 +333,7 @@ fn dispatch_run_subcommand(
 /// command completed.
 fn outcome_to_exit_code(outcome: RunOutcome) -> ExitCode {
     match outcome {
-        RunOutcome::RollbackRejected => ExitCode::RollbackRejected,
+        RunOutcome::RollbackRejected(_) => ExitCode::RollbackRejected,
         RunOutcome::NothingToDo
         | RunOutcome::AppliedAutomatically
         | RunOutcome::SilentMerge

--- a/cli/src/pipeline.rs
+++ b/cli/src/pipeline.rs
@@ -86,6 +86,21 @@ pub enum RunOutcome {
     RollbackRejected(RollbackEvidence),
 }
 
+impl RunOutcome {
+    /// `true` iff this outcome advanced `state.highest_vector_clock_seen`
+    /// and therefore must be persisted before the next daemon iteration.
+    /// Matches the C.2 spec §"State persistence" persist-list (extended
+    /// to include `SilentMerge`, which post-dates the spec text but does
+    /// advance the clock — see `run_one`'s state-mutation contract).
+    #[must_use]
+    pub fn advanced_state(&self) -> bool {
+        matches!(
+            self,
+            Self::AppliedAutomatically | Self::SilentMerge | Self::MergedAndCommitted { .. }
+        )
+    }
+}
+
 /// Outcome of one [`sync_pass_pause_on_conflict`] pass. Mirrors
 /// [`RunOutcome`] for the safe arms, but replaces the always-commit
 /// `MergedAndCommitted` with two outcomes: [`Self::MergedClean`] (a
@@ -789,6 +804,20 @@ mod tests {
         let dbg = format!("{c:?}");
         assert!(dbg.contains("ConflictsPending"));
         assert!(dbg.contains('7'));
+    }
+
+    #[test]
+    fn advanced_state_true_for_advancing_arms() {
+        assert!(RunOutcome::AppliedAutomatically.advanced_state());
+        assert!(RunOutcome::SilentMerge.advanced_state());
+        assert!(RunOutcome::MergedAndCommitted { vetoes_resolved: 0 }.advanced_state());
+        assert!(RunOutcome::MergedAndCommitted { vetoes_resolved: 5 }.advanced_state());
+    }
+
+    #[test]
+    fn advanced_state_false_for_non_advancing_arms() {
+        assert!(!RunOutcome::NothingToDo.advanced_state());
+        assert!(!RunOutcome::RollbackRejected(sample_evidence()).advanced_state());
     }
 
     /// `Clone` round-trip preserves variant + payload. Pins the

--- a/cli/src/pipeline.rs
+++ b/cli/src/pipeline.rs
@@ -91,7 +91,8 @@ impl RunOutcome {
     /// and therefore must be persisted before the next daemon iteration.
     /// Matches the C.2 spec §"State persistence" persist-list (extended
     /// to include `SilentMerge`, which post-dates the spec text but does
-    /// advance the clock — see `run_one`'s state-mutation contract).
+    /// advance the clock — see `run_one`'s `# State mutation contract`
+    /// doc section for the per-variant details).
     #[must_use]
     pub fn advanced_state(&self) -> bool {
         matches!(

--- a/cli/src/pipeline.rs
+++ b/cli/src/pipeline.rs
@@ -25,8 +25,8 @@ use std::path::Path;
 use secretary_core::crypto::secret::SecretBytes;
 use secretary_core::sync::draft::RecordCollisionSummary;
 use secretary_core::sync::{
-    commit_with_decisions, prepare_merge, sync_once, ManifestHash, RecordTombstoneVeto, SyncError,
-    SyncOutcome, SyncState, VetoDecision,
+    commit_with_decisions, prepare_merge, sync_once, ManifestHash, RecordTombstoneVeto,
+    RollbackEvidence, SyncError, SyncOutcome, SyncState, VetoDecision,
 };
 use secretary_core::unlock::UnlockedIdentity;
 use secretary_core::vault::block::VectorClockEntry;
@@ -80,8 +80,10 @@ pub enum RunOutcome {
     /// `highest_vector_clock_seen` (rollback per
     /// `docs/crypto-design.md` §10). `state` is NOT advanced — caller
     /// surfaces [`crate::exit::ExitCode::RollbackRejected`] and the
-    /// next attempt sees the same disk state.
-    RollbackRejected,
+    /// next attempt sees the same disk state. Carries the
+    /// [`RollbackEvidence`] (disk clock + local clock) so the daemon
+    /// loop can log the attack indicator with forensic detail (#207).
+    RollbackRejected(RollbackEvidence),
 }
 
 /// Outcome of one [`sync_pass_pause_on_conflict`] pass. Mirrors
@@ -223,7 +225,7 @@ pub fn run_one(
             *state = new_state;
             Ok(RunOutcome::AppliedAutomatically)
         }
-        SyncOutcome::RollbackRejected(_evidence) => Ok(RunOutcome::RollbackRejected),
+        SyncOutcome::RollbackRejected(evidence) => Ok(RunOutcome::RollbackRejected(evidence)),
         SyncOutcome::ConcurrentDetected {
             bundle,
             plan,
@@ -554,6 +556,13 @@ mod tests {
 
     use super::*;
 
+    fn sample_evidence() -> RollbackEvidence {
+        RollbackEvidence {
+            disk_vector_clock: Vec::new(),
+            local_highest_seen: Vec::new(),
+        }
+    }
+
     /// Identical variants compare equal via the derived [`Eq`] impl.
     #[test]
     fn nothing_to_do_is_self_equal() {
@@ -578,7 +587,10 @@ mod tests {
     /// Identical `RollbackRejected` values compare equal.
     #[test]
     fn rollback_rejected_is_self_equal() {
-        assert_eq!(RunOutcome::RollbackRejected, RunOutcome::RollbackRejected);
+        assert_eq!(
+            RunOutcome::RollbackRejected(sample_evidence()),
+            RunOutcome::RollbackRejected(sample_evidence())
+        );
     }
 
     /// Two `MergedAndCommitted` with the same `vetoes_resolved` count
@@ -619,8 +631,14 @@ mod tests {
     fn distinct_variants_are_not_equal() {
         assert_ne!(RunOutcome::NothingToDo, RunOutcome::AppliedAutomatically);
         assert_ne!(RunOutcome::AppliedAutomatically, RunOutcome::SilentMerge);
-        assert_ne!(RunOutcome::SilentMerge, RunOutcome::RollbackRejected);
-        assert_ne!(RunOutcome::NothingToDo, RunOutcome::RollbackRejected);
+        assert_ne!(
+            RunOutcome::SilentMerge,
+            RunOutcome::RollbackRejected(sample_evidence())
+        );
+        assert_ne!(
+            RunOutcome::NothingToDo,
+            RunOutcome::RollbackRejected(sample_evidence())
+        );
         assert_ne!(
             RunOutcome::AppliedAutomatically,
             RunOutcome::MergedAndCommitted { vetoes_resolved: 0 }
@@ -641,7 +659,10 @@ mod tests {
         assert!(format!("{:?}", RunOutcome::NothingToDo).contains("NothingToDo"));
         assert!(format!("{:?}", RunOutcome::AppliedAutomatically).contains("AppliedAutomatically"));
         assert!(format!("{:?}", RunOutcome::SilentMerge).contains("SilentMerge"));
-        assert!(format!("{:?}", RunOutcome::RollbackRejected).contains("RollbackRejected"));
+        assert!(
+            format!("{:?}", RunOutcome::RollbackRejected(sample_evidence()))
+                .contains("RollbackRejected")
+        );
         let merged = RunOutcome::MergedAndCommitted { vetoes_resolved: 3 };
         let dbg = format!("{merged:?}");
         assert!(dbg.contains("MergedAndCommitted"));
@@ -780,7 +801,7 @@ mod tests {
             RunOutcome::NothingToDo,
             RunOutcome::AppliedAutomatically,
             RunOutcome::SilentMerge,
-            RunOutcome::RollbackRejected,
+            RunOutcome::RollbackRejected(sample_evidence()),
             RunOutcome::MergedAndCommitted {
                 vetoes_resolved: 42,
             },

--- a/cli/src/state.rs
+++ b/cli/src/state.rs
@@ -41,6 +41,12 @@ const STATE_FILE_EXTENSION: &str = "state.cbor";
 const LOCK_FILE_EXTENSION: &str = "lock";
 const VAULT_UUID_HEX_LEN: usize = 32;
 
+/// Mode the state directory is created with on first run (Unix only).
+/// C.2 spec §"State persistence": "Directory created on first run with
+/// mode 0700 (Unix)." Non-secret metadata, but the spec/code divergence
+/// is resolved in favour of the spec.
+const STATE_DIR_MODE: u32 = 0o700;
+
 #[derive(Debug, Error)]
 pub enum StateError {
     #[error("I/O error reading or writing state file: {0}")]
@@ -56,6 +62,101 @@ pub enum StateError {
     Encode(SyncError),
     #[error("lockfile {0} already held by another secretary-sync process")]
     LockfileHeld(PathBuf),
+}
+
+/// Why a usable state directory could not be established. Distinct from
+/// [`StateError`] (I/O / decode / lock): these are operator
+/// misconfigurations caught before any vault work, mapped by `main` to
+/// the usage exit code.
+#[derive(Debug, Error)]
+pub enum StateDirError {
+    #[error(
+        "could not resolve a state directory (no --state-dir given and no OS data dir available); \
+         pass --state-dir to a host-local path outside the vault folder"
+    )]
+    Unresolvable,
+    #[error(
+        "refusing to place rollback-detection state inside the vault folder \
+         (state dir {state_dir} is within {vault}); pass --state-dir to a host-local path \
+         outside the vault"
+    )]
+    InsideVault { state_dir: String, vault: String },
+}
+
+/// Absolute, lexically-normalized form of `p`: joins the current dir if
+/// relative, then folds `.` and `..` components. Does NOT resolve
+/// symlinks — this is a misconfiguration guard, not a defence against an
+/// attacker who can plant symlinks on the operator's local filesystem
+/// (the in-scope adversary controls the synced folder's *contents*, not
+/// the host's FS layout).
+fn normalize_abs(p: &Path) -> PathBuf {
+    use std::path::Component;
+    let abs = if p.is_absolute() {
+        p.to_path_buf()
+    } else {
+        std::env::current_dir()
+            .unwrap_or_else(|_| PathBuf::from("."))
+            .join(p)
+    };
+    let mut out = PathBuf::new();
+    for comp in abs.components() {
+        match comp {
+            Component::CurDir => {}
+            Component::ParentDir => {
+                out.pop();
+            }
+            other => out.push(other.as_os_str()),
+        }
+    }
+    out
+}
+
+/// `true` iff `child` is `ancestor` or lives beneath it, compared over
+/// the lexically-normalized absolute forms.
+fn is_within(child: &Path, ancestor: &Path) -> bool {
+    normalize_abs(child).starts_with(normalize_abs(ancestor))
+}
+
+/// Resolve the state directory. `explicit` is `--state-dir`; `os_default`
+/// is [`default_state_dir`]. An explicit path always wins (even `.` —
+/// an informed operator choice). Otherwise the OS data dir. If neither is
+/// available the result is [`StateDirError::Unresolvable`] — there is
+/// **no** silent current-working-directory fallback. The resolved path is
+/// rejected with [`StateDirError::InsideVault`] if it lies within
+/// `vault_folder`.
+pub fn resolve_state_dir(
+    explicit: Option<PathBuf>,
+    os_default: Option<PathBuf>,
+    vault_folder: &Path,
+) -> Result<PathBuf, StateDirError> {
+    let dir = explicit.or(os_default).ok_or(StateDirError::Unresolvable)?;
+    if is_within(&dir, vault_folder) {
+        return Err(StateDirError::InsideVault {
+            state_dir: dir.display().to_string(),
+            vault: vault_folder.display().to_string(),
+        });
+    }
+    Ok(dir)
+}
+
+/// Create `path` and any missing parents. On Unix the directory is
+/// created with mode [`STATE_DIR_MODE`] (0700); other platforms use a
+/// plain recursive create. An already-existing directory is left as-is
+/// (its mode is not changed), matching the spec wording "created on first
+/// run with mode 0700".
+fn create_dir_secure(path: &Path) -> std::io::Result<()> {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::DirBuilderExt;
+        std::fs::DirBuilder::new()
+            .recursive(true)
+            .mode(STATE_DIR_MODE)
+            .create(path)
+    }
+    #[cfg(not(unix))]
+    {
+        std::fs::create_dir_all(path)
+    }
 }
 
 /// 16-byte vault UUID → lowercase hex string (32 chars, no separator).
@@ -132,7 +233,7 @@ pub fn load(state_dir: &Path, vault_uuid: [u8; 16]) -> Result<SyncState, StateEr
 /// Uses `tempfile::NamedTempFile::persist` for rename(2) / MoveFileExW
 /// semantics — same `=3.27.0` exact pin as the vault format layer.
 pub fn save(state_dir: &Path, state: &SyncState) -> Result<(), StateError> {
-    fs::create_dir_all(state_dir)?;
+    create_dir_secure(state_dir)?;
     let final_path = state_file_path(state_dir, state.vault_uuid);
     let bytes = state.to_canonical_cbor().map_err(StateError::Encode)?;
 
@@ -156,7 +257,7 @@ impl LockfileGuard {
     /// Returns `Err(StateError::LockfileHeld)` if another process already
     /// holds it.
     pub fn acquire(state_dir: &Path, vault_uuid: [u8; 16]) -> Result<Self, StateError> {
-        fs::create_dir_all(state_dir)?;
+        create_dir_secure(state_dir)?;
         let path = lock_file_path(state_dir, vault_uuid);
         let file = OpenOptions::new()
             .create(true)
@@ -317,5 +418,71 @@ mod tests {
             matches!(err, StateError::Decode(_)),
             "expected Decode, got {err:?}"
         );
+    }
+
+    #[test]
+    fn is_within_detects_nested_and_rejects_sibling() {
+        assert!(is_within(
+            Path::new("/vault/sub/state"),
+            Path::new("/vault")
+        ));
+        assert!(is_within(Path::new("/vault"), Path::new("/vault")));
+        assert!(!is_within(Path::new("/other/state"), Path::new("/vault")));
+    }
+
+    #[test]
+    fn is_within_folds_parent_dir_escape() {
+        // /vault/../else normalizes out of /vault.
+        assert!(!is_within(Path::new("/vault/../else"), Path::new("/vault")));
+    }
+
+    #[test]
+    fn resolve_explicit_wins_even_if_no_os_default() {
+        let got = resolve_state_dir(
+            Some(PathBuf::from("/etc/secretary")),
+            None,
+            Path::new("/vault"),
+        )
+        .unwrap();
+        assert_eq!(got, PathBuf::from("/etc/secretary"));
+    }
+
+    #[test]
+    fn resolve_falls_back_to_os_default() {
+        let got = resolve_state_dir(
+            None,
+            Some(PathBuf::from("/home/u/.local")),
+            Path::new("/vault"),
+        )
+        .unwrap();
+        assert_eq!(got, PathBuf::from("/home/u/.local"));
+    }
+
+    #[test]
+    fn resolve_unresolvable_when_no_source() {
+        let err = resolve_state_dir(None, None, Path::new("/vault")).unwrap_err();
+        assert!(matches!(err, StateDirError::Unresolvable));
+    }
+
+    #[test]
+    fn resolve_rejects_state_dir_inside_vault() {
+        let err = resolve_state_dir(
+            Some(PathBuf::from("/vault/state")),
+            None,
+            Path::new("/vault"),
+        )
+        .unwrap_err();
+        assert!(matches!(err, StateDirError::InsideVault { .. }));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn create_dir_secure_sets_0700() {
+        use std::os::unix::fs::PermissionsExt;
+        let base = TempDir::new().unwrap();
+        let dir = base.path().join("nested").join("sync");
+        create_dir_secure(&dir).unwrap();
+        let mode = std::fs::metadata(&dir).unwrap().permissions().mode() & 0o777;
+        assert_eq!(mode, STATE_DIR_MODE);
     }
 }

--- a/cli/tests/pipeline_integration.rs
+++ b/cli/tests/pipeline_integration.rs
@@ -268,7 +268,7 @@ fn run_one_returns_rollback_rejected_when_state_dominates() {
         TEST_NOW_MS,
     )
     .expect("run_one must succeed (rollback returns Ok, not Err)");
-    assert_eq!(outcome, RunOutcome::RollbackRejected);
+    assert!(matches!(outcome, RunOutcome::RollbackRejected(_)));
     assert_eq!(
         dominating_state.highest_vector_clock_seen, dominating_clock,
         "RollbackRejected must NOT mutate state — the local clock stays dominating"

--- a/docs/handoffs/2026-06-24-daemon-rollback-hardening-shipped.md
+++ b/docs/handoffs/2026-06-24-daemon-rollback-hardening-shipped.md
@@ -1,0 +1,81 @@
+# NEXT_SESSION.md — daemon rollback-detection hardening (#207/#208/#209) ✅ SHIPPED (PR opening)
+
+**Session date:** 2026-06-24. Started from a clean baton — PR #294 (#293 restore content-commitment) had merged to `main` (`1b18b6b4`); cleaned up the prior `.worktrees/trash-content-commitment` worktree + deleted branch. Picked the **#207/#208/#209 daemon-security cluster** (you chose it over #206 / #210 / #251+#229). Brainstormed → spec → plan → executed via **subagent-driven development** (fresh implementer + spec/quality reviewer per task, final whole-branch review on opus) → fixed review Minors → opened PR.
+
+**Status:** ✅ **SHIPPED — branch `feature/daemon-rollback-hardening`, PR opening.** 3 security fixes + 12 new tests; final whole-branch review (opus): **Ready to merge, 0 Critical / 0 Important**; 5 Minors fixed in one wave, 1 filed as #295, 1 dismissed.
+
+## (1) What we shipped this session
+
+All three are confirmed spec/code divergences against the C.2 design (`docs/superpowers/specs/2026-05-23-c2-headless-sync-cli-design.md`); each fix code-aligns to the existing spec (the spec stays the source of truth). **`cli/` only** — no `core/` crypto change, no FFI surface, no on-disk vault/manifest/`SyncState` format change → `conformance.py` + Swift/Kotlin harnesses unaffected.
+
+**#207 (Medium, observability):** the daemon loop discarded every `Ok(RunOutcome)`, so `RollbackRejected` (the threat-model §3.1 attack indicator) and auto-resolved tombstone vetoes were never logged at any verbosity — a malicious cloud host could probe the daemon with replayed manifests at zero alerting cost. **Fix:** enriched `RunOutcome::RollbackRejected(RollbackEvidence)` (the type already derives the needed traits; `once` mode ignores the payload → still exit 10), added a pure `daemon::outcome_log` classifier + `daemon::log_outcome` emitter, and the loop now logs rollback (with disk+local vector clocks) at `warn!` and the auto-resolved-veto count. Logging stays at the daemon edge — `pipeline.rs` has zero `tracing` calls.
+
+**#208 (Medium, defense voided on crash):** `SyncState` (the sole rollback anchor) was persisted only once after the loop exits, so an unclean exit (SIGKILL/OOM/panic/power-loss) discarded the whole session's clock advances → on restart a stale clock let the host replay any manifest from the elapsed window as a forward update (silent rollback). **Fix:** pure `RunOutcome::advanced_state()` (true for AppliedAutomatically | SilentMerge | MergedAndCommitted), `daemon::after_sync(result, state, &mut save_sink)` that logs + persists via an **injected sink** (unit-testable without a watcher/FS) whenever the outcome advanced; threaded `state_dir` into `run_against_vault`; in-loop save failure is logged + swallowed (daemon survives transient FS errors); the final-save failure now escalates a `Success` exit to `GenericError` without overriding a more specific non-success code.
+
+**#209 (Low–Medium, state could land in the attacker's folder):** when `dirs::data_dir()` returns `None` (headless, no `$HOME` — a stated systemd/Docker target) the state dir silently fell back to `"."` (cwd); if WorkingDirectory was the vault folder, rollback state landed inside the attacker-controlled synced folder where the cloud host deletes it → detection disabled. Plus a `0700` spec/code divergence. **Fix (decisions from brainstorming):** **hard error** on implicit cwd fallback (`StateDirError::Unresolvable`; explicit `--state-dir .` still allowed) **and** on a state dir resolving inside the vault (`StateDirError::InsideVault`), both → exit 2 (UsageError); a **lexical** (intentionally symlink-unaware) `normalize_abs`/`is_within` containment guard; `create_dir_secure` applies `STATE_DIR_MODE = 0o700` on Unix. Deleted the old `STATE_DIR_FALLBACK` const + infallible resolver.
+
+**Branch commits** (off `main` @ `1b18b6b4`):
+| SHA | What |
+|---|---|
+| `cee9f4c0` | design doc (`docs/superpowers/specs/2026-06-24-daemon-rollback-hardening-design.md`) |
+| `9f63d564` | implementation plan (`docs/superpowers/plans/2026-06-24-daemon-rollback-hardening.md`) |
+| `82b25072` | **fix(#207)**: log RollbackRejected + auto-resolved vetoes in daemon loop |
+| `f398bd57` | **fix(#208)**: persist SyncState after every advancing sync (+ spec persist-list extended for SilentMerge) |
+| `ef2dcf46` | **fix(#209)**: state-dir safety — no cwd fallback, never inside vault, 0700 (+ spec no-fallback note) |
+| `203c09b2` | **fix**: final-review Minors — exit-code + save-swallow regression tests, comment/doc tidy |
+| (+ handoff commit) | this baton + retargeted `NEXT_SESSION.md` symlink |
+
+**Tests added (~18 test fns):** `outcome_log` ×3, `advanced_state` ×2, `after_sync` ×4 (incl. the save-error-swallow teeth test), `outcome_to_exit_code` ×2, and the #209 path-helper set ×7 — `is_within` ×2, `resolve_state_dir` ×4, `create_dir_secure(0700)` ×1. The teeth tests (assert the gap is closed, fail on pre-fix code): `after_sync_skips_save_on_non_advancing_arms` (#208), `resolve_rejects_state_dir_inside_vault` + `is_within_folds_parent_dir_escape` (#209), and the daemon-loop logging path (#207).
+
+### Acceptance (all GREEN locally on the branch, verified by the controller, not assumed)
+```bash
+cd /Users/hherb/src/secretary/.worktrees/daemon-rollback-hardening
+cargo test --release --workspace                             # 0 FAILED across all binaries
+cargo clippy --release --workspace --tests -- -D warnings    # clean
+cargo fmt --all -- --check                                   # clean
+uv run core/tests/python/conformance.py                      # PASS (no format/semantics change)
+```
+**CI is the real gate once pushed** — `test.yml` (rust ×2 OS + desktop vitest + swift/kotlin conformance) + `rust-lint.yml` (fmt/clippy) + CodeQL. No new `FfiVaultError`/format surface → Swift/Kotlin conformance harnesses unaffected.
+
+## (2) What's next
+**Cluster done (PR open). Pick a fresh item.** Remaining sync/daemon + memory-hygiene security backlog:
+- **#206** — FFI `share_block` accepts an unverified contact card and overwrites a trusted one (TOFU substitution); verified primitives not projected to PyO3/uniffi. *Larger — touches FFI surface; if it needs a new `FfiVaultError` variant, thread uniffi/pyo3 + Swift/Kotlin `ConformanceErrors.{swift,kt}` and run both `run_conformance.sh` scripts (see [[project_secretary_ffivaulterror_workspace_match]]).*
+- **#210** — fuzz monitor dashboard binds `0.0.0.0` with no auth (Python; small, quick win).
+- **#251** (`openBlocks` accumulates plaintext until lock) / **#229** (passwords as plain `[UInt8]`/`Data` not zeroized across Swift FFI) — memory hygiene.
+- **#295** (NEW, filed this session) — `once` mode doesn't `log_outcome` (rollback/veto surfaced only via exit code, no forensic clocks). Small; just call `daemon::log_outcome` on the `Ok` arm of `dispatch_once_subcommand`.
+- **#290** — allowlist the 3 D.4 freshness false-positives once the `d4-browser-autofill` session settles.
+
+**Acceptance criteria template for the next pick:** a failing test that reproduces the gap on `main`, the typed-error/enforcement surface *proven* (not assumed — security paths), full `cargo test --workspace` + clippy `-D warnings` green, and spec/`conformance.py` updated in lockstep if observable bytes/semantics change.
+
+**Open follow-up issues (carried):** #295 / #290 / #284 / #280 / #277 / #273 / #272 / #269 / #255 / #252 / #251 / #247 / #246 / #234 / #232 / #231 / #229 / #224 / #218 / #210 / #206 / #193 / #192 / #190 / #189 / #186 / #183. (#207 / #208 / #209 now closed by this PR; #205 + #293 closed earlier.)
+
+## (3) Open decisions and risks
+- **Deliberate scope (frozen v1):** all three are observability/durability/config fixes to the existing daemon — no `SyncState` CBOR change, no manifest/vault format bump.
+- **Lexical (not canonical) containment guard:** `is_within` is symlink-unaware **by design** — the in-scope adversary (malicious cloud host) controls the synced folder's *contents*, not the operator's local-FS symlink layout. Documented at the call site; the final review confirmed it can't produce a false-negative (both sides route through the same `normalize_abs`). Don't "harden" it into a `canonicalize` that requires the path to exist — that would break the not-yet-created-state-dir case.
+- **`advanced_state()` arms are load-bearing:** true for exactly {AppliedAutomatically, SilentMerge, MergedAndCommitted}, false for {NothingToDo, RollbackRejected}. A wrong arm either loses rollback durability (missing save) or persists a non-advancing clock. Verified ⇔ the actual `run_one` mutation sites. Don't relax.
+- **Final-save escalation must not override a specific code:** `Success → GenericError` only; `RollbackRejected`/`EvidenceStale`/etc. are preserved. (`LockfileHeld` returns earlier and never reaches that block — the comment was corrected in `203c09b`.)
+- **0700 is leaf-only:** `create_dir_secure` sets 0700 on the created leaf; intermediate parents are umask-governed and an already-existing dir is not chmod'd — matches the spec wording "created on first run with mode 0700". Acknowledged, not a defect.
+- **Risk:** none introduced — honest-vault behavior is unchanged (the new checks only bite on misconfiguration or an actual rollback/crash). Full suite + final security review clean.
+
+## (4) Exact commands to resume
+```bash
+cd /Users/hherb/src/secretary
+git fetch --prune origin && git checkout main && git pull --ff-only origin main
+# If PR merged: branch + worktree .worktrees/daemon-rollback-hardening can be removed:
+#   git worktree remove .worktrees/daemon-rollback-hardening && git branch -D feature/daemon-rollback-hardening
+git worktree list && git status -s
+
+# Run any gate locally (from the worktree if the PR is still open):
+cargo test --release --workspace
+cargo clippy --release --workspace --tests -- -D warnings
+```
+
+## (5) Handoff file model
+`NEXT_SESSION.md` is a **relative symlink** to this file in `docs/handoffs/`. Authored once here; symlink retargeted in the same commit on the feature branch. New-path handoff → no add/add conflict. Branch was cut from current `origin/main` (`1b18b6b4`) and `origin/main` had **not** advanced at handoff time (verified: `origin/main` == merge-base), so no history-binding merge was needed this session.
+
+## Closing inventory
+- **State on close:** PR opening on `feature/daemon-rollback-hardening` (6 code/doc commits + handoff). Worktree `.worktrees/daemon-rollback-hardening`.
+- **Acceptance:** local GREEN — full workspace suite (0 fail), ~18 new tests incl. teeth tests for each gap, clippy clean, fmt clean, conformance PASS. Final whole-branch review (opus): Ready to merge, 0 Critical/Important; 5 Minors fixed (`203c09b`), 1 filed (#295), 1 dismissed. CI pending on push.
+- **README.md / ROADMAP.md:** unchanged — these describe capabilities/milestones; #207/#208/#209 are bugfixes to the already-shipped C.2 daemon (capability-level unchanged), and per the brief-status README style three internal fixes would be minutiae.
+- **CLAUDE.md:** unchanged (no daemon-loop invariant documented there; the "both halves" hybrid-verify property it documents is untouched).
+- **NEXT_SESSION.md:** symlink → `docs/handoffs/2026-06-24-daemon-rollback-hardening-shipped.md`.

--- a/docs/superpowers/plans/2026-06-24-daemon-rollback-hardening.md
+++ b/docs/superpowers/plans/2026-06-24-daemon-rollback-hardening.md
@@ -1,0 +1,810 @@
+# Daemon rollback-detection hardening Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Close three confirmed gaps in the headless sync daemon's manifest-rollback defense (#207 observability, #208 crash-durability, #209 state-dir safety).
+
+**Architecture:** All changes live in `cli/` (`pipeline.rs`, `daemon.rs`, `main.rs`, `state.rs`). No `core/` crypto change, no FFI surface, no on-disk vault/manifest/`SyncState` format change. Three commits, one per issue, on one branch/PR. Each fix code-aligns to the existing C.2 design spec (`docs/superpowers/specs/2026-05-23-c2-headless-sync-cli-design.md`); two small spec-text clarifications are folded into the relevant commits.
+
+**Tech Stack:** Rust (stable, workspace toolchain), `tracing` for logs, `thiserror` for typed errors, `tempfile`/`fs4` (already in `state.rs`). Tests via `cargo test --release`.
+
+## Global Constraints
+
+- `#![forbid(unsafe_code)]` workspace-wide — no `unsafe`.
+- Clippy must stay clean: `cargo clippy --release --workspace --tests -- -D warnings`.
+- `cargo fmt --all -- --check` must pass — run `cargo fmt` before every commit.
+- Tests run `--release` (crypto crates are slow in debug).
+- No magic numbers — name constants (e.g. the `0o700` mode).
+- Pure functions in reusable modules; push I/O to the edges; logging side effects live only at the daemon edge (keep `pipeline.rs` free of `tracing` calls).
+- Design doc: `docs/superpowers/specs/2026-06-24-daemon-rollback-hardening-design.md`.
+- Crate package name: `secretary-cli` (run task-scoped tests with `-p secretary-cli`).
+
+---
+
+### Task 1 — #207: surface `Ok(RunOutcome)` attack indicators in the daemon loop
+
+**Files:**
+- Modify: `cli/src/pipeline.rs` (enrich `RunOutcome::RollbackRejected`, fix `run_one`, fix unit tests)
+- Modify: `cli/src/main.rs:336` (`outcome_to_exit_code` match arm)
+- Modify: `cli/tests/pipeline_integration.rs:271` (construction in assertion)
+- Modify: `cli/src/daemon.rs` (add `OutcomeLog` + `outcome_log` + `log_outcome`; rewrite the loop closure's `run_one` handling)
+
+**Interfaces:**
+- Produces: `RunOutcome::RollbackRejected(RollbackEvidence)` (was unit variant); `daemon::log_outcome(&RunOutcome)`; `daemon::outcome_log(&RunOutcome) -> Option<OutcomeLog>` with `enum OutcomeLog { RollbackRejected { disk: Vec<VectorClockEntry>, local: Vec<VectorClockEntry> }, VetoesResolved(usize) }`.
+- Consumes: `secretary_core::sync::RollbackEvidence` (fields `disk_vector_clock: Vec<VectorClockEntry>`, `local_highest_seen: Vec<VectorClockEntry>`; derives `Debug, Clone, PartialEq, Eq`).
+
+- [ ] **Step 1: Enrich the enum and fix `run_one`'s construction**
+
+In `cli/src/pipeline.rs`, add `RollbackEvidence` to the `secretary_core::sync` use-list:
+
+```rust
+use secretary_core::sync::{
+    commit_with_decisions, prepare_merge, sync_once, ManifestHash, RecordTombstoneVeto,
+    RollbackEvidence, SyncError, SyncOutcome, SyncState, VetoDecision,
+};
+```
+
+Change the `RunOutcome::RollbackRejected` variant (around line 84) to carry evidence:
+
+```rust
+    /// Disk vector clock is strictly dominated by the local
+    /// `highest_vector_clock_seen` (rollback per
+    /// `docs/crypto-design.md` §10). `state` is NOT advanced — caller
+    /// surfaces [`crate::exit::ExitCode::RollbackRejected`] and the
+    /// next attempt sees the same disk state. Carries the
+    /// [`RollbackEvidence`] (disk clock + local clock) so the daemon
+    /// loop can log the attack indicator with forensic detail (#207).
+    RollbackRejected(RollbackEvidence),
+```
+
+Change the construction in `run_one` (line 226) to carry the evidence:
+
+```rust
+        SyncOutcome::RollbackRejected(evidence) => Ok(RunOutcome::RollbackRejected(evidence)),
+```
+
+- [ ] **Step 2: Fix the existing match/construction sites (compile-fix)**
+
+`cli/src/main.rs:336` — match arm ignores the payload:
+
+```rust
+        RunOutcome::RollbackRejected(_) => ExitCode::RollbackRejected,
+```
+
+`cli/tests/pipeline_integration.rs:271` — the assertion now needs an evidence payload; assert on the variant shape instead of equality to a unit value:
+
+```rust
+    assert!(matches!(outcome, RunOutcome::RollbackRejected(_)));
+```
+
+`cli/src/pipeline.rs` unit tests — update each `RunOutcome::RollbackRejected` (lines ~581, 622, 623, 644, 783) to construct with an empty-clock evidence. Add a tiny helper at the top of the `tests` module and use it:
+
+```rust
+    fn sample_evidence() -> RollbackEvidence {
+        RollbackEvidence {
+            disk_vector_clock: Vec::new(),
+            local_highest_seen: Vec::new(),
+        }
+    }
+```
+
+Then e.g. the self-equal test becomes:
+
+```rust
+    #[test]
+    fn rollback_rejected_is_self_equal() {
+        assert_eq!(
+            RunOutcome::RollbackRejected(sample_evidence()),
+            RunOutcome::RollbackRejected(sample_evidence())
+        );
+    }
+```
+
+Apply the same substitution at lines ~622, 623, 644, 783 (the `assert_ne!`, the `Debug`-contains check, and the `sync_pass`/inspect test that names the variant). `RollbackEvidence` is in scope via `use super::*;`.
+
+- [ ] **Step 3: Write the failing test for `outcome_log`**
+
+In `cli/src/daemon.rs`, inside the `#[cfg(test)] mod tests` block, add:
+
+```rust
+    use crate::pipeline::RunOutcome;
+    use secretary_core::sync::RollbackEvidence;
+    use secretary_core::vault::block::VectorClockEntry;
+
+    #[test]
+    fn outcome_log_rollback_carries_clocks() {
+        let ev = RollbackEvidence {
+            disk_vector_clock: Vec::new(),
+            local_highest_seen: Vec::new(),
+        };
+        let log = outcome_log(&RunOutcome::RollbackRejected(ev));
+        assert!(matches!(log, Some(OutcomeLog::RollbackRejected { .. })));
+    }
+
+    #[test]
+    fn outcome_log_vetoes_only_when_nonzero() {
+        assert_eq!(
+            outcome_log(&RunOutcome::MergedAndCommitted { vetoes_resolved: 3 }),
+            Some(OutcomeLog::VetoesResolved(3))
+        );
+        assert_eq!(
+            outcome_log(&RunOutcome::MergedAndCommitted { vetoes_resolved: 0 }),
+            None
+        );
+    }
+
+    #[test]
+    fn outcome_log_silent_arms_are_none() {
+        assert_eq!(outcome_log(&RunOutcome::NothingToDo), None);
+        assert_eq!(outcome_log(&RunOutcome::AppliedAutomatically), None);
+        assert_eq!(outcome_log(&RunOutcome::SilentMerge), None);
+    }
+```
+
+- [ ] **Step 4: Run the test to verify it fails**
+
+Run: `cargo test --release -p secretary-cli outcome_log`
+Expected: FAIL — `outcome_log` / `OutcomeLog` not defined.
+
+- [ ] **Step 5: Implement `OutcomeLog`, `outcome_log`, `log_outcome`**
+
+In `cli/src/daemon.rs`, add the imports near the top (after the existing `secretary_core` uses):
+
+```rust
+use secretary_core::vault::block::VectorClockEntry;
+```
+
+Add these items at module scope (above `run_against_vault`):
+
+```rust
+/// What (if anything) a successful [`RunOutcome`] should announce to the
+/// operator. Pure classification — the caller maps it to a `tracing`
+/// call. Kept separate from the emission so the decision is unit-testable
+/// without a subscriber, and so `pipeline.rs` stays free of logging.
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum OutcomeLog {
+    /// Manifest-rollback attack indicator (threat-model §3.1). Carries
+    /// the two clocks an operator needs for forensics.
+    RollbackRejected {
+        disk: Vec<VectorClockEntry>,
+        local: Vec<VectorClockEntry>,
+    },
+    /// `n > 0` tombstone vetoes were auto-resolved — a peer record
+    /// deletion was overridden this pass.
+    VetoesResolved(usize),
+}
+
+/// Classify an `Ok(RunOutcome)` into the operator-visible log event, if
+/// any. The silent arms (`NothingToDo`, `AppliedAutomatically`,
+/// `SilentMerge`, and `MergedAndCommitted { vetoes_resolved: 0 }`) return
+/// `None`.
+fn outcome_log(outcome: &RunOutcome) -> Option<OutcomeLog> {
+    match outcome {
+        RunOutcome::RollbackRejected(ev) => Some(OutcomeLog::RollbackRejected {
+            disk: ev.disk_vector_clock.clone(),
+            local: ev.local_highest_seen.clone(),
+        }),
+        RunOutcome::MergedAndCommitted { vetoes_resolved } if *vetoes_resolved > 0 => {
+            Some(OutcomeLog::VetoesResolved(*vetoes_resolved))
+        }
+        RunOutcome::NothingToDo
+        | RunOutcome::AppliedAutomatically
+        | RunOutcome::SilentMerge
+        | RunOutcome::MergedAndCommitted { .. } => None,
+    }
+}
+
+/// Emit the operator-visible log line (if any) for a successful sync
+/// outcome. The side-effecting edge over the pure [`outcome_log`].
+fn log_outcome(outcome: &RunOutcome) {
+    match outcome_log(outcome) {
+        Some(OutcomeLog::RollbackRejected { disk, local }) => tracing::warn!(
+            disk_clock = ?disk,
+            local_clock = ?local,
+            "manifest rollback rejected (threat-model §3.1 attack indicator); daemon continues",
+        ),
+        Some(OutcomeLog::VetoesResolved(n)) => tracing::warn!(
+            vetoes_resolved = n,
+            "auto-resolved {n} tombstone veto(es): a peer record deletion was overridden",
+        ),
+        None => {}
+    }
+}
+```
+
+Add `RunOutcome` to the daemon's imports (it currently imports only `run_one`):
+
+```rust
+use crate::pipeline::{run_one, RunOutcome};
+```
+
+- [ ] **Step 6: Wire the loop closure to log `Ok` outcomes**
+
+In `run_against_vault`, replace the `if let Err(e) = run_one(...)` block (lines ~293-295) with:
+
+```rust
+            match run_one(vault_folder, identity, password, state, veto_ux, now_ms()) {
+                Ok(outcome) => log_outcome(&outcome),
+                Err(e) => tracing::warn!("pipeline error (continuing): {e}"),
+            }
+```
+
+- [ ] **Step 7: Run the full CLI test suite + lint + fmt**
+
+Run:
+```bash
+cargo test --release -p secretary-cli
+cargo clippy --release -p secretary-cli --tests -- -D warnings
+cargo fmt --all -- --check
+```
+Expected: all PASS / clean.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add cli/src/pipeline.rs cli/src/main.rs cli/src/daemon.rs cli/tests/pipeline_integration.rs
+git commit -m "fix(cli): log RollbackRejected + auto-resolved vetoes in daemon loop (#207)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2 — #208: persist `SyncState` after every state-advancing sync
+
+**Files:**
+- Modify: `cli/src/pipeline.rs` (add `RunOutcome::advanced_state`; spec-comment)
+- Modify: `cli/src/daemon.rs` (add `after_sync`; thread `state_dir` into `run_against_vault`; rewire closure)
+- Modify: `cli/src/main.rs` (pass `state_dir` to `dispatch_run_subcommand`/`run_against_vault`; downgrade exit on final-save failure)
+- Modify: `docs/superpowers/specs/2026-05-23-c2-headless-sync-cli-design.md:313` (extend persist-list with `SilentMerge`)
+
+**Interfaces:**
+- Consumes: `daemon::log_outcome` (Task 1).
+- Produces: `RunOutcome::advanced_state(&self) -> bool`; `daemon::after_sync(result: Result<RunOutcome, SyncError>, state: &SyncState, save: &mut dyn FnMut(&SyncState) -> Result<(), StateError>)`; `run_against_vault(..., state_dir: &Path, ...)` (new `state_dir: &Path` parameter, inserted before `config`).
+
+- [ ] **Step 1: Write the failing test for `advanced_state`**
+
+In `cli/src/pipeline.rs` `tests` module add (use `sample_evidence()` from Task 1):
+
+```rust
+    #[test]
+    fn advanced_state_true_for_advancing_arms() {
+        assert!(RunOutcome::AppliedAutomatically.advanced_state());
+        assert!(RunOutcome::SilentMerge.advanced_state());
+        assert!(RunOutcome::MergedAndCommitted { vetoes_resolved: 0 }.advanced_state());
+        assert!(RunOutcome::MergedAndCommitted { vetoes_resolved: 5 }.advanced_state());
+    }
+
+    #[test]
+    fn advanced_state_false_for_non_advancing_arms() {
+        assert!(!RunOutcome::NothingToDo.advanced_state());
+        assert!(!RunOutcome::RollbackRejected(sample_evidence()).advanced_state());
+    }
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cargo test --release -p secretary-cli advanced_state`
+Expected: FAIL — no method `advanced_state`.
+
+- [ ] **Step 3: Implement `advanced_state`**
+
+In `cli/src/pipeline.rs`, add an `impl` block after the `RunOutcome` enum definition:
+
+```rust
+impl RunOutcome {
+    /// `true` iff this outcome advanced `state.highest_vector_clock_seen`
+    /// and therefore must be persisted before the next daemon iteration.
+    /// Matches the C.2 spec §"State persistence" persist-list (extended
+    /// to include `SilentMerge`, which post-dates the spec text but does
+    /// advance the clock — see `run_one`'s state-mutation contract).
+    #[must_use]
+    pub fn advanced_state(&self) -> bool {
+        matches!(
+            self,
+            Self::AppliedAutomatically | Self::SilentMerge | Self::MergedAndCommitted { .. }
+        )
+    }
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `cargo test --release -p secretary-cli advanced_state`
+Expected: PASS.
+
+- [ ] **Step 5: Write the failing test for `after_sync`**
+
+In `cli/src/daemon.rs` `tests` module add:
+
+```rust
+    use secretary_core::sync::{SyncError, SyncState};
+
+    #[test]
+    fn after_sync_saves_on_advancing_arms() {
+        let state = SyncState::empty([1; 16]);
+        for outcome in [
+            RunOutcome::AppliedAutomatically,
+            RunOutcome::SilentMerge,
+            RunOutcome::MergedAndCommitted { vetoes_resolved: 0 },
+        ] {
+            let mut saves = 0u32;
+            let mut sink = |_: &SyncState| {
+                saves += 1;
+                Ok(())
+            };
+            after_sync(Ok(outcome), &state, &mut sink);
+            assert_eq!(saves, 1);
+        }
+    }
+
+    #[test]
+    fn after_sync_skips_save_on_non_advancing_arms() {
+        let state = SyncState::empty([2; 16]);
+        let ev = RollbackEvidence {
+            disk_vector_clock: Vec::new(),
+            local_highest_seen: Vec::new(),
+        };
+        for outcome in [RunOutcome::NothingToDo, RunOutcome::RollbackRejected(ev)] {
+            let mut saves = 0u32;
+            let mut sink = |_: &SyncState| {
+                saves += 1;
+                Ok(())
+            };
+            after_sync(Ok(outcome), &state, &mut sink);
+            assert_eq!(saves, 0);
+        }
+    }
+
+    #[test]
+    fn after_sync_does_not_save_on_err() {
+        let state = SyncState::empty([3; 16]);
+        let mut saves = 0u32;
+        let mut sink = |_: &SyncState| {
+            saves += 1;
+            Ok(())
+        };
+        let err = SyncError::Vault(secretary_core::vault::VaultError::Io {
+            context: "test",
+            source: std::io::Error::other("boom"),
+        });
+        after_sync(Err(err), &state, &mut sink);
+        assert_eq!(saves, 0);
+    }
+```
+
+- [ ] **Step 6: Run to verify failure**
+
+Run: `cargo test --release -p secretary-cli after_sync`
+Expected: FAIL — `after_sync` not defined.
+
+- [ ] **Step 7: Implement `after_sync` and import `StateError`**
+
+In `cli/src/daemon.rs` add to imports:
+
+```rust
+use crate::state::{self, StateError};
+```
+
+Add at module scope (near `log_outcome`):
+
+```rust
+/// Handle the result of one `run_one` pass: log the operator-visible
+/// outcome (#207) and persist `state` (#208) whenever it advanced. `save`
+/// is injected (not a direct `state::save` call) so the loop body is
+/// unit-testable without a real watcher or filesystem. A save failure is
+/// logged and swallowed — the in-memory clock has still advanced, and a
+/// transient FS error must not kill a daemon that may run for weeks; the
+/// next advancing pass retries the persist.
+fn after_sync(
+    result: Result<RunOutcome, SyncError>,
+    state: &SyncState,
+    save: &mut dyn FnMut(&SyncState) -> Result<(), StateError>,
+) {
+    match result {
+        Ok(outcome) => {
+            log_outcome(&outcome);
+            if outcome.advanced_state() {
+                if let Err(e) = save(state) {
+                    tracing::warn!("state persist after sync failed (continuing): {e}");
+                }
+            }
+        }
+        Err(e) => tracing::warn!("pipeline error (continuing): {e}"),
+    }
+}
+```
+
+- [ ] **Step 8: Thread `state_dir` into `run_against_vault` and rewire the closure**
+
+Add `state_dir: &Path` to `run_against_vault`'s signature (insert before `config: DaemonConfig`):
+
+```rust
+pub fn run_against_vault(
+    vault_folder: &Path,
+    identity: &UnlockedIdentity,
+    password: &SecretBytes,
+    state: &mut SyncState,
+    veto_ux: &mut dyn VetoUx,
+    state_dir: &Path,
+    config: DaemonConfig,
+    ready_window: Duration,
+) -> Result<(), SyncError> {
+```
+
+Replace the `match run_one(...)` block from Task 1 (the closure body) with the injected-sink form:
+
+```rust
+            let result = run_one(vault_folder, identity, password, state, veto_ux, now_ms());
+            let mut save = |s: &SyncState| state::save(state_dir, s);
+            after_sync(result, state, &mut save);
+```
+
+- [ ] **Step 9: Update `main.rs` call sites to pass `state_dir`**
+
+In `cli/src/main.rs`, `dispatch_run_subcommand` gains a `state_dir: &Path` parameter (add it to the signature) and forwards it to both `run_against_vault` calls (insert `state_dir,` before `config,`). At the `dispatch_run_subcommand(...)` call in `run` (line ~138), pass `&state_dir`:
+
+```rust
+        Some(run_args) => dispatch_run_subcommand(
+            run_args,
+            vault,
+            &identity,
+            &password,
+            &mut state,
+            &state_dir,
+            interactive,
+        ),
+```
+
+And in `dispatch_run_subcommand`'s body, both `daemon::run_against_vault(...)` calls insert `state_dir,` before `config,`.
+
+- [ ] **Step 10: Downgrade exit code on final-save failure**
+
+Replace the final-save block (`cli/src/main.rs:149-151`) with:
+
+```rust
+    let exit_code = match state::save(&state_dir, &state) {
+        Ok(()) => exit_code,
+        Err(e) => {
+            error!("final state save failed: {e}");
+            // Don't override a more specific non-success code (e.g.
+            // RollbackRejected, LockfileHeld); only escalate a Success.
+            if matches!(exit_code, ExitCode::Success) {
+                ExitCode::GenericError
+            } else {
+                exit_code
+            }
+        }
+    };
+
+    exit_code
+```
+
+- [ ] **Step 11: Extend the spec persist-list**
+
+In `docs/superpowers/specs/2026-05-23-c2-headless-sync-cli-design.md`, line ~313, change:
+
+> Persists ONLY after `AppliedAutomatically` or successful `commit_with_decisions`. NOT after `NothingToDo` ...
+
+to:
+
+> Persists after every state-advancing outcome: `AppliedAutomatically`, `SilentMerge`, and successful `commit_with_decisions` (`MergedAndCommitted`). NOT after `NothingToDo` (no change), NOT after `RollbackRejected` (intentionally unchanged), NOT after `ConcurrentDetected` before commit. (`SilentMerge` post-dates the original draft but advances `highest_vector_clock_seen`; see `cli/src/pipeline.rs` `run_one`.)
+
+- [ ] **Step 12: Run full suite + lint + fmt**
+
+Run:
+```bash
+cargo test --release -p secretary-cli
+cargo clippy --release -p secretary-cli --tests -- -D warnings
+cargo fmt --all -- --check
+```
+Expected: all PASS / clean.
+
+- [ ] **Step 13: Commit**
+
+```bash
+git add cli/src/pipeline.rs cli/src/daemon.rs cli/src/main.rs docs/superpowers/specs/2026-05-23-c2-headless-sync-cli-design.md
+git commit -m "fix(cli): persist SyncState after every advancing sync in daemon loop (#208)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 3 — #209: state-dir safety (no silent cwd, never inside vault, 0700)
+
+**Files:**
+- Modify: `cli/src/state.rs` (add `StateDirError`, `resolve_state_dir`, `normalize_abs`, `is_within`, `create_dir_secure`, `STATE_DIR_MODE`; use `create_dir_secure` in `save` + `LockfileGuard::acquire`)
+- Modify: `cli/src/main.rs` (call `state::resolve_state_dir`; delete `STATE_DIR_FALLBACK` + old `resolve_state_dir`)
+- Modify: `docs/superpowers/specs/2026-05-23-c2-headless-sync-cli-design.md` (note: no cwd fallback — hard error)
+
+**Interfaces:**
+- Produces: `state::resolve_state_dir(explicit: Option<PathBuf>, os_default: Option<PathBuf>, vault_folder: &Path) -> Result<PathBuf, StateDirError>`; `pub enum StateDirError { Unresolvable, InsideVault { state_dir: String, vault: String } }` (derives `Debug`, `thiserror::Error`).
+- Consumes: existing `state::default_state_dir() -> Option<PathBuf>`; `CommonArgs::state_dir: Option<PathBuf>`.
+
+- [ ] **Step 1: Write failing tests for path helpers + resolution**
+
+In `cli/src/state.rs` `tests` module add:
+
+```rust
+    #[test]
+    fn is_within_detects_nested_and_rejects_sibling() {
+        assert!(is_within(Path::new("/vault/sub/state"), Path::new("/vault")));
+        assert!(is_within(Path::new("/vault"), Path::new("/vault")));
+        assert!(!is_within(Path::new("/other/state"), Path::new("/vault")));
+    }
+
+    #[test]
+    fn is_within_folds_parent_dir_escape() {
+        // /vault/../else normalizes out of /vault.
+        assert!(!is_within(Path::new("/vault/../else"), Path::new("/vault")));
+    }
+
+    #[test]
+    fn resolve_explicit_wins_even_if_no_os_default() {
+        let got = resolve_state_dir(
+            Some(PathBuf::from("/etc/secretary")),
+            None,
+            Path::new("/vault"),
+        )
+        .unwrap();
+        assert_eq!(got, PathBuf::from("/etc/secretary"));
+    }
+
+    #[test]
+    fn resolve_falls_back_to_os_default() {
+        let got =
+            resolve_state_dir(None, Some(PathBuf::from("/home/u/.local")), Path::new("/vault"))
+                .unwrap();
+        assert_eq!(got, PathBuf::from("/home/u/.local"));
+    }
+
+    #[test]
+    fn resolve_unresolvable_when_no_source() {
+        let err = resolve_state_dir(None, None, Path::new("/vault")).unwrap_err();
+        assert!(matches!(err, StateDirError::Unresolvable));
+    }
+
+    #[test]
+    fn resolve_rejects_state_dir_inside_vault() {
+        let err = resolve_state_dir(
+            Some(PathBuf::from("/vault/state")),
+            None,
+            Path::new("/vault"),
+        )
+        .unwrap_err();
+        assert!(matches!(err, StateDirError::InsideVault { .. }));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn create_dir_secure_sets_0700() {
+        use std::os::unix::fs::PermissionsExt;
+        let base = TempDir::new().unwrap();
+        let dir = base.path().join("nested").join("sync");
+        create_dir_secure(&dir).unwrap();
+        let mode = std::fs::metadata(&dir).unwrap().permissions().mode() & 0o777;
+        assert_eq!(mode, STATE_DIR_MODE);
+    }
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `cargo test --release -p secretary-cli resolve_ is_within create_dir_secure`
+Expected: FAIL — items not defined.
+
+- [ ] **Step 3: Implement the error type, constants, and pure helpers**
+
+In `cli/src/state.rs`, add the mode constant near the other consts:
+
+```rust
+/// Mode the state directory is created with on first run (Unix only).
+/// C.2 spec §"State persistence": "Directory created on first run with
+/// mode 0700 (Unix)." Non-secret metadata, but the spec/code divergence
+/// is resolved in favour of the spec.
+const STATE_DIR_MODE: u32 = 0o700;
+```
+
+Add the error enum (next to `StateError`):
+
+```rust
+/// Why a usable state directory could not be established. Distinct from
+/// [`StateError`] (I/O / decode / lock): these are operator
+/// misconfigurations caught before any vault work, mapped by `main` to
+/// the usage exit code.
+#[derive(Debug, Error)]
+pub enum StateDirError {
+    #[error(
+        "could not resolve a state directory (no --state-dir given and no OS data dir available); \
+         pass --state-dir to a host-local path outside the vault folder"
+    )]
+    Unresolvable,
+    #[error(
+        "refusing to place rollback-detection state inside the vault folder \
+         (state dir {state_dir} is within {vault}); pass --state-dir to a host-local path \
+         outside the vault"
+    )]
+    InsideVault { state_dir: String, vault: String },
+}
+```
+
+Add the pure helpers + secure-create at module scope:
+
+```rust
+/// Absolute, lexically-normalized form of `p`: joins the current dir if
+/// relative, then folds `.` and `..` components. Does NOT resolve
+/// symlinks — this is a misconfiguration guard, not a defence against an
+/// attacker who can plant symlinks on the operator's local filesystem
+/// (the in-scope adversary controls the synced folder's *contents*, not
+/// the host's FS layout).
+fn normalize_abs(p: &Path) -> PathBuf {
+    use std::path::Component;
+    let abs = if p.is_absolute() {
+        p.to_path_buf()
+    } else {
+        std::env::current_dir()
+            .unwrap_or_else(|_| PathBuf::from("."))
+            .join(p)
+    };
+    let mut out = PathBuf::new();
+    for comp in abs.components() {
+        match comp {
+            Component::CurDir => {}
+            Component::ParentDir => {
+                out.pop();
+            }
+            other => out.push(other.as_os_str()),
+        }
+    }
+    out
+}
+
+/// `true` iff `child` is `ancestor` or lives beneath it, compared over
+/// the lexically-normalized absolute forms.
+fn is_within(child: &Path, ancestor: &Path) -> bool {
+    normalize_abs(child).starts_with(normalize_abs(ancestor))
+}
+
+/// Resolve the state directory. `explicit` is `--state-dir`; `os_default`
+/// is [`default_state_dir`]. An explicit path always wins (even `.` —
+/// an informed operator choice). Otherwise the OS data dir. If neither is
+/// available the result is [`StateDirError::Unresolvable`] — there is
+/// **no** silent current-working-directory fallback. The resolved path is
+/// rejected with [`StateDirError::InsideVault`] if it lies within
+/// `vault_folder`.
+pub fn resolve_state_dir(
+    explicit: Option<PathBuf>,
+    os_default: Option<PathBuf>,
+    vault_folder: &Path,
+) -> Result<PathBuf, StateDirError> {
+    let dir = explicit.or(os_default).ok_or(StateDirError::Unresolvable)?;
+    if is_within(&dir, vault_folder) {
+        return Err(StateDirError::InsideVault {
+            state_dir: dir.display().to_string(),
+            vault: vault_folder.display().to_string(),
+        });
+    }
+    Ok(dir)
+}
+
+/// Create `path` and any missing parents. On Unix the directory is
+/// created with mode [`STATE_DIR_MODE`] (0700); other platforms use a
+/// plain recursive create. An already-existing directory is left as-is
+/// (its mode is not changed), matching the spec wording "created on first
+/// run with mode 0700".
+fn create_dir_secure(path: &Path) -> std::io::Result<()> {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::DirBuilderExt;
+        std::fs::DirBuilder::new()
+            .recursive(true)
+            .mode(STATE_DIR_MODE)
+            .create(path)
+    }
+    #[cfg(not(unix))]
+    {
+        std::fs::create_dir_all(path)
+    }
+}
+```
+
+- [ ] **Step 4: Use `create_dir_secure` in the two create sites**
+
+In `state::save` (line ~135) replace `fs::create_dir_all(state_dir)?;` with `create_dir_secure(state_dir)?;`.
+In `LockfileGuard::acquire` (line ~159) replace `fs::create_dir_all(state_dir)?;` with `create_dir_secure(state_dir)?;`.
+
+- [ ] **Step 5: Run the state tests**
+
+Run: `cargo test --release -p secretary-cli resolve_ is_within create_dir_secure`
+Expected: PASS.
+
+- [ ] **Step 6: Wire `main.rs` to the fallible resolver; delete the old fallback**
+
+In `cli/src/main.rs`: delete the `STATE_DIR_FALLBACK` const (line 56) and its doc comment, and delete the old `resolve_state_dir` fn (lines ~176-186) with its doc comment. Add `StateDirError` to the `state` import line:
+
+```rust
+use secretary_cli::state::{self, LockfileGuard, StateDirError, StateError};
+```
+
+Replace the `let state_dir = resolve_state_dir(common);` line (113) with:
+
+```rust
+    let state_dir = match state::resolve_state_dir(
+        common.state_dir.clone(),
+        state::default_state_dir(),
+        vault,
+    ) {
+        Ok(d) => d,
+        Err(e) => {
+            error!("{e}");
+            return ExitCode::UsageError;
+        }
+    };
+```
+
+(`StateDirError` is imported for clarity even though it is only named in the error path's `Display`; if clippy flags it as unused, drop it from the import.)
+
+- [ ] **Step 7: Add the spec clarification on the fallback**
+
+In `docs/superpowers/specs/2026-05-23-c2-headless-sync-cli-design.md`, in the `--state-dir` flag-table row / state-persistence section, append a sentence:
+
+> If neither `--state-dir` nor the OS data dir resolves, the binary exits with the usage error code rather than falling back to the current working directory — host-local state must never land inside the (attacker-controlled) vault folder. A state dir resolving inside the vault folder is likewise a hard error.
+
+- [ ] **Step 8: Run full suite + lint + fmt**
+
+Run:
+```bash
+cargo test --release -p secretary-cli
+cargo clippy --release -p secretary-cli --tests -- -D warnings
+cargo fmt --all -- --check
+```
+Expected: all PASS / clean.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add cli/src/state.rs cli/src/main.rs docs/superpowers/specs/2026-05-23-c2-headless-sync-cli-design.md
+git commit -m "fix(cli): state-dir safety — no cwd fallback, never inside vault, 0700 (#209)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 4 — Whole-workspace verification + docs sweep
+
+**Files:**
+- Possibly modify: `README.md`, `ROADMAP.md` (only if a status line references the daemon rollback defense)
+
+- [ ] **Step 1: Full workspace gates**
+
+Run from the worktree root:
+```bash
+cargo test --release --workspace
+cargo clippy --release --workspace --tests -- -D warnings
+cargo fmt --all -- --check
+uv run core/tests/python/conformance.py
+```
+Expected: 0 FAILED; clippy clean; fmt clean; conformance PASS (unaffected — no format/semantics change).
+
+- [ ] **Step 2: README/ROADMAP review**
+
+Check whether `README.md` (C.2 / sync-daemon status) or `ROADMAP.md` references the rollback-detection behavior being changed. Grep:
+```bash
+grep -ni "rollback\|state-dir\|daemon\|C.2" README.md ROADMAP.md
+```
+If a line is now inaccurate or worth a one-line note (#207/#208/#209 closed), update it (keep README status terse per the project's README style). If nothing references it, make no change. Commit any edit:
+```bash
+git add README.md ROADMAP.md
+git commit -m "docs: note daemon rollback-detection hardening (#207/#208/#209)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Self-Review notes
+
+- **Spec coverage:** #207 → Task 1; #208 → Task 2 (advanced_state + after_sync + in-loop save + final-save downgrade + spec persist-list); #209 → Task 3 (resolve/containment/0700 + main wiring + spec fallback note). Whole-workspace verify + docs → Task 4.
+- **Type consistency:** `RunOutcome::RollbackRejected(RollbackEvidence)` used consistently across pipeline.rs, main.rs (`outcome_to_exit_code`, `_` arm), daemon.rs (`outcome_log`), and integration test. `after_sync` sink type `&mut dyn FnMut(&SyncState) -> Result<(), StateError>` matches the production `|s| state::save(state_dir, s)` closure (returns `Result<(), StateError>`). `resolve_state_dir` 3-arg signature matches the `main.rs` call site.
+- **No new FFI/format surface:** `RunOutcome` is `cli`-internal; `SyncState` CBOR unchanged; no `core/` change → `conformance.py` and Swift/Kotlin harnesses untouched.

--- a/docs/superpowers/specs/2026-05-23-c2-headless-sync-cli-design.md
+++ b/docs/superpowers/specs/2026-05-23-c2-headless-sync-cli-design.md
@@ -105,6 +105,8 @@ Where `<state-dir>` resolves via the `dirs` crate:
 
 Override via `--state-dir PATH`. Filename uses 32-char lowercase hex of `vault_uuid` (mirrors core's block-UUID naming convention). Directory created on first run with mode 0700 (Unix).
 
+If neither `--state-dir` nor the OS data dir resolves, the binary exits with the usage error code rather than falling back to the current working directory — host-local state must never land inside the (attacker-controlled) vault folder. A state dir resolving inside the vault folder is likewise a hard error.
+
 Rationale: `SyncState` carries `vault_uuid` + `highest_vector_clock_seen` — public material, not secret. The OS keyring buys nothing. Per-vault filename allows multiple vaults to coexist on one host without collision. Host-local placement (not inside the vault folder) means each device's local state stays local; the two-instance convergence test uses one `--state-dir` per simulated device.
 
 Forecloses: OS keychain (no security gain); sibling file inside vault folder (cross-device coupling); user-mandatory `--state-file` (high friction for casual users).

--- a/docs/superpowers/specs/2026-05-23-c2-headless-sync-cli-design.md
+++ b/docs/superpowers/specs/2026-05-23-c2-headless-sync-cli-design.md
@@ -310,7 +310,7 @@ state::save(state_dir: &Path, state: &SyncState) -> Result<(), _>
     write atomically via tempfile::NamedTempFile + persist
 ```
 
-Persists ONLY after `AppliedAutomatically` or successful `commit_with_decisions`. NOT after `NothingToDo` (no change), NOT after `RollbackRejected` (intentionally unchanged), NOT after `ConcurrentDetected` before commit.
+Persists after every state-advancing outcome: `AppliedAutomatically`, `SilentMerge`, and successful `commit_with_decisions` (`MergedAndCommitted`). NOT after `NothingToDo` (no change), NOT after `RollbackRejected` (intentionally unchanged), NOT after `ConcurrentDetected` before commit. (`SilentMerge` post-dates the original draft but advances `highest_vector_clock_seen`; see `cli/src/pipeline.rs` `run_one`.)
 
 `tempfile = "=3.27.0"` exact pin propagates from `core/Cargo.toml` to `cli/Cargo.toml` — same atomic-rename discipline applies to the state file as to the vault format.
 

--- a/docs/superpowers/specs/2026-06-24-daemon-rollback-hardening-design.md
+++ b/docs/superpowers/specs/2026-06-24-daemon-rollback-hardening-design.md
@@ -1,0 +1,268 @@
+# Daemon rollback-detection hardening (#207 / #208 / #209)
+
+**Date:** 2026-06-24
+**Status:** Design — approved, pre-implementation
+**Scope:** `cli/` only. No FFI surface, no `core/` crypto change, no on-disk
+vault/manifest format change. The per-vault `SyncState` CBOR file format is
+**unchanged**.
+
+## Problem
+
+The headless sync daemon (`secretary-sync run`) implements the threat-model
+§3.1 manifest-rollback defense, but three gaps weaken it in exactly the
+long-running deployment it most matters for. All three are confirmed
+spec/code divergences against the C.2 design
+(`docs/superpowers/specs/2026-05-23-c2-headless-sync-cli-design.md`).
+
+- **#207 (Medium, observability):** the daemon loop discards the entire
+  `Ok(RunOutcome)`, logging only the `Err` arm
+  (`cli/src/daemon.rs:293-295`). `RollbackRejected` — the CLI-visible
+  attack indicator — and `MergedAndCommitted { vetoes_resolved > 0 }`
+  (auto-resolved deletion conflicts) are never surfaced at any verbosity.
+  A malicious cloud host can probe the daemon with replayed manifests at
+  zero alerting cost. C.2 spec line 294 says "on RollbackRejected: log at
+  warn, continue."
+
+- **#208 (Medium, defense voided on crash):** the per-vault `SyncState`
+  ("highest vector clock seen" — the sole anchor for rollback rejection)
+  is mutated in memory throughout a run but persisted **exactly once**,
+  after the loop exits (`cli/src/main.rs:149-151`). An unclean exit
+  (SIGKILL/OOM/panic/power-loss) discards every clock advance of the
+  session; on restart the stale clock lets the host replay any manifest
+  from the elapsed window as a forward update — a silent rollback. C.2
+  spec line 313 prescribes per-successful-sync persistence inside the loop.
+
+- **#209 (Low–Medium, state can land in the attacker's folder):** when
+  `dirs::data_dir()` returns `None` (headless, no `$HOME` — a stated
+  systemd/Docker target) the state dir silently falls back to `"."`
+  (`cli/src/main.rs:56`). If the working directory is the vault folder,
+  rollback state is written **inside the attacker-controlled synced
+  folder**, where the in-scope malicious host deletes it →
+  `state::load` returns `SyncState::empty` → rollback detection disabled.
+  Plus a spec/code divergence: the spec says the dir is created `0700`
+  (line 106); the code uses plain `fs::create_dir_all` with no mode.
+
+## Decisions (from brainstorming)
+
+1. **Packaging:** one branch `feature/daemon-rollback-hardening`, one
+   commit per issue, one PR. The fixes are coupled — #208 threads
+   `state_dir` into `run_against_vault`, which #209's containment guard
+   also consumes.
+2. **#209 `"."` fallback:** **hard error** when the state dir would
+   *implicitly* fall back to cwd (no `--state-dir`, no OS data dir). An
+   *explicit* `--state-dir .` stays allowed (informed operator choice).
+   The `"."` fallback was never in the C.2 spec, so this code-aligns to
+   spec.
+3. **#209 state-dir inside vault:** **hard error**. The C.2 rationale
+   (lines 108/143) explicitly requires host-local placement NOT inside
+   the vault folder.
+4. **#207 detail:** enrich `RunOutcome::RollbackRejected` to carry
+   `RollbackEvidence` (disk clock + local clock) and log the clocks at
+   `warn!`. `RollbackEvidence` already derives `Debug, Clone, PartialEq,
+   Eq`, so the shared enum keeps its derives; `once` mode ignores the
+   payload.
+
+## Design
+
+### Commit 1 — #207: surface `Ok(RunOutcome)` attack indicators
+
+**Enum change.** `RunOutcome::RollbackRejected` →
+`RollbackRejected(RollbackEvidence)`. In `run_one`
+(`cli/src/pipeline.rs:226`) stop discarding `_evidence`; carry it into the
+returned outcome. `outcome_to_exit_code` (`cli/src/main.rs`) matches the
+variant ignoring its payload — `once` mode still maps to exit code 10,
+behaviour unchanged.
+
+**Pure decision function.** A side-effect-free classifier that the daemon
+closure consults before emitting any log line:
+
+```rust
+/// What (if anything) an Ok(RunOutcome) should announce to the operator.
+enum OutcomeLog {
+    /// Manifest-rollback attack indicator (threat-model §3.1). Carries the
+    /// two clocks the operator needs for forensics.
+    RollbackRejected { disk: Vec<VectorClockEntry>, local: Vec<VectorClockEntry> },
+    /// Auto-resolved tombstone vetoes — a record deletion was overridden.
+    VetoesResolved(usize),
+}
+
+fn outcome_log(outcome: &RunOutcome) -> Option<OutcomeLog>;
+```
+
+Returns `Some(RollbackRejected{..})` for the rollback arm,
+`Some(VetoesResolved(n))` for `MergedAndCommitted { vetoes_resolved: n }`
+**only when `n > 0`**, `None` otherwise. Unit-tested for every variant.
+The daemon closure maps `Some(..)` to `tracing::warn!` with the clocks /
+count as structured fields. `cli/src/pipeline.rs` stays free of any
+`tracing` call — logging lives only at the daemon edge.
+
+### Commit 2 — #208: persist `SyncState` after every state-advancing sync
+
+**Pure predicate.**
+
+```rust
+impl RunOutcome {
+    /// True iff this outcome advanced `state.highest_vector_clock_seen`
+    /// and therefore must be persisted before the next iteration.
+    #[must_use]
+    fn advanced_state(&self) -> bool;  // Applied | SilentMerge | MergedAndCommitted
+}
+```
+
+`NothingToDo` and `RollbackRejected` return `false` (state byte-unchanged).
+Unit-tested per variant.
+
+**Thread `state_dir` + a save sink into the loop.** `run_against_vault`
+gains a `state_dir: &Path` parameter (plumbed from `dispatch_run_subcommand`
+in `cli/src/main.rs`). The post-`run_one` handling is extracted into a
+testable helper:
+
+```rust
+/// Log the outcome (#207) and persist `state` (#208) when it advanced.
+/// `save` is injected so the loop body is unit-testable without a real
+/// watcher or filesystem.
+fn after_sync(
+    result: Result<RunOutcome, SyncError>,
+    state: &SyncState,
+    save: &mut dyn FnMut(&SyncState) -> Result<(), StateError>,
+);
+```
+
+On `Ok(outcome)`: emit `outcome_log(&outcome)`; if `outcome.advanced_state()`
+call `save(state)`. A save error inside the loop is logged at `warn!` and
+the loop **continues** — the in-memory clock has still advanced, and a
+transient FS error must not kill a daemon that may run for weeks. On
+`Err(e)`: `warn!("pipeline error (continuing): {e}")` (unchanged behaviour).
+
+In production `run_against_vault` builds the sink as
+`|s| state::save(state_dir, s)`.
+
+**Final-save failure → non-success exit.** At `cli/src/main.rs:149`, on
+`state::save` `Err`: log at `error!`, and if the pending `exit_code` was
+`Success`, downgrade it to `GenericError`. Never override a more specific
+non-success code (e.g. `RollbackRejected`, `LockfileHeld`).
+
+**Teeth test (#208).** A unit test driving `after_sync` with an injected
+recording sink proves `save` is called on each advancing arm
+(`AppliedAutomatically`, `SilentMerge`, `MergedAndCommitted`) and **not**
+on `NothingToDo` / `RollbackRejected`. This fails on `main` (no in-loop
+save exists today).
+
+### Commit 3 — #209: state-dir safety
+
+**Fallible, injectable resolution.**
+
+```rust
+/// Resolve the state dir. `explicit` = `--state-dir`; `os_default` =
+/// `state::default_state_dir()`. Explicit always wins (even `.`). Else the
+/// OS data dir. Else an error — never a silent cwd fallback.
+fn resolve_state_dir(
+    explicit: Option<PathBuf>,
+    os_default: Option<PathBuf>,
+) -> Result<PathBuf, StateDirError>;
+```
+
+Injecting `os_default` makes the `None` branch unit-testable (the real
+`dirs::data_dir()` is environment-dependent). `STATE_DIR_FALLBACK` is
+deleted.
+
+**Containment guard (lexical).**
+
+```rust
+/// Absolute, lexically-normalized form of `p` (joins cwd if relative,
+/// folds `.` and `..`). Does NOT resolve symlinks.
+fn normalize_abs(p: &Path) -> PathBuf;
+
+/// True iff `child` is `ancestor` or lives beneath it, compared lexically.
+fn is_within(child: &Path, ancestor: &Path) -> bool;
+```
+
+If `is_within(state_dir, vault_folder)` → error. Documented as a
+**misconfiguration** guard, deliberately symlink-unaware: the in-scope
+adversary (malicious cloud host) controls the *contents* of the synced
+folder, not the operator's local-FS symlink layout, so a lexical check is
+the right level. Both functions are pure and unit-tested, including `..`
+escapes and relative inputs.
+
+**Error surface.** A locally-typed `StateDirError` with two variants
+(`Unresolvable`, `InsideVault { state_dir, vault }`), each `Display`ing a
+one-line actionable message ("pass --state-dir to a host-local path
+outside the vault folder"). Both map to `ExitCode::UsageError` (2) — this
+is operator misconfiguration, caught before any vault work.
+
+**0700 directory creation.**
+
+```rust
+/// Create `path` (and parents). On Unix the leaf is created with mode
+/// 0700; other platforms use plain create_dir_all. Matches C.2 spec
+/// line 106. Does not chmod an already-existing dir (spec wording:
+/// "created on first run with mode 0700").
+fn create_dir_secure(path: &Path) -> io::Result<()>;
+```
+
+Used by both `state::save` and `LockfileGuard::acquire` (the two
+`create_dir_all` sites). Implemented with
+`std::os::unix::fs::DirBuilderExt::mode(0o700)` + `.recursive(true)` under
+`#[cfg(unix)]`. A `#[cfg(unix)]` test asserts the created dir's mode is
+`0o700`.
+
+## Testing strategy (TDD)
+
+Every pure helper is written failing-first:
+
+| Unit | Test focus |
+|---|---|
+| `outcome_log` | each `RunOutcome` variant → expected `Option<OutcomeLog>`; `vetoes_resolved == 0` → `None` |
+| `RunOutcome::advanced_state` | `true`/`false` per variant |
+| `after_sync` | save called on advancing arms, skipped on `NothingToDo`/`RollbackRejected` (injected recording sink) — **#208 teeth** |
+| `resolve_state_dir` | explicit-wins, os-default, unresolvable→error |
+| `normalize_abs` / `is_within` | relative join, `.`/`..` folding, escape cases |
+| `create_dir_secure` | `#[cfg(unix)]` mode `0o700` on first creation |
+| `outcome_to_exit_code` | `RollbackRejected(evidence)` still → exit 10 (payload ignored) |
+
+Gates (run from the worktree):
+
+```bash
+cargo test --release --workspace
+cargo clippy --release --workspace --tests -- -D warnings
+cargo fmt --all -- --check
+uv run core/tests/python/conformance.py   # unaffected — sanity only
+```
+
+Each implementer runs `cargo fmt --check` before committing (carried
+process note: last session's SDD implementers skipped it).
+
+## Spec impact
+
+The three fixes code-align to the existing C.2 spec; the spec stays the
+source of truth. Two small clarifying edits to
+`docs/superpowers/specs/2026-05-23-c2-headless-sync-cli-design.md`:
+
+1. Note that an unresolvable state dir is a **hard error** (no cwd
+   fallback), since the spec's flag table (line 219) lists "OS data dir"
+   without ever sanctioning the `"."` fallback the code had silently added.
+2. Extend the per-sync-persistence enumeration (line 313: "Persists ONLY
+   after `AppliedAutomatically` or successful `commit_with_decisions`") to
+   include the **`SilentMerge`** arm. That arm post-dates the spec text but
+   `run_one` advances `state.highest_vector_clock_seen` on it
+   (`cli/src/pipeline.rs:246-251`), so it must persist too. `advanced_state()`
+   already reflects this; the spec line is brought into agreement rather
+   than the code.
+
+No `conformance.py` / Swift / Kotlin changes — no observable byte format or
+merge semantics change.
+
+## Risks / non-goals
+
+- **No MAC on the state file** (explicitly out of scope per #209): an
+  adversary who can substitute the file can also delete it, and absent-file
+  must map to `SyncState::empty` for first-run semantics, so authentication
+  cannot distinguish "fresh install" from "attacker wiped it". `load`
+  already validates CBOR structure + `vault_uuid`, the right level.
+- **Lexical (not canonical) containment guard:** symlink-unaware by design;
+  matches the threat model (the cloud host controls folder contents, not
+  the operator's local symlinks). Documented at the call site.
+- **`#126` (capturing the save on dispatch `Err`)** is related but distinct
+  and remains its own issue; not addressed here.
+- The enum change to `RunOutcome::RollbackRejected` is `cli`-internal only
+  — `RunOutcome` is not part of any FFI or on-disk surface.


### PR DESCRIPTION
Closes #207, closes #208, closes #209.

Three confirmed spec/code divergences in the headless `secretary-sync` daemon's manifest-rollback defense (threat-model §3.1), all in `cli/`. **No `core/` crypto change, no FFI surface, no on-disk vault/manifest/`SyncState` format change** → `conformance.py` + Swift/Kotlin conformance harnesses unaffected. Each fix code-aligns to the existing C.2 design spec (the spec stays the source of truth; two small clarifications folded in).

## #207 — daemon loop now surfaces `Ok(RunOutcome)` attack indicators
The loop discarded every `Ok(RunOutcome)`, so `RollbackRejected` (the §3.1 attack indicator) and auto-resolved tombstone vetoes were never logged at any verbosity — a malicious cloud host could probe with replayed manifests at zero alerting cost. Now: `RunOutcome::RollbackRejected(RollbackEvidence)` (once-mode ignores the payload → still exit 10), a pure `daemon::outcome_log` classifier + `daemon::log_outcome` emitter, and the loop logs rollback (with disk+local vector clocks) and the auto-resolved-veto count at `warn!`. `pipeline.rs` stays free of `tracing` calls.

## #208 — `SyncState` persisted after every advancing sync
The rollback anchor was persisted only once after the loop exits, so an unclean exit discarded the whole session's clock advances → on restart a stale clock let the host replay an old manifest as a forward update. Now: pure `RunOutcome::advanced_state()`, `daemon::after_sync` persisting via an injected sink (unit-testable without a watcher/FS) on every state-advancing arm; `state_dir` threaded into `run_against_vault`; in-loop save failure logged + swallowed (daemon survives transient FS errors); final-save failure escalates a `Success` exit to non-success without overriding a more specific code.

## #209 — state-dir safety
Silent `"."` (cwd) fallback when `dirs::data_dir()` is `None` could place rollback state inside the attacker-controlled synced vault folder; plus a `0700` spec/code divergence. Now: **hard error** on implicit cwd fallback (`Unresolvable`; explicit `--state-dir .` still allowed) and on a state dir inside the vault (`InsideVault`), both → exit 2; a lexical (intentionally symlink-unaware) containment guard; `create_dir_secure` applies `STATE_DIR_MODE = 0o700` on Unix.

## Process
Brainstorm → design → plan → subagent-driven development (fresh implementer + spec/quality reviewer per task) → final whole-branch review (opus): **Ready to merge, 0 Critical / 0 Important**. 5 review Minors fixed in one wave (`203c09b`), 1 filed as #295 (once-mode `log_outcome`, out of #207's daemon scope), 1 dismissed.

## Verification (local, GREEN)
- `cargo test --release --workspace` — 0 failed (~18 new tests incl. teeth tests for each gap)
- `cargo clippy --release --workspace --tests -- -D warnings` — clean
- `cargo fmt --all -- --check` — clean
- `uv run core/tests/python/conformance.py` — PASS

Design: `docs/superpowers/specs/2026-06-24-daemon-rollback-hardening-design.md` · Plan: `docs/superpowers/plans/2026-06-24-daemon-rollback-hardening.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)