### PR TITLE
fix(ffi): bound reveal-residency to on-screen block + scrub password Data copy (#251, #229)

### DIFF
--- a/NEXT_SESSION.md
+++ b/NEXT_SESSION.md
@@ -1,1 +1,1 @@
-docs/handoffs/2026-06-25-ffi-share-tofu-hardening-shipped.md
+docs/handoffs/2026-06-25-ios-android-memory-hygiene-shipped.md

--- a/android/kit/src/androidTest/kotlin/org/secretary/browse/RevealResidencyInstrumentedTest.kt
+++ b/android/kit/src/androidTest/kotlin/org/secretary/browse/RevealResidencyInstrumentedTest.kt
@@ -44,6 +44,8 @@ class RevealResidencyInstrumentedTest {
             session.readBlock(blockUuid, false)
 
             // Pre-fix: prior block still in openBlocks → still reveals. Post-fix: throws.
+            // (No-growth on re-selection is enforced by the `currentBlock: BlockReadOutput?`
+            // type itself — a runtime count assertion would be redundant.)
             assertThrows(VaultBrowseError.CorruptVault::class.java) { staleField.reveal() }
             Unit
         } finally {

--- a/android/kit/src/androidTest/kotlin/org/secretary/browse/RevealResidencyInstrumentedTest.kt
+++ b/android/kit/src/androidTest/kotlin/org/secretary/browse/RevealResidencyInstrumentedTest.kt
@@ -1,0 +1,53 @@
+package org.secretary.browse
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Assert.assertThrows
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.secretary.sync.GoldenVaultStaging
+import java.io.File
+
+/**
+ * #251 (Android parity): navigating to another block must evict the prior block's decrypted
+ * plaintext — a stale reveal closure must stop yielding plaintext. Reads the single golden
+ * block twice (eviction + re-selection dedup in one). Real native FFI: host tests cannot
+ * exercise the uniffi handle cascade.
+ */
+@RunWith(AndroidJUnit4::class)
+class RevealResidencyInstrumentedTest {
+    private val context get() = InstrumentationRegistry.getInstrumentation().targetContext
+    private val goldenPassword = "correct horse battery staple".toByteArray()
+    private val toClean = mutableListOf<File>()
+
+    @After fun cleanup() = toClean.forEach { it.deleteRecursively() }
+
+    private fun stageVault(): File =
+        GoldenVaultStaging.stageWritableVault(context).also { toClean += it.parentFile!! }
+
+    @Test
+    fun navigatingAwayEvictsPriorBlockPlaintext() = runBlocking {
+        val vault = stageVault()
+        val session = uniffiVaultOpenPort().openWithPassword(vault.path, goldenPassword)
+        try {
+            val blockUuid = session.blockSummaries().first().uuid
+
+            // First read: capture a reveal closure from this block's first field.
+            val firstRecords = session.readBlock(blockUuid, false)
+            val staleField = firstRecords.flatMap { it.fields }.first()
+            staleField.reveal()  // sanity: reveals before navigating away
+
+            // Navigate (re-read the only block). The fix wipes the prior BlockReadOutput,
+            // cascading to the captured FieldHandle.
+            session.readBlock(blockUuid, false)
+
+            // Pre-fix: prior block still in openBlocks → still reveals. Post-fix: throws.
+            assertThrows(VaultBrowseError.CorruptVault::class.java) { staleField.reveal() }
+            Unit
+        } finally {
+            session.wipe()
+        }
+    }
+}

--- a/android/kit/src/main/kotlin/org/secretary/browse/UniffiVaultOpenPort.kt
+++ b/android/kit/src/main/kotlin/org/secretary/browse/UniffiVaultOpenPort.kt
@@ -69,16 +69,17 @@ class UniffiVaultOpenPort(
 
 /**
  * The real [VaultSession]: owns the decrypted [OpenVaultManifest] + [UnlockedIdentity] handles,
- * plus every [BlockReadOutput] retained from [readBlock]. [blockSummaries] reads in-memory manifest
- * metadata. [readBlock] decrypts ONE block, retains it in [openBlocks] (NO `.use{}`), and builds
- * one [RevealableField] per field whose `reveal` lambda calls `expose_text`/`expose_bytes` ON DEMAND
- * — no secret value is materialized until the user taps. [wipe] zeroizes blocks → manifest →
- * identity in that order (mirrors iOS UniffiVaultSession). Kotlin mirror of iOS `UniffiVaultSession`.
+ * plus the single on-screen [BlockReadOutput] retained from [readBlock] (at most one at a time).
+ * [blockSummaries] reads in-memory manifest metadata. [readBlock] decrypts ONE block, evicts the
+ * prior [currentBlock], retains the new one (NO `.use{}`), and builds one [RevealableField] per
+ * field whose `reveal` lambda calls `expose_text`/`expose_bytes` ON DEMAND — no secret value is
+ * materialized until the user taps. [wipe] zeroizes the current block → manifest → identity in
+ * that order (mirrors iOS UniffiVaultSession). Kotlin mirror of iOS `UniffiVaultSession`.
  *
  * Thread-safety: unlike iOS (whose `readBlock` is synchronous), Android runs [readBlock] on
  * [ioDispatcher] while [wipe] runs on the main thread (the slice-7 `ON_STOP` lock-on-background).
- * Every touch of the shared FFI state — the `identity`/`manifest` handles and the [openBlocks]
- * list — is therefore serialized under [sessionLock], and a [wiped] flag makes a read that loses
+ * Every touch of the shared FFI state — the `identity`/`manifest` handles and [currentBlock] —
+ * is therefore serialized under [sessionLock], and a [wiped] flag makes a read that loses
  * the race to a concurrent [wipe] zeroize its just-decrypted block instead of leaving plaintext
  * resident after a lock the caller believed cleared everything.
  */
@@ -90,7 +91,7 @@ class UniffiVaultSession(
     private val identity: UnlockedIdentity = output.identity
     private val manifest: OpenVaultManifest = output.manifest
 
-    /** Serializes all access to the FFI handles + [openBlocks] across the IO dispatcher (reads)
+    /** Serializes all access to the FFI handles + [currentBlock] across the IO dispatcher (reads)
      *  and the main thread (wipe). The held section spans the block decrypt, so a concurrent
      *  [wipe] waits for an in-flight read (bounded — one block decrypt is milliseconds). */
     private val sessionLock = Any()
@@ -101,11 +102,11 @@ class UniffiVaultSession(
     /** Resolved once per session (first write) so every write stamps the same device UUID. */
     private var cachedDeviceUuid: ByteArray? = null
 
-    /** Decrypted blocks retained so the per-field reveal closures (which capture a FieldHandle)
-     *  stay valid until wipe(). Mirror of iOS UniffiVaultSession.openBlocks. NOTE: this currently
-     *  accumulates every visited block's plaintext until wipe() (no per-navigation eviction); the
-     *  cross-platform residency tradeoff is tracked in #251. */
-    private val openBlocks: MutableList<BlockReadOutput> = mutableListOf()
+    /** The single retained decrypted block — the on-screen one. Bounding to one block (not a
+     *  growing list) makes "≤1 block resident" a type-level invariant and dedups re-selection.
+     *  The VM clears the reveal map on selectBlock, so no live reveal closure references a prior
+     *  block when we evict it here. Mirror of iOS UniffiVaultSession.currentBlock (#251). */
+    private var currentBlock: BlockReadOutput? = null
 
     override fun vaultUuidHex(): String = hexOfBytes(manifest.vaultUuid())
 
@@ -125,7 +126,11 @@ class UniffiVaultSession(
                         block.wipe()
                         return@synchronized emptyList<RecordSummaryView>()
                     }
-                    openBlocks += block   // retained (NO .use{}) — reveal closures depend on it
+                    // Decrypt-first ordering: `block` is decoded above; a thrown read left the
+                    // prior block retained. Evict it before retaining the new one (NO .use{} —
+                    // reveal closures depend on currentBlock until wipe()).
+                    currentBlock?.wipe()
+                    currentBlock = block
                     val count = block.recordCount().toInt()
                     (0 until count).map { i ->
                         // Record is a transient Kotlin wrapper; the FieldHandle secrets it
@@ -249,8 +254,8 @@ class UniffiVaultSession(
         // repeatedly, e.g. ON_STOP then explicit lock).
         synchronized(sessionLock) {
             wiped = true
-            openBlocks.forEach { it.wipe() }
-            openBlocks.clear()
+            currentBlock?.wipe()
+            currentBlock = null
             manifest.wipe()
             identity.wipe()
         }

--- a/docs/handoffs/2026-06-25-ios-android-memory-hygiene-shipped.md
+++ b/docs/handoffs/2026-06-25-ios-android-memory-hygiene-shipped.md
@@ -1,0 +1,90 @@
+# NEXT_SESSION.md — iOS/Android memory-hygiene hardening (#251 + #229) ✅ SHIPPED (PR opening)
+
+**Session date:** 2026-06-25. Started from a clean baton — PR #297 (#206 FFI share-TOFU) had merged to `main` (`e3f5f370`); removed the prior `.worktrees/ffi-share-tofu-hardening` worktree + deleted branch. Picked the **memory-hygiene pair #251 + #229** (you chose it over #210 / #295). Brainstormed → spec → plan → executed via **subagent-driven development** (fresh sonnet implementer + sonnet spec/quality reviewer per task; final whole-branch review on opus) → applied 2 cosmetic final-review minors → docs decision → opening PR.
+
+**Status:** ✅ **SHIPPED — branch `feature/ios-android-memory-hygiene`, PR opening.** Final whole-branch review (opus): **Ready to merge, 0 Critical / 0 Important.** All per-task reviews: spec ✅ / quality Approved.
+
+## (1) What we shipped this session
+
+Two independent, pre-existing memory-hygiene gaps in the **iOS/Android FFI layer** — no Rust-core / on-disk-format / spec change; `conformance.py` + the Swift/Kotlin conformance harnesses untouched.
+
+**#251 — reveal-residency accumulation (iOS + Android parity).** `UniffiVaultSession.readBlock` appended every decrypted `BlockReadOutput` to an `openBlocks` list and never released it until the session was wiped (lock/background), so browsing A→B→A left every visited block's *entire* decrypted plaintext resident, and re-selecting a block accumulated duplicates. **Fix:** replace the unbounded list with a single `currentBlock: BlockReadOutput?`, wiping the prior block on each **successful** `readBlock` (decrypt-first: a thrown decrypt leaves the on-screen block retained). Making it an optional turns "≤1 block resident" into a **type-level invariant** (accidental accumulation impossible) and dedups re-selection. Android keeps the #250 `sessionLock` + `wiped`-race guard — eviction sits inside the lock, after the `wiped` check.
+
+**#229 — iOS FFI-boundary password copy never scrubbed.** The port adapters copy the master password / recovery phrase into `Data(password)` at the FFI boundary and never overwrite that copy (uniffi copies into Rust where it *is* zeroized; the residue is the Swift `Data`). **Fix:** a pure `zeroize(_ data: inout Data)` + a `withZeroizingData` wrapper that scrubs the boundary `Data` in a `defer` (fires on return **and** throw), applied at all five sites (open password/recovery, create, sync, commitDecisions). Scrubs only the **adapter-owned** `Data` — deliberately NOT the caller's `[UInt8]` (Swift copy-on-write makes that ineffective; documented in the helper, matching the existing `toFfi` text-residue precedent).
+
+**Why the #251 fix is safe (verified against real code by the final review, not assumed):** the VM clears the reveal map before every read (iOS `VaultBrowseViewModel.reload` → `revealed.removeAll()`; Android `VaultBrowseModel.selectBlock` → `_revealed.value = emptyMap()`), so no *live* reveal closure points at the evicted block; and `BlockReadOutput.wipe()` cascades `Record.wipe()` → `FieldHandle.wipe()` via a shared `Arc` (`Option::take`), so an already-captured `FieldHandle` returns `None`/throws after eviction — proven by the existing bridge unit test `arc_clone_shares_wiped_state` and exercised directly by both teeth tests.
+
+**Branch commits** (off `main` @ `e3f5f370`):
+| SHA | What |
+|---|---|
+| `c244f172` | design doc (`docs/superpowers/specs/2026-06-25-ios-android-memory-hygiene-design.md`) |
+| `c8a7de65` | implementation plan (`docs/superpowers/plans/2026-06-25-ios-android-memory-hygiene.md`) |
+| `8b702215` | **fix(ios)**: bound reveal-residency to the on-screen block (#251, Task 1) |
+| `3a82886f` | **fix(android)**: bound reveal-residency to the on-screen block (#251, Task 2) |
+| `303cc537` | **fix(ios)**: scrub FFI-boundary password Data copy via `withZeroizingData` (#229, Task 3) |
+| `3cc97dff` | docs(test): note dedup is a type-level invariant; wrap long comment (final-review minors) |
+| (+ handoff commit) | this baton + retargeted `NEXT_SESSION.md` symlink |
+
+**Tests added (TDD red→green throughout):**
+- **#251 iOS** — `RevealResidencyIntegrationTests.swift` (host XCTest, golden_vault_001 temp copy): captures a reveal closure, re-reads the single golden block, asserts the **stale closure throws** after eviction (fails on pre-fix accumulate-forever code).
+- **#251 Android** — `RevealResidencyInstrumentedTest.kt` (instrumented, on `emulator-5554`): the same teeth assertion (`assertThrows(VaultBrowseError.CorruptVault)`).
+- **#229** — `ZeroizingDataTests.swift` (5 cases): `zeroize` overwrites all bytes + empty-data no-op; `withZeroizingData` exposes bytes / returns body result / propagates throws (the scrub itself proven by composition through the pure `zeroize`, since the local `Data` is unobservable post-call — a Swift value-type/CoW limit).
+
+### Acceptance (verified by the controller this session, not assumed)
+```bash
+cd /Users/hherb/src/secretary/.worktrees/ios-android-memory-hygiene
+bash ios/scripts/run-ios-tests.sh           # 29 tests, 0 failures — RevealResidency ✅ + ZeroizingData(5) ✅
+# Android instrumented (emulator-5554 was up):
+cd android && ./gradlew :kit:connectedDebugAndroidTest \
+  -Pandroid.testInstrumentationRunnerArguments.class=org.secretary.browse.RevealResidencyInstrumentedTest
+cd android && ./gradlew :kit:testDebugUnitTest :vault-access:test   # host units green
+# Rust unchanged but proven no incidental drift:
+cargo fmt --all -- --check                   # clean
+uv run core/tests/python/conformance.py      # PASS (unchanged)
+cargo test --release --workspace             # <SEE PR — running at handoff; CI is the gate>
+```
+**CI is the real gate once pushed** — `test.yml` (rust ×2 OS + desktop vitest + swift/kotlin conformance + smoke) + `rust-lint.yml` (fmt/clippy) + CodeQL. No new `FfiVaultError`/format surface → conformance KAT + harnesses unaffected.
+
+## (2) What's next
+**#251 + #229 done (PR open). Pick a fresh item.** Remaining sync/daemon + tooling backlog:
+- **#295** — `once` mode doesn't `log_outcome` (rollback/veto surfaced only via exit code, no forensic clocks). Small, pure-Rust/cli; spinoff of the daemon cluster. Call `daemon::log_outcome` on the `Ok` arm of `dispatch_once_subcommand`.
+- **#210** — fuzz monitor dashboard binds `0.0.0.0` with no auth (docs say localhost). Python; small, quick win; carries the `security` label.
+- **#290** — allowlist the 3 D.4 freshness false-positives (`origin_binding`/`registrable_domain`/`exact_origin`) once the `d4-browser-autofill` session settles (worktree `.worktrees/d4-browser-autofill` was still active at handoff).
+- **Possible #251/#229 follow-ups (not filed):** (a) the VM-owned input `[UInt8]` password array on iOS is still unscrubbed (CoW makes adapter-side scrubbing impossible — would need `inout`/a wrapper type threaded through every port signature + VM; out of scope here, file if wanted). (b) #251's derived-handle note: the per-`Record`/`FieldHandle` uniffi wrappers are now bounded to one block's worth regardless, so the minor "lingering native allocation" sub-concern in #251 is closed by construction.
+
+**Acceptance criteria template for the next pick:** a failing test that reproduces the gap on `main`, the typed-error/enforcement surface *proven* not assumed (security paths), full `cargo test --workspace` + clippy `-D warnings` green, and spec/`conformance.py` updated in lockstep if observable bytes/semantics change.
+
+**Open follow-up issues (carried):** #295 / #290 / #284 / #280 / #277 / #273 / #272 / #269 / #255 / #252 / #247 / #246 / #234 / #232 / #231 / #224 / #218 / #210 / #193 / #192 / #190 / #189 / #186 / #183. (#251 + #229 now closed by this PR; #206 / #207 / #208 / #209 / #205 / #293 closed earlier.)
+
+## (3) Open decisions and risks
+- **#251: single-optional, not a bounded list (deliberate).** Bounding `openBlocks` to one element would also work, but `currentBlock: BlockReadOutput?` makes "≤1 block resident" a compile-time invariant — accidental re-accumulation is impossible. The no-growth-on-re-selection property is therefore enforced by the **type**, not a runtime count assertion (both teeth tests carry a comment saying so). Don't "promote" it back to a list.
+- **#251: decrypt-first ordering is load-bearing.** Evict the prior block only AFTER the new block decrypts successfully — a thrown decrypt must leave the on-screen block (and its live reveal closures) retained. Structurally enforced on both platforms (the eviction lines are unreachable if the FFI read throws). Don't reorder.
+- **#229: scrub the `Data` copy only (fail-honest scope).** The helper cannot scrub the caller's `[UInt8]` (Swift CoW → mutating our binding allocates a throwaway and leaves the caller's buffer intact). This is documented, not a gap to "fix" by mutating the param. Threading `inout`/a `SecretBytes` wrapper through every port signature + VM was explicitly rejected as disproportionate for this PR (see #2 follow-up (a)).
+- **#229: `zeroize` is the pure, testable core.** The happy-path/throw-path scrub at the `withZeroizingData` level is not directly observable (the `Data` is local and gone post-call) — proven by composition via `testZeroizeOverwritesAllBytes`. Don't inline `zeroize` into the wrapper; the split is what makes the post-condition assertable.
+- **README / ROADMAP unchanged (deliberate).** #251/#229 add **no new capability or projected surface** — pure internal hardening of already-shipped mobile reveal/sync slices (C.3). The README iOS reveal row stays accurate; adding per-fix hardening notes would be the per-binding minutiae the README-style guidance discourages. (Contrast #206, which projected *new* primitives to Python/mobile → warranted a README note.) No milestone moved, so ROADMAP is unchanged.
+- **Risk:** none to honest-vault behavior. #251 eviction only drops blocks the user navigated away from (reveal map already cleared); the on-screen block is always retained → reveal-on-tap, write, and sync paths unaffected (full iOS suite + Android host units green; instrumented teeth test green on `emulator-5554`). #229 only overwrites a copy the FFI call has already consumed.
+
+## (4) Exact commands to resume
+```bash
+cd /Users/hherb/src/secretary
+git fetch --prune origin && git checkout main && git pull --ff-only origin main
+# If PR merged: branch + worktree .worktrees/ios-android-memory-hygiene can be removed:
+#   git worktree remove .worktrees/ios-android-memory-hygiene && git branch -D feature/ios-android-memory-hygiene
+git worktree list && git status -s
+
+# Run any gate locally (from the worktree if the PR is still open):
+bash ios/scripts/run-ios-tests.sh
+cd android && ./gradlew :kit:connectedDebugAndroidTest \
+  -Pandroid.testInstrumentationRunnerArguments.class=org.secretary.browse.RevealResidencyInstrumentedTest   # needs an emulator/device up
+cargo test --release --workspace && cargo clippy --release --workspace --tests -- -D warnings
+```
+
+## (5) Handoff file model
+`NEXT_SESSION.md` is a **relative symlink** to this file in `docs/handoffs/`. Authored once here; symlink retargeted in the same commit on the feature branch. New-path handoff → no add/add conflict. Branch was cut from current `origin/main` (`e3f5f370`) and `origin/main` had **not** advanced at handoff time (verified: `origin/main` == merge-base), so no history-binding merge was needed this session.
+
+## Closing inventory
+- **State on close:** PR opening on `feature/ios-android-memory-hygiene` (6 code/doc commits + handoff). Worktree `.worktrees/ios-android-memory-hygiene`.
+- **Acceptance:** local GREEN — iOS host suite (29 tests, 0 fail), Android instrumented teeth test + host units, conformance PASS, fmt clean. Full `cargo test --release --workspace` was running at handoff (Rust diff is empty — zero core files touched); CI is the gate on push. Final whole-branch review (opus): Ready to merge, 0 Critical / 0 Important; only cosmetic Minors (2 applied as `3cc97dff`, rest intentional/language-imposed).
+- **README.md / ROADMAP.md:** unchanged (rationale in §3 — internal hardening, no capability/milestone change).
+- **CLAUDE.md:** unchanged (the zeroize-discipline + "both halves" properties it documents are preserved and now also enforced at the mobile reveal-residency + password-boundary surfaces).
+- **NEXT_SESSION.md:** symlink → `docs/handoffs/2026-06-25-ios-android-memory-hygiene-shipped.md`.

--- a/docs/superpowers/plans/2026-06-25-ios-android-memory-hygiene.md
+++ b/docs/superpowers/plans/2026-06-25-ios-android-memory-hygiene.md
@@ -1,0 +1,466 @@
+# iOS/Android memory-hygiene hardening Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Bound the reveal-residency window to the on-screen block (#251, iOS + Android) and scrub the FFI-boundary password `Data` copy on iOS (#229), without any Rust-core / on-disk-format / spec change.
+
+**Architecture:** Replace the unbounded `openBlocks: [BlockReadOutput]` accumulator in each platform's `UniffiVaultSession` with a single retained `currentBlock: BlockReadOutput?`, wiping the prior block on each successful `readBlock`. Add a small `withZeroizingData` helper in iOS `SecretaryKit` and apply it at the five password/phrase FFI sites.
+
+**Tech Stack:** Swift (XCTest, Foundation `Data`), Kotlin (AndroidJUnit4 instrumented tests, kotlinx-coroutines), uniffi-generated `BlockReadOutput`/`Record`/`FieldHandle` handles.
+
+## Global Constraints
+
+- No new `FfiVaultError` / `VaultError` variant; no change to observable bytes or merge semantics → `conformance.py`, conformance KATs, and the Swift/Kotlin conformance harnesses must stay untouched and green.
+- Preserve the "blocks → manifest → identity" wipe order in `wipe()` on both platforms.
+- Preserve Android's existing `sessionLock` serialization + `wiped`-race guard from #250 — the new eviction goes **inside** the lock, after the `wiped` check.
+- Decrypt-first ordering is load-bearing: evict the prior block only **after** the new block decrypts successfully (a thrown decrypt must leave the on-screen block retained).
+- No magic numbers; doc-comment every new symbol; one concept per file. Reuse the existing golden-vault test harness (`goldenPassword = "correct horse battery staple"`, the published KAT password — not a real secret, so not zeroized).
+- The golden vault (`golden_vault_001`) has exactly **one** block, so the #251 teeth test reads that block **twice** — proving eviction and re-selection dedup in one shot.
+
+---
+
+### Task 1: #251 — bound iOS `UniffiVaultSession` to the on-screen block
+
+**Files:**
+- Modify: `ios/SecretaryKit/Sources/SecretaryKit/VaultAccess/UniffiVaultSession.swift` (field at :14, append at :56, `wipe()` at :116-121)
+- Test: `ios/SecretaryKit/Tests/SecretaryKitTests/RevealResidencyIntegrationTests.swift` (create)
+
+**Interfaces:**
+- Consumes: `UniffiVaultOpenPort().openWithPassword(vaultPath:password:) async throws -> VaultSession`; `VaultSession.blockSummaries() -> [BlockSummary]` (`.uuid`); `VaultSession.readBlock(blockUuid:includeDeleted:) throws -> [RecordView]`; `RecordView.fields: [FieldView]`; `FieldView.reveal: () throws -> RevealedValue`.
+- Produces: no new public API — behavior change only (`openBlocks` list → `currentBlock` optional).
+
+- [ ] **Step 1: Write the failing test**
+
+Create `ios/SecretaryKit/Tests/SecretaryKitTests/RevealResidencyIntegrationTests.swift`. Mirror the temp-copy fixture setup from `VaultAccessIntegrationTests.swift` (copy `golden_vault_001` from `Bundle.module` to a temp dir in `setUp`, remove in `tearDown`).
+
+```swift
+import XCTest
+import SecretaryVaultAccess
+@testable import SecretaryKit
+
+/// #251: navigating to another block must evict the prior block's decrypted
+/// plaintext (a stale reveal closure must stop yielding plaintext), and
+/// re-selecting the same block must not accumulate. Reads the single golden
+/// block twice — proves eviction + dedup together.
+final class RevealResidencyIntegrationTests: XCTestCase {
+    private let goldenPassword = "correct horse battery staple"
+    private var vaultCopy: URL!
+
+    override func setUpWithError() throws {
+        let bundled = try XCTUnwrap(
+            Bundle.module.url(forResource: "golden_vault_001", withExtension: nil),
+            "golden_vault_001 not bundled — run ios/scripts/build-xcframework.sh")
+        let tmp = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("res-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: tmp, withIntermediateDirectories: true)
+        vaultCopy = tmp.appendingPathComponent("golden_vault_001", isDirectory: true)
+        try FileManager.default.copyItem(at: bundled, to: vaultCopy)
+    }
+
+    override func tearDownWithError() throws {
+        try? FileManager.default.removeItem(at: vaultCopy.deletingLastPathComponent())
+    }
+
+    func testNavigatingAwayEvictsPriorBlockPlaintext() async throws {
+        let port = UniffiVaultOpenPort()
+        let path = Data(vaultCopy.path.utf8)
+        let session = try await port.openWithPassword(
+            vaultPath: path, password: [UInt8](goldenPassword.utf8))
+        defer { session.wipe() }
+
+        let blocks = session.blockSummaries()
+        let blockUuid = try XCTUnwrap(blocks.first?.uuid, "golden vault has one block")
+
+        // First read: capture a reveal closure from this block's first revealable field.
+        let firstRecords = try session.readBlock(blockUuid: blockUuid, includeDeleted: false)
+        let staleField = try XCTUnwrap(
+            firstRecords.flatMap(\.fields).first, "block has at least one field")
+        _ = try staleField.reveal()  // sanity: reveals before we navigate away
+
+        // Navigate (re-read the same block — the only one). The fix wipes the prior
+        // BlockReadOutput, which cascades to the captured FieldHandle.
+        _ = try session.readBlock(blockUuid: blockUuid, includeDeleted: false)
+
+        // Pre-fix: the prior block stays in `openBlocks`, so this still yields plaintext.
+        // Post-fix: the prior block was wiped, so reveal() throws.
+        XCTAssertThrowsError(try staleField.reveal(),
+            "stale reveal closure must fail after navigating away (block evicted)")
+    }
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `bash ios/scripts/run-ios-tests.sh` (or the script's documented filter for `RevealResidencyIntegrationTests`).
+Expected: FAIL — `testNavigatingAwayEvictsPriorBlockPlaintext` does not throw (pre-fix the prior block is still retained and reveals plaintext).
+
+- [ ] **Step 3: Implement the single-block bound**
+
+In `UniffiVaultSession.swift`, replace the accumulator field (line ~13-14):
+
+```swift
+    /// The single retained decrypted block — the on-screen one. Bounding to one
+    /// block (not a growing list) makes "≤1 block resident" a type-level invariant
+    /// and dedups re-selection. The VM clears the reveal map on `selectBlock`, so no
+    /// live reveal closure references a prior block when we evict it here (#251).
+    private var currentBlock: BlockReadOutput?
+```
+
+In `readBlock`, replace `openBlocks.append(out)` (line ~56) with eviction-after-decrypt:
+
+```swift
+        // Decrypt-first ordering: `out` is already decoded above, so a thrown read
+        // left the prior block retained. Now evict it before retaining the new one.
+        currentBlock?.wipe()
+        currentBlock = out  // keep alive for reveal closures + wipe
+```
+
+Replace `wipe()` (lines ~116-121):
+
+```swift
+    public func wipe() {
+        currentBlock?.wipe()
+        currentBlock = nil
+        manifest.wipe()
+        identity.wipe()
+    }
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `bash ios/scripts/run-ios-tests.sh`
+Expected: PASS — `RevealResidencyIntegrationTests` green; existing `VaultAccessIntegrationTests` / `BlockCrudRoundTripIntegrationTests` / `RecordEditIntegrationTests` still green (the on-screen block is always retained, so reveal-on-tap and the write paths are unaffected).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add ios/SecretaryKit/Sources/SecretaryKit/VaultAccess/UniffiVaultSession.swift \
+        ios/SecretaryKit/Tests/SecretaryKitTests/RevealResidencyIntegrationTests.swift
+git commit -m "fix(ios): bound reveal-residency to the on-screen block (#251)"
+```
+
+---
+
+### Task 2: #251 — bound Android `UniffiVaultSession` to the on-screen block
+
+**Files:**
+- Modify: `android/kit/src/main/kotlin/org/secretary/browse/UniffiVaultOpenPort.kt` (field + doc-comment at :104-108, append at :128, `wipe()` at :245-257)
+- Test: `android/kit/src/androidTest/kotlin/org/secretary/browse/RevealResidencyInstrumentedTest.kt` (create)
+
+**Interfaces:**
+- Consumes: `uniffiVaultOpenPort(): VaultOpenPort`; `VaultOpenPort.openWithPassword(vaultFolder:String, password:ByteArray): VaultSession` (suspend); `VaultSession.blockSummaries(): List<BlockSummaryView>` (`.uuid: ByteArray`); `VaultSession.readBlock(blockUuid:ByteArray, includeDeleted:Boolean): List<RecordSummaryView>` (suspend); `RecordSummaryView.fields: List<RevealableField>`; `RevealableField.reveal: () -> RevealedValue` (throws `VaultBrowseError.CorruptVault`). Uses `GoldenVaultStaging.stageWritableVault(context)` from `org.secretary.sync`.
+- Produces: no new public API — behavior change only.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `android/kit/src/androidTest/kotlin/org/secretary/browse/RevealResidencyInstrumentedTest.kt`. (`GoldenVaultStaging` lives in package `org.secretary.sync` — import it.)
+
+```kotlin
+package org.secretary.browse
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Assert.assertThrows
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.secretary.sync.GoldenVaultStaging
+import java.io.File
+
+/**
+ * #251 (Android parity): navigating to another block must evict the prior block's decrypted
+ * plaintext — a stale reveal closure must stop yielding plaintext. Reads the single golden
+ * block twice (eviction + re-selection dedup in one). Real native FFI: host tests cannot
+ * exercise the uniffi handle cascade.
+ */
+@RunWith(AndroidJUnit4::class)
+class RevealResidencyInstrumentedTest {
+    private val context get() = InstrumentationRegistry.getInstrumentation().targetContext
+    private val goldenPassword = "correct horse battery staple".toByteArray()
+    private val toClean = mutableListOf<File>()
+
+    @After fun cleanup() = toClean.forEach { it.deleteRecursively() }
+
+    private fun stageVault(): File =
+        GoldenVaultStaging.stageWritableVault(context).also { toClean += it.parentFile!! }
+
+    @Test
+    fun navigatingAwayEvictsPriorBlockPlaintext() = runBlocking {
+        val vault = stageVault()
+        val session = uniffiVaultOpenPort().openWithPassword(vault.path, goldenPassword)
+        try {
+            val blockUuid = session.blockSummaries().first().uuid
+
+            // First read: capture a reveal closure from this block's first field.
+            val firstRecords = session.readBlock(blockUuid, false)
+            val staleField = firstRecords.flatMap { it.fields }.first()
+            staleField.reveal()  // sanity: reveals before navigating away
+
+            // Navigate (re-read the only block). The fix wipes the prior BlockReadOutput,
+            // cascading to the captured FieldHandle.
+            session.readBlock(blockUuid, false)
+
+            // Pre-fix: prior block still in openBlocks → still reveals. Post-fix: throws.
+            assertThrows(VaultBrowseError.CorruptVault::class.java) { staleField.reveal() }
+        } finally {
+            session.wipe()
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run (emulator/device connected; `--tests` is rejected for instrumented runs — use the runner-arg class filter):
+```bash
+cd android && ./gradlew :kit:connectedDebugAndroidTest \
+  -Pandroid.testInstrumentationRunnerArguments.class=org.secretary.browse.RevealResidencyInstrumentedTest
+```
+Expected: FAIL — `staleField.reveal()` returns a value instead of throwing (pre-fix accumulation).
+
+- [ ] **Step 3: Implement the single-block bound**
+
+In `UniffiVaultOpenPort.kt`, replace the `openBlocks` field + its stale-tradeoff doc-comment (lines ~104-108):
+
+```kotlin
+    /** The single retained decrypted block — the on-screen one. Bounding to one block (not a
+     *  growing list) makes "≤1 block resident" a type-level invariant and dedups re-selection.
+     *  The VM clears the reveal map on selectBlock, so no live reveal closure references a prior
+     *  block when we evict it here. Mirror of iOS UniffiVaultSession.currentBlock (#251). */
+    private var currentBlock: BlockReadOutput? = null
+```
+
+In `readBlock`, replace `openBlocks += block` (line ~128) with eviction-after-decrypt (still inside `synchronized(sessionLock)`, after the `wiped` check):
+
+```kotlin
+                    // Decrypt-first ordering: `block` is decoded above; a thrown read left the
+                    // prior block retained. Evict it before retaining the new one (NO .use{} —
+                    // reveal closures depend on currentBlock until wipe()).
+                    currentBlock?.wipe()
+                    currentBlock = block
+```
+
+Replace the `openBlocks` lines in `wipe()` (lines ~252-253):
+
+```kotlin
+            currentBlock?.wipe()
+            currentBlock = null
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run:
+```bash
+cd android && ./gradlew :kit:connectedDebugAndroidTest \
+  -Pandroid.testInstrumentationRunnerArguments.class=org.secretary.browse.RevealResidencyInstrumentedTest
+```
+Expected: PASS. Then run the host unit tests to confirm no regression in the mapping/model layer:
+```bash
+cd android && ./gradlew :kit:testDebugUnitTest :vault-access:test
+```
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add android/kit/src/main/kotlin/org/secretary/browse/UniffiVaultOpenPort.kt \
+        android/kit/src/androidTest/kotlin/org/secretary/browse/RevealResidencyInstrumentedTest.kt
+git commit -m "fix(android): bound reveal-residency to the on-screen block (#251)"
+```
+
+---
+
+### Task 3: #229 — scrub the FFI-boundary password `Data` copy on iOS
+
+**Files:**
+- Create: `ios/SecretaryKit/Sources/SecretaryKit/VaultAccess/ZeroizingData.swift`
+- Test: `ios/SecretaryKit/Tests/SecretaryKitTests/ZeroizingDataTests.swift` (create)
+- Modify: `ios/SecretaryKit/Sources/SecretaryKit/VaultAccess/UniffiVaultOpenPort.swift` (sites at :14, :26)
+- Modify: `ios/SecretaryKit/Sources/SecretaryKit/VaultAccess/UniffiVaultCreatePort.swift` (the `createVaultInFolder` `Data(password)` site)
+- Modify: `ios/SecretaryKit/Sources/SecretaryKit/VaultAccess/UniffiVaultSyncPort.swift` (sites in `sync` :29 and `commitDecisions` :46)
+
+**Interfaces:**
+- Produces: `func zeroize(_ data: inout Data)`; `func withZeroizingData<T>(_ bytes: [UInt8], _ body: (Data) throws -> T) rethrows -> T`. Both internal to `SecretaryKit`.
+- Consumes: existing FFI fns `openVaultWithPassword`/`openVaultWithRecovery`/`createVaultInFolder`/`syncVault`/`commitSyncDecisions` (whatever the current names are — only the `password:`/`mnemonic:` `Data` argument changes from `Data(x)` to the helper's `pw`).
+
+- [ ] **Step 1: Write the failing test**
+
+Create `ios/SecretaryKit/Tests/SecretaryKitTests/ZeroizingDataTests.swift`:
+
+```swift
+import XCTest
+import Foundation
+@testable import SecretaryKit
+
+/// #229: the FFI-boundary password copy must be scrubbed after use.
+final class ZeroizingDataTests: XCTestCase {
+    func testZeroizeOverwritesAllBytes() {
+        var d = Data([1, 2, 3, 4, 5])
+        zeroize(&d)
+        XCTAssertEqual(d, Data(repeating: 0, count: 5))
+    }
+
+    func testZeroizeEmptyDataIsNoOp() {
+        var d = Data()
+        zeroize(&d)  // must not crash on a zero-length range
+        XCTAssertEqual(d.count, 0)
+    }
+
+    func testWithZeroizingDataExposesBytesToBody() {
+        let bytes: [UInt8] = [9, 8, 7]
+        let seen = withZeroizingData(bytes) { d in [UInt8](d) }
+        XCTAssertEqual(seen, [9, 8, 7])
+    }
+
+    func testWithZeroizingDataReturnsBodyResult() {
+        let n = withZeroizingData([1, 2, 3]) { d in d.count }
+        XCTAssertEqual(n, 3)
+    }
+
+    func testWithZeroizingDataPropagatesThrow() {
+        struct Boom: Error {}
+        // The defer-scrub still runs on the throwing path; we assert the error propagates
+        // (the scrub itself is proven by testZeroizeOverwritesAllBytes — same code path).
+        XCTAssertThrowsError(try withZeroizingData([1, 2, 3]) { _ in throw Boom() })
+    }
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `bash ios/scripts/run-ios-tests.sh`
+Expected: FAIL to compile — `zeroize` / `withZeroizingData` are undefined.
+
+- [ ] **Step 3: Implement the helper**
+
+Create `ios/SecretaryKit/Sources/SecretaryKit/VaultAccess/ZeroizingData.swift`:
+
+```swift
+import Foundation
+
+/// Overwrite every byte of `data` in place. Pure; post-condition: all bytes are
+/// zero. Mirrors the Rust core's `Sensitive<T>`/`SecretBytes` discipline at the
+/// one heap copy the Swift FFI boundary owns. No-op on empty data (#229).
+func zeroize(_ data: inout Data) {
+    guard !data.isEmpty else { return }
+    data.resetBytes(in: 0..<data.count)
+}
+
+/// Build a `Data` from `bytes`, hand it to `body`, and scrub that `Data` on the
+/// way out — the `defer` fires on both a normal return and a thrown error, so the
+/// FFI-boundary copy never lingers in the heap.
+///
+/// Scope/limitation: this scrubs the adapter-owned `Data` copy only. It does NOT
+/// scrub the caller's `bytes` array — Swift arrays are copy-on-write, so mutating
+/// our binding would allocate a throwaway buffer and leave the caller's storage
+/// intact. The caller's lifetime is minimized separately by the "password passed
+/// per call, never stored" port discipline (#229).
+func withZeroizingData<T>(_ bytes: [UInt8], _ body: (Data) throws -> T) rethrows -> T {
+    var data = Data(bytes)
+    defer { zeroize(&data) }
+    return try body(data)
+}
+```
+
+- [ ] **Step 4: Run the helper tests to verify they pass**
+
+Run: `bash ios/scripts/run-ios-tests.sh`
+Expected: PASS — `ZeroizingDataTests` green.
+
+- [ ] **Step 5: Apply the helper at all five FFI sites**
+
+`UniffiVaultOpenPort.swift` — `openWithPassword` (replace lines ~13-14):
+
+```swift
+                let out = try withZeroizingData(password) { pw in
+                    try SecretaryKit.openVaultWithPassword(folderPath: vaultPath, password: pw)
+                }
+```
+
+`openWithRecovery` (replace lines ~25-26):
+
+```swift
+                let out = try withZeroizingData(phrase) { ph in
+                    try SecretaryKit.openVaultWithRecovery(folderPath: vaultPath, mnemonic: ph)
+                }
+```
+
+`UniffiVaultCreatePort.swift` — wrap the `createVaultInFolder` call so the `Data(password)` becomes the helper's `pw` (keep the surrounding `do/catch` mapping `VaultError`):
+
+```swift
+            let mnem: MnemonicOutput
+            do {
+                mnem = try withZeroizingData(password) { pw in
+                    try SecretaryKit.createVaultInFolder(
+                        folderPath: Data(folder.path.utf8),
+                        password: pw,
+                        displayName: displayName,
+                        createdAtMs: UInt64(Date().timeIntervalSince1970 * 1000))
+                }
+            } catch let e as VaultError {
+                throw mapProvisioningError(e)
+            }
+```
+
+`UniffiVaultSyncPort.swift` — `sync` (the `password: Data(password)` argument, ~line 29):
+
+```swift
+                let dto = try withZeroizingData(password) { pw in
+                    try SecretaryKit.syncVault(
+                        stateDir: stateDir, vaultFolder: vaultFolder,
+                        password: pw, nowMs: nowMs)
+                }
+```
+
+`commitDecisions` (the `password: Data(password)` argument, ~line 46):
+
+```swift
+                let dto = try withZeroizingData(password) { pw in
+                    try SecretaryKit.commitSyncDecisions(
+                        stateDir: stateDir, vaultFolder: vaultFolder, password: pw,
+                        decisions: dtoDecisions, manifestHash: Data(manifestHash), nowMs: nowMs)
+                }
+```
+
+(Use the actual current FFI function names + argument labels found in each file — only the password/mnemonic `Data(...)` argument changes to `pw`/`ph`. Leave non-secret `Data(...)` conversions like `manifestHash` as-is.)
+
+- [ ] **Step 6: Run the full iOS suite to verify no regression**
+
+Run: `bash ios/scripts/run-ios-tests.sh`
+Expected: PASS — the existing open/create/sync integration tests (`VaultAccessIntegrationTests`, `UniffiVaultCreatePortTests`, `UniffiVaultSyncPortOffMainActorTests`) still pass; the password path is unchanged except the boundary copy is now scrubbed after the FFI call consumes it.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add ios/SecretaryKit/Sources/SecretaryKit/VaultAccess/ZeroizingData.swift \
+        ios/SecretaryKit/Tests/SecretaryKitTests/ZeroizingDataTests.swift \
+        ios/SecretaryKit/Sources/SecretaryKit/VaultAccess/UniffiVaultOpenPort.swift \
+        ios/SecretaryKit/Sources/SecretaryKit/VaultAccess/UniffiVaultCreatePort.swift \
+        ios/SecretaryKit/Sources/SecretaryKit/VaultAccess/UniffiVaultSyncPort.swift
+git commit -m "fix(ios): scrub FFI-boundary password Data copy via withZeroizingData (#229)"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- #251 iOS reveal-residency bound → Task 1. ✅
+- #251 Android reveal-residency bound + stale doc-comment update → Task 2. ✅
+- #251 dedup of re-selection → covered by both teeth tests (read same block twice) + the single-optional invariant. ✅
+- #229 `zeroize` + `withZeroizingData` helper + 5 sites + documented CoW residual → Task 3. ✅
+- #229 unit tests (zeroize post-condition, throw propagation) → Task 3 Step 1. ✅
+- Out-of-scope Android `#229` analogue (no second buffer copy) → no task needed; will note in PR/handoff after verifying `UniffiVaultOpenPort.kt:47` forwards the `ByteArray` directly. ✅
+
+**Placeholder scan:** No TBD/TODO; every code step shows full code. The only deferred specifics are the exact current FFI function names/labels in Task 3 Step 5, explicitly flagged to read from each file (they are mechanical 1-arg substitutions). ✅
+
+**Type consistency:** `currentBlock: BlockReadOutput?` named identically in Tasks 1 & 2; `zeroize(_:inout Data)` / `withZeroizingData(_:_:)` signatures identical between the test (Step 1), the impl (Step 3), and the call sites (Step 5). ✅
+
+## Verification gate (whole branch, before PR)
+
+After all three tasks:
+- iOS: `bash ios/scripts/run-ios-tests.sh` (host XCTest — runs on this machine).
+- Android: `cd android && ./gradlew :kit:connectedDebugAndroidTest -Pandroid.testInstrumentationRunnerArguments.class=org.secretary.browse.RevealResidencyInstrumentedTest` + `./gradlew :kit:testDebugUnitTest :vault-access:test` (emulator/device for the instrumented test).
+- Rust unchanged, but run `cargo test --release --workspace` + `cargo clippy --release --workspace --tests -- -D warnings` + `uv run core/tests/python/conformance.py` to prove no incidental drift (conformance must be byte-identical PASS).
+- CI is the real gate once pushed (`test.yml` rust ×2 OS + swift/kotlin conformance + smoke; `rust-lint.yml`; CodeQL).

--- a/docs/superpowers/specs/2026-06-25-ios-android-memory-hygiene-design.md
+++ b/docs/superpowers/specs/2026-06-25-ios-android-memory-hygiene-design.md
@@ -1,0 +1,139 @@
+# Design: iOS/Android memory-hygiene hardening (#251 + #229)
+
+**Date:** 2026-06-25
+**Issues:** #251 (reveal-residency accumulation, iOS + Android), #229 (iOS FFI-boundary password copy not scrubbed)
+**Scope:** `ios/` + `android/` FFI port-adapter surface only. No Rust-core / on-disk-format / spec change; `conformance.py` untouched.
+
+## Problem
+
+Two independent, pre-existing gaps in the Swift/Kotlin layer that widen the in-memory
+plaintext-residency window beyond what the feature needs. Both run against the
+zeroize/minimize-residency discipline the Rust core follows (`Sensitive<T>` / `SecretBytes`,
+CLAUDE.md "Memory hygiene: zeroize discipline").
+
+### #251 — `openBlocks` accumulates every visited block's plaintext until lock
+
+`UniffiVaultSession.readBlock` appends each decrypted `BlockReadOutput` to an `openBlocks`
+list (iOS `UniffiVaultSession.swift:56`, Android `UniffiVaultOpenPort.kt:128`) and never
+releases it until the whole session is wiped (lock / background). Consequences:
+
+- **Accumulation across navigation.** Browsing A → B → A leaves block A's *entire* decrypted
+  contents (every field, not just revealed ones) resident even after navigating away. The
+  reveal map is cleared on every `selectBlock` (VM layer), so no live reveal closure
+  references a prior block — yet its plaintext stays decrypted.
+- **Duplicate retention.** Re-selecting the same block appends another `BlockReadOutput`;
+  nothing dedups. A long browse session monotonically grows the resident plaintext set.
+
+The reveal architecture is a deliberate cross-platform mirror, so this is a **parity
+property**, not an Android-only bug. The Android concurrency hazard (read racing `wipe()`)
+was already fixed in #250 via `sessionLock` + a `wiped` guard; that fix does **not** change
+the accumulation behavior tracked here.
+
+### #229 — iOS FFI-boundary password `Data` copy is never scrubbed
+
+Master passwords / recovery phrases are passed as `[UInt8]` and copied into `Data(password)`
+at the FFI boundary; the `Data` buffer is not overwritten after the call. uniffi copies the
+`Data` into Rust (where it *is* zeroized), so the residue is the Swift-side `Data` copy.
+Five sites across three port adapters:
+
+- `UniffiVaultOpenPort.openWithPassword` / `openWithRecovery`
+- `UniffiVaultCreatePort.create`
+- `UniffiVaultSyncPort.sync` / `commitDecisions`
+
+(The create port already correctly scrubs its recovery-phrase *output* via
+`phrase.resetBytes`; #229 is strictly about the *input* password/phrase copy.)
+
+## Design
+
+### Part A — #251: bound reveal-residency to the on-screen block
+
+Replace the unbounded accumulator with a single retained block, making "≤1 block resident"
+a **type-level invariant** (accidental accumulation becomes impossible):
+
+- Field type changes `openBlocks: [BlockReadOutput]` → `currentBlock: BlockReadOutput?` on
+  both `UniffiVaultSession` (iOS Swift + Android Kotlin).
+- On each **successful** `readBlock`: decrypt the new block first; if it succeeds, wipe + drop
+  the previously-retained block, then retain the new one.
+  **Decrypt-first ordering is load-bearing:** if the new decrypt throws, the prior block stays
+  retained so the on-screen block's live reveal closures remain valid (no use-after-wipe).
+- `wipe()` becomes `currentBlock?.wipe(); currentBlock = nil; manifest.wipe(); identity.wipe()`
+  (same blocks → manifest → identity order).
+
+Platform specifics:
+
+- **iOS** (`readBlock` is synchronous): `out = try readBlock(...)` → `currentBlock?.wipe()` →
+  `currentBlock = out`.
+- **Android** (`readBlock` runs on `ioDispatcher`, `wipe()` on main): the eviction happens
+  **inside the existing `sessionLock`**, after the `wiped`-race check. Both the `sessionLock`
+  serialization and the `wiped` guard are preserved unchanged. Sequence under the lock:
+  decrypt → if `wiped` { wipe new block; return empty } → else { `currentBlock?.wipe()`;
+  `currentBlock = block` }.
+- Update the stale Android doc-comment (`UniffiVaultOpenPort.kt:104-107`) that currently cites
+  #251 as an *accepted* residency tradeoff — it is now fixed.
+
+**Safety argument.** The VM clears the reveal map on `selectBlock`, so at the moment a new
+`readBlock` evicts the prior block, no live reveal closure references it. This is exactly the
+invariant the issue identifies as making option 1 safe. Retains the exact reveal behavior;
+bounds both decrypted plaintext and native FFI handles to one block; dedups re-selection.
+
+### Part B — #229: scrub the FFI-boundary `Data` copy
+
+A small reusable helper in `SecretaryKit`, decomposed into a pure, directly-testable core:
+
+```swift
+/// Overwrite every byte of `data` in place. Pure; post-condition: all bytes zero.
+func zeroize(_ data: inout Data)
+
+/// Build a `Data` from `bytes`, run `body`, and scrub the `Data` on the way out
+/// (defer fires on both normal return and a thrown error).
+func withZeroizingData<T>(_ bytes: [UInt8], _ body: (Data) throws -> T) rethrows -> T {
+    var data = Data(bytes)
+    defer { zeroize(&data) }
+    return try body(data)
+}
+```
+
+Applied at all five sites, e.g.:
+
+```swift
+try withZeroizingData(password) { pw in
+    try SecretaryKit.openVaultWithPassword(folderPath: vaultPath, password: pw)
+}
+```
+
+### Documented residual (honest scope)
+
+The adapter **cannot** scrub the caller's (VM-owned) `[UInt8]`: Swift arrays are
+copy-on-write, so mutating the adapter's binding triggers CoW into a fresh throwaway buffer
+and leaves the caller's storage untouched. The achievable scrub is the adapter-owned `Data`
+copy — the one concrete heap copy the boundary owns. The VM-owned input array's lifetime is
+already minimized by the existing "password passed per call, never stored" discipline; its
+residue is a separate concern and is documented as a known limitation in the helper's doc
+comment, mirroring how the Rust side documents `Sensitive<T>`.
+
+## Testing (TDD)
+
+- **#251 teeth test** (one per platform — iOS `SecretaryKitTests`, Android instrumented/host
+  with a real vault fixture): `readBlock(A)` → capture a field reveal closure → `readBlock(B)`
+  → invoking A's now-stale reveal closure returns `nil` / throws, proving A's `BlockReadOutput`
+  was wiped on navigation. Fails on the current accumulate-forever code; passes after the fix.
+  Also assert re-selecting the same block does not grow residency (single-optional invariant).
+- **#229 unit tests** (`SecretaryKitTests`): `zeroize(&data)` overwrites all bytes
+  (all-zero post-condition); `withZeroizingData` returns the body result on success and still
+  scrubs when the body throws.
+
+## Out of scope
+
+- The unprojected contact primitives (`enumerate/delete/revoke`, #206 follow-up).
+- VM-side input-array scrubbing (separate VM concern; documented residual above).
+- Android `#229` analogue: Kotlin forwards the password `ByteArray` directly to the uniffi
+  function (`UniffiVaultOpenPort.kt:47`) with no second buffer copy, so there is no
+  adapter-owned copy to scrub. Verified during implementation; noted, no change.
+
+## Risks
+
+- None to honest-vault behavior. #251's eviction only drops blocks the user has navigated
+  away from (reveal map already cleared); the on-screen block is always retained. #229 only
+  overwrites a copy after the FFI call has consumed it.
+- No new error variant, no format/semantics change → `conformance.py`, conformance KATs, and
+  the Swift/Kotlin conformance harnesses are unaffected.

--- a/ios/SecretaryKit/Sources/SecretaryKit/VaultAccess/UniffiVaultCreatePort.swift
+++ b/ios/SecretaryKit/Sources/SecretaryKit/VaultAccess/UniffiVaultCreatePort.swift
@@ -33,11 +33,13 @@ public struct UniffiVaultCreatePort: VaultCreatePort {
 
             let mnem: MnemonicOutput
             do {
-                mnem = try SecretaryKit.createVaultInFolder(
-                    folderPath: Data(folder.path.utf8),
-                    password: Data(password),
-                    displayName: displayName,
-                    createdAtMs: UInt64(Date().timeIntervalSince1970 * 1000))
+                mnem = try withZeroizingData(password) { pw in
+                    try SecretaryKit.createVaultInFolder(
+                        folderPath: Data(folder.path.utf8),
+                        password: pw,
+                        displayName: displayName,
+                        createdAtMs: UInt64(Date().timeIntervalSince1970 * 1000))
+                }
             } catch let e as VaultError {
                 throw mapProvisioningError(e)
             }

--- a/ios/SecretaryKit/Sources/SecretaryKit/VaultAccess/UniffiVaultOpenPort.swift
+++ b/ios/SecretaryKit/Sources/SecretaryKit/VaultAccess/UniffiVaultOpenPort.swift
@@ -10,8 +10,10 @@ public struct UniffiVaultOpenPort: VaultOpenPort {
     public func openWithPassword(vaultPath: Data, password: [UInt8]) async throws -> VaultSession {
         try await runOffMainActor {
             do {
-                let out = try SecretaryKit.openVaultWithPassword(
-                    folderPath: vaultPath, password: Data(password))
+                let out = try withZeroizingData(password) { pw in
+                    try SecretaryKit.openVaultWithPassword(
+                        folderPath: vaultPath, password: pw)
+                }
                 return UniffiVaultSession(output: out)
             } catch let e as VaultError {
                 throw mapVaultAccessError(e)
@@ -22,8 +24,10 @@ public struct UniffiVaultOpenPort: VaultOpenPort {
     public func openWithRecovery(vaultPath: Data, phrase: [UInt8]) async throws -> VaultSession {
         try await runOffMainActor {
             do {
-                let out = try SecretaryKit.openVaultWithRecovery(
-                    folderPath: vaultPath, mnemonic: Data(phrase))
+                let out = try withZeroizingData(phrase) { ph in
+                    try SecretaryKit.openVaultWithRecovery(
+                        folderPath: vaultPath, mnemonic: ph)
+                }
                 return UniffiVaultSession(output: out)
             } catch let e as VaultError {
                 throw mapVaultAccessError(e)

--- a/ios/SecretaryKit/Sources/SecretaryKit/VaultAccess/UniffiVaultSession.swift
+++ b/ios/SecretaryKit/Sources/SecretaryKit/VaultAccess/UniffiVaultSession.swift
@@ -3,15 +3,20 @@ import Security
 import SecretaryVaultAccess
 
 /// Real `VaultSession` over the uniffi `OpenVaultOutput` (identity + manifest)
-/// plus `readBlock`. Retains every `BlockReadOutput` it decodes so the
-/// per-field `reveal` closures (which capture an FFI `FieldHandle`) stay valid
-/// until `wipe()`. `wipe()` releases blocks, then manifest, then identity.
+/// plus `readBlock`. Retains only the most-recently-decoded `BlockReadOutput`
+/// (`currentBlock`) so the per-field `reveal` closures (which capture an FFI
+/// `FieldHandle`) stay valid while the block is on screen. Prior blocks are
+/// wiped on each `readBlock` call (#251). `wipe()` releases the current block,
+/// then manifest, then identity.
 public final class UniffiVaultSession: VaultSession {
     private let identity: UnlockedIdentity
     private let manifest: OpenVaultManifest
     private let deviceUuids: DeviceUuidProviding?
-    /// Retained decrypted-block handles, so reveal closures remain valid.
-    private var openBlocks: [BlockReadOutput] = []
+    /// The single retained decrypted block — the on-screen one. Bounding to one
+    /// block (not a growing list) makes "≤1 block resident" a type-level invariant
+    /// and dedups re-selection. The VM clears the reveal map on `selectBlock`, so no
+    /// live reveal closure references a prior block when we evict it here (#251).
+    private var currentBlock: BlockReadOutput?
     /// Cached per this session so every write stamps the same device UUID.
     private var cachedDeviceUuid: [UInt8]?
 
@@ -53,7 +58,10 @@ public final class UniffiVaultSession: VaultSession {
         } catch let e as VaultError {
             throw mapVaultAccessError(e)
         }
-        openBlocks.append(out)  // keep alive for reveal closures + wipe
+        // Decrypt-first ordering: `out` is already decoded above, so a thrown read
+        // left the prior block retained. Now evict it before retaining the new one.
+        currentBlock?.wipe()
+        currentBlock = out  // keep alive for reveal closures + wipe
         let count = out.recordCount()
         var records: [RecordView] = []
         records.reserveCapacity(Int(count))
@@ -96,7 +104,7 @@ public final class UniffiVaultSession: VaultSession {
     private func makeFieldView(_ handle: FieldHandle) -> FieldView {
         let kind: FieldView.Kind = handle.isText() ? .text : .bytes
         // `handle` is captured: calling reveal() invokes expose_* ON DEMAND.
-        // The owning BlockReadOutput is retained in `openBlocks` until wipe().
+        // The owning BlockReadOutput is retained in `currentBlock` until wipe() or the next readBlock().
         return FieldView(name: handle.name(), kind: kind) {
             switch kind {
             case .text:
@@ -114,8 +122,8 @@ public final class UniffiVaultSession: VaultSession {
     }
 
     public func wipe() {
-        for b in openBlocks { b.wipe() }
-        openBlocks.removeAll()
+        currentBlock?.wipe()
+        currentBlock = nil
         manifest.wipe()
         identity.wipe()
     }

--- a/ios/SecretaryKit/Sources/SecretaryKit/VaultAccess/UniffiVaultSession.swift
+++ b/ios/SecretaryKit/Sources/SecretaryKit/VaultAccess/UniffiVaultSession.swift
@@ -104,7 +104,8 @@ public final class UniffiVaultSession: VaultSession {
     private func makeFieldView(_ handle: FieldHandle) -> FieldView {
         let kind: FieldView.Kind = handle.isText() ? .text : .bytes
         // `handle` is captured: calling reveal() invokes expose_* ON DEMAND.
-        // The owning BlockReadOutput is retained in `currentBlock` until wipe() or the next readBlock().
+        // The owning BlockReadOutput is retained in `currentBlock` until wipe()
+        // or the next readBlock().
         return FieldView(name: handle.name(), kind: kind) {
             switch kind {
             case .text:

--- a/ios/SecretaryKit/Sources/SecretaryKit/VaultAccess/UniffiVaultSyncPort.swift
+++ b/ios/SecretaryKit/Sources/SecretaryKit/VaultAccess/UniffiVaultSyncPort.swift
@@ -24,9 +24,11 @@ public struct UniffiVaultSyncPort: VaultSyncPort {
                      password: [UInt8], nowMs: UInt64) async throws -> SyncOutcome {
         try await runOffMainActor {
             do {
-                let dto = try SecretaryKit.syncVault(
-                    stateDir: stateDir, vaultFolder: vaultFolder,
-                    password: Data(password), nowMs: nowMs)
+                let dto = try withZeroizingData(password) { pw in
+                    try SecretaryKit.syncVault(
+                        stateDir: stateDir, vaultFolder: vaultFolder,
+                        password: pw, nowMs: nowMs)
+                }
                 return Self.mapOutcome(dto)
             } catch let e as VaultError {
                 throw mapVaultSyncError(e)
@@ -42,9 +44,11 @@ public struct UniffiVaultSyncPort: VaultSyncPort {
                 let dtoDecisions = decisions.map {
                     VetoDecisionDto(recordUuidHex: $0.recordUuidHex, keepLocal: $0.keepLocal)
                 }
-                let dto = try SecretaryKit.syncCommitDecisions(
-                    stateDir: stateDir, vaultFolder: vaultFolder, password: Data(password),
-                    decisions: dtoDecisions, manifestHash: Data(manifestHash), nowMs: nowMs)
+                let dto = try withZeroizingData(password) { pw in
+                    try SecretaryKit.syncCommitDecisions(
+                        stateDir: stateDir, vaultFolder: vaultFolder, password: pw,
+                        decisions: dtoDecisions, manifestHash: Data(manifestHash), nowMs: nowMs)
+                }
                 return Self.mapOutcome(dto)
             } catch let e as VaultError {
                 throw mapVaultSyncError(e)

--- a/ios/SecretaryKit/Sources/SecretaryKit/VaultAccess/ZeroizingData.swift
+++ b/ios/SecretaryKit/Sources/SecretaryKit/VaultAccess/ZeroizingData.swift
@@ -1,0 +1,24 @@
+import Foundation
+
+/// Overwrite every byte of `data` in place. Pure; post-condition: all bytes are
+/// zero. Mirrors the Rust core's `Sensitive<T>`/`SecretBytes` discipline at the
+/// one heap copy the Swift FFI boundary owns. No-op on empty data (#229).
+func zeroize(_ data: inout Data) {
+    guard !data.isEmpty else { return }
+    data.resetBytes(in: 0..<data.count)
+}
+
+/// Build a `Data` from `bytes`, hand it to `body`, and scrub that `Data` on the
+/// way out — the `defer` fires on both a normal return and a thrown error, so the
+/// FFI-boundary copy never lingers in the heap.
+///
+/// Scope/limitation: this scrubs the adapter-owned `Data` copy only. It does NOT
+/// scrub the caller's `bytes` array — Swift arrays are copy-on-write, so mutating
+/// our binding would allocate a throwaway buffer and leave the caller's storage
+/// intact. The caller's lifetime is minimized separately by the "password passed
+/// per call, never stored" port discipline (#229).
+func withZeroizingData<T>(_ bytes: [UInt8], _ body: (Data) throws -> T) rethrows -> T {
+    var data = Data(bytes)
+    defer { zeroize(&data) }
+    return try body(data)
+}

--- a/ios/SecretaryKit/Tests/SecretaryKitTests/RevealResidencyIntegrationTests.swift
+++ b/ios/SecretaryKit/Tests/SecretaryKitTests/RevealResidencyIntegrationTests.swift
@@ -1,0 +1,53 @@
+import XCTest
+import SecretaryVaultAccess
+@testable import SecretaryKit
+
+/// #251: navigating to another block must evict the prior block's decrypted
+/// plaintext (a stale reveal closure must stop yielding plaintext), and
+/// re-selecting the same block must not accumulate. Reads the single golden
+/// block twice — proves eviction + dedup together.
+final class RevealResidencyIntegrationTests: XCTestCase {
+    private let goldenPassword = "correct horse battery staple"
+    private var vaultCopy: URL!
+
+    override func setUpWithError() throws {
+        let bundled = try XCTUnwrap(
+            Bundle.module.url(forResource: "golden_vault_001", withExtension: nil),
+            "golden_vault_001 not bundled — run ios/scripts/build-xcframework.sh")
+        let tmp = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("res-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: tmp, withIntermediateDirectories: true)
+        vaultCopy = tmp.appendingPathComponent("golden_vault_001", isDirectory: true)
+        try FileManager.default.copyItem(at: bundled, to: vaultCopy)
+    }
+
+    override func tearDownWithError() throws {
+        try? FileManager.default.removeItem(at: vaultCopy.deletingLastPathComponent())
+    }
+
+    func testNavigatingAwayEvictsPriorBlockPlaintext() async throws {
+        let port = UniffiVaultOpenPort()
+        let path = Data(vaultCopy.path.utf8)
+        let session = try await port.openWithPassword(
+            vaultPath: path, password: [UInt8](goldenPassword.utf8))
+        defer { session.wipe() }
+
+        let blocks = session.blockSummaries()
+        let blockUuid = try XCTUnwrap(blocks.first?.uuid, "golden vault has one block")
+
+        // First read: capture a reveal closure from this block's first revealable field.
+        let firstRecords = try session.readBlock(blockUuid: blockUuid, includeDeleted: false)
+        let staleField = try XCTUnwrap(
+            firstRecords.flatMap(\.fields).first, "block has at least one field")
+        _ = try staleField.reveal()  // sanity: reveals before we navigate away
+
+        // Navigate (re-read the same block — the only one). The fix wipes the prior
+        // BlockReadOutput, which cascades to the captured FieldHandle.
+        _ = try session.readBlock(blockUuid: blockUuid, includeDeleted: false)
+
+        // Pre-fix: the prior block stays in `openBlocks`, so this still yields plaintext.
+        // Post-fix: the prior block was wiped, so reveal() throws.
+        XCTAssertThrowsError(try staleField.reveal(),
+            "stale reveal closure must fail after navigating away (block evicted)")
+    }
+}

--- a/ios/SecretaryKit/Tests/SecretaryKitTests/RevealResidencyIntegrationTests.swift
+++ b/ios/SecretaryKit/Tests/SecretaryKitTests/RevealResidencyIntegrationTests.swift
@@ -47,6 +47,8 @@ final class RevealResidencyIntegrationTests: XCTestCase {
 
         // Pre-fix: the prior block stays in `openBlocks`, so this still yields plaintext.
         // Post-fix: the prior block was wiped, so reveal() throws.
+        // (No-growth on re-selection is enforced by the `currentBlock: BlockReadOutput?`
+        // type itself — a runtime count assertion would be redundant.)
         XCTAssertThrowsError(try staleField.reveal(),
             "stale reveal closure must fail after navigating away (block evicted)")
     }

--- a/ios/SecretaryKit/Tests/SecretaryKitTests/ZeroizingDataTests.swift
+++ b/ios/SecretaryKit/Tests/SecretaryKitTests/ZeroizingDataTests.swift
@@ -1,0 +1,36 @@
+import XCTest
+import Foundation
+@testable import SecretaryKit
+
+/// #229: the FFI-boundary password copy must be scrubbed after use.
+final class ZeroizingDataTests: XCTestCase {
+    func testZeroizeOverwritesAllBytes() {
+        var d = Data([1, 2, 3, 4, 5])
+        zeroize(&d)
+        XCTAssertEqual(d, Data(repeating: 0, count: 5))
+    }
+
+    func testZeroizeEmptyDataIsNoOp() {
+        var d = Data()
+        zeroize(&d)  // must not crash on a zero-length range
+        XCTAssertEqual(d.count, 0)
+    }
+
+    func testWithZeroizingDataExposesBytesToBody() {
+        let bytes: [UInt8] = [9, 8, 7]
+        let seen = withZeroizingData(bytes) { d in [UInt8](d) }
+        XCTAssertEqual(seen, [9, 8, 7])
+    }
+
+    func testWithZeroizingDataReturnsBodyResult() {
+        let n = withZeroizingData([1, 2, 3]) { d in d.count }
+        XCTAssertEqual(n, 3)
+    }
+
+    func testWithZeroizingDataPropagatesThrow() {
+        struct Boom: Error {}
+        // The defer-scrub still runs on the throwing path; we assert the error propagates
+        // (the scrub itself is proven by testZeroizeOverwritesAllBytes — same code path).
+        XCTAssertThrowsError(try withZeroizingData([1, 2, 3]) { _ in throw Boom() })
+    }
+}


### PR DESCRIPTION
Two pre-existing memory-hygiene gaps in the **iOS/Android FFI layer**. No Rust-core / on-disk-format / spec change; `conformance.py` + the Swift/Kotlin conformance harnesses untouched. Closes #251, closes #229.

## #251 — reveal-residency accumulation (iOS + Android parity)
`UniffiVaultSession.readBlock` appended every decrypted `BlockReadOutput` to an `openBlocks` list and never released it until the session was wiped, so browsing A→B→A left every visited block's decrypted plaintext resident and re-selecting accumulated duplicates.

**Fix:** replace the unbounded list with a single `currentBlock: BlockReadOutput?`, wiping the prior block on each **successful** `readBlock` (decrypt-first: a thrown decrypt leaves the on-screen block retained). The optional makes "≤1 block resident" a **type-level invariant** and dedups re-selection. Android keeps the #250 `sessionLock` + `wiped`-race guard — eviction sits inside the lock, after the `wiped` check.

**Safe because** the VM clears the reveal map before every read (so no live closure points at the evicted block), and `BlockReadOutput.wipe()` cascades `Record.wipe()` → `FieldHandle.wipe()` via a shared `Arc`, so an already-captured `FieldHandle` returns `None`/throws after eviction — exactly what the teeth tests assert.

## #229 — iOS FFI-boundary password copy never scrubbed
Port adapters copy the password/phrase into `Data(password)` at the FFI boundary and never overwrite that copy. uniffi copies into Rust (where it *is* zeroized); the residue is the Swift `Data`.

**Fix:** a pure `zeroize(_ data: inout Data)` + a `withZeroizingData` wrapper that scrubs the boundary `Data` in a `defer` (fires on return **and** throw), applied at all 5 sites (open password/recovery, create, sync, commitDecisions). Scrubs only the **adapter-owned** `Data` — not the caller's `[UInt8]` (Swift copy-on-write makes that ineffective; documented).

## Tests (TDD red→green)
- **#251 iOS** — `RevealResidencyIntegrationTests` (host XCTest): stale reveal closure throws after eviction.
- **#251 Android** — `RevealResidencyInstrumentedTest` (instrumented): same teeth assertion.
- **#229** — `ZeroizingDataTests` (5): `zeroize` post-condition + empty no-op; `withZeroizingData` exposes/returns/propagates-throw.

## Local verification
- iOS host suite: 29 tests, 0 failures (RevealResidency ✅ + ZeroizingData ✅).
- Android instrumented teeth test + host units: green (on `emulator-5554`).
- `cargo test --release --workspace` exit 0; `cargo fmt --all -- --check` clean; `conformance.py` PASS (Rust diff is empty — zero core files touched).

Subagent-driven development (fresh implementer + spec/quality reviewer per task; final whole-branch review on opus: **Ready to merge, 0 Critical / 0 Important**).

🤖 Generated with [Claude Code](https://claude.com/claude-code)