### PR TITLE
fix(test): stop share_block proptest flaking on fixture-seed collision

### DIFF
--- a/ffi/secretary-ffi-bridge/tests/share_block_helpers/mod.rs
+++ b/ffi/secretary-ffi-bridge/tests/share_block_helpers/mod.rs
@@ -66,10 +66,59 @@ pub const NEW_RECORD_UUID: [u8; 16] = [0xCD; 16];
 pub const DEVICE_UUID: [u8; 16] = [0x07; 16];
 pub const NOW_MS_BASE: u64 = 1_715_000_000_000;
 
-/// Mint an external identity from a deterministic seed and return its
+/// The all-equal-byte ChaCha seeds used to mint `golden_vault_001`'s bundled
+/// contacts: owner `[0xA0; 32]`, Alice `[0xA1; 32]`, Bob `[0xA2; 32]` (see the
+/// `_doc` fields in `core/tests/data/golden_vault_001_inputs.json`). Those three
+/// identities already live in the fixture's `contacts/` dir, so re-minting one
+/// and sharing a block to it trips `share_block`'s TOFU non-overwrite guard
+/// (`ContactAlreadyExists`). Share tests that mint *recipient* identities must
+/// keep them disjoint from these — trivially guaranteed by a seed whose bytes
+/// are NOT all equal (see [`mint_external_card_from_seed32`]).
+#[allow(dead_code)]
+pub const FIXTURE_CONTACT_MINT_SEEDS: [u8; 3] = [0xA0, 0xA1, 0xA2];
+
+/// Mint an external identity from a full 32-byte ChaCha seed and return its
 /// canonical-CBOR-encoded self-signed `ContactCard` alongside the
-/// `IdentityBundle` (kept in case future tests need to decrypt as that
-/// identity).
+/// `IdentityBundle`.
+///
+/// The array-seed form lets callers build identity spaces that are *disjoint by
+/// construction* from the golden-vault fixture contacts: those are minted from
+/// all-equal-byte seeds (`[k; 32]`, see [`FIXTURE_CONTACT_MINT_SEEDS`]), so any
+/// seed whose bytes are not all equal cannot reproduce a fixture contact's UUID,
+/// whatever `k` it might otherwise alias.
+#[allow(dead_code)]
+pub fn mint_external_card_from_seed32(
+    seed: [u8; 32],
+    display_name: &str,
+) -> (IdentityBundle, Vec<u8>) {
+    let mut rng = ChaCha20Rng::from_seed(seed);
+    let bundle = generate_bundle(display_name, 1_714_060_800_000, &mut rng);
+    let pq_sk = MlDsa65Secret::from_bytes(bundle.ml_dsa_65_sk.expose()).unwrap();
+    let mut card = ContactCard {
+        card_version: CARD_VERSION_V1,
+        contact_uuid: bundle.user_uuid,
+        display_name: bundle.display_name.clone(),
+        x25519_pk: bundle.x25519_pk,
+        ml_kem_768_pk: bundle.ml_kem_768_pk.clone(),
+        ed25519_pk: bundle.ed25519_pk,
+        ml_dsa_65_pk: bundle.ml_dsa_65_pk.clone(),
+        created_at_ms: bundle.created_at_ms,
+        self_sig_ed: [0u8; ED25519_SIG_LEN],
+        self_sig_pq: vec![0u8; ML_DSA_65_SIG_LEN],
+    };
+    card.sign(&bundle.ed25519_sk, &pq_sk).unwrap();
+    let bytes = card.to_canonical_cbor().unwrap();
+    (bundle, bytes)
+}
+
+/// Mint an external identity from a single-byte seed (expanded to `[seed; 32]`)
+/// and return its canonical-CBOR-encoded self-signed `ContactCard` alongside the
+/// `IdentityBundle` (kept in case future tests need to decrypt as that identity).
+///
+/// NOTE: the all-equal-byte expansion means `seed` values in
+/// [`FIXTURE_CONTACT_MINT_SEEDS`] reproduce the fixture's bundled contacts — mint
+/// fresh recipients via [`mint_external_card_from_seed32`] to stay disjoint.
+#[allow(dead_code)]
 pub fn mint_external_card(seed: u8, display_name: &str) -> (IdentityBundle, Vec<u8>) {
     let mut rng = ChaCha20Rng::from_seed([seed; 32]);
     let bundle = generate_bundle(display_name, 1_714_060_800_000, &mut rng);

--- a/ffi/secretary-ffi-bridge/tests/share_block_proptest.rs
+++ b/ffi/secretary-ffi-bridge/tests/share_block_proptest.rs
@@ -12,8 +12,8 @@ use secretary_core::unlock::bundle::IdentityBundle;
 use secretary_ffi_bridge::share_block;
 
 use share_block_helpers::{
-    fresh_writable_vault, mint_external_card, save_one_record_block, DEVICE_UUID, NEW_BLOCK_UUID,
-    NEW_RECORD_UUID, NOW_MS_BASE,
+    fresh_writable_vault, mint_external_card_from_seed32, save_one_record_block, DEVICE_UUID,
+    NEW_BLOCK_UUID, NEW_RECORD_UUID, NOW_MS_BASE,
 };
 
 /// Cases held low because each case opens a fresh writable vault (Argon2id
@@ -47,10 +47,23 @@ proptest::proptest! {
         );
 
         // Mint N recipient identities with deterministic-but-distinct seeds.
-        // Seed-mix uses the proptest-supplied `seed` plus the recipient
-        // index so every case generates fresh UUIDs.
+        // Each recipient's 32-byte ChaCha seed carries the proptest-supplied
+        // `seed` in bytes 0..4 and the recipient index in byte 4 (over a
+        // zero-filled tail), so recipients within a case are distinct (byte 4)
+        // and vary across cases (bytes 0..4). The zero-filled tail also keeps
+        // every recipient seed NON-all-equal-byte, which guarantees it cannot
+        // alias any FIXTURE_CONTACT_MINT_SEEDS `[k; 32]` identity already in the
+        // vault's contacts/ — without that, a drawn `seed` of 0xA0/0xA1/0xA2
+        // would re-mint the owner/Alice/Bob and trip share_block's TOFU guard
+        // (ContactAlreadyExists) — the n=1 seed=0xA0 case pinned in this bin's
+        // .proptest-regressions file.
         let recipients: Vec<(IdentityBundle, Vec<u8>)> = (0..n)
-            .map(|i| mint_external_card(seed[0].wrapping_add(i as u8), &format!("R{i}")))
+            .map(|i| {
+                let mut rng_seed = [0u8; 32];
+                rng_seed[..4].copy_from_slice(&seed);
+                rng_seed[4] = i as u8;
+                mint_external_card_from_seed32(rng_seed, &format!("R{i}"))
+            })
             .collect();
 
         // existing_recipient_cards grows by one element per iteration.
@@ -95,4 +108,56 @@ proptest::proptest! {
             );
         }
     }
+}
+
+/// Deterministic regression for the fixture-seed collision the proptest above
+/// used to flake on (`.proptest-regressions` is gitignored repo-wide, so the
+/// guard lives here as a committed test). A proptest `seed` whose byte 0 equals
+/// a `FIXTURE_CONTACT_MINT_SEEDS` value — e.g. the owner's `0xA0` — must NOT
+/// re-mint that fixture contact and trip `share_block`'s TOFU non-overwrite
+/// guard (`ContactAlreadyExists`). This pins the disjoint-by-construction
+/// recipient seeding: a future "simplification" back to an all-equal-byte seed
+/// (`[k; 32]`) fails loudly here instead of intermittently in CI.
+#[test]
+fn share_block_recipient_seed_aliasing_a_fixture_mint_byte_does_not_collide() {
+    let (_tmp, identity, manifest) = fresh_writable_vault();
+    save_one_record_block(
+        &identity,
+        &manifest,
+        NEW_BLOCK_UUID,
+        NEW_RECORD_UUID,
+        "k",
+        "v",
+        NOW_MS_BASE,
+    );
+
+    // Worst case from the regression: drawn seed byte 0 == 0xA0 (the golden
+    // owner's mint seed byte), built exactly as the proptest builds it.
+    let mut rng_seed = [0u8; 32];
+    rng_seed[0] = 0xA0;
+    let (recipient, card_bytes) = mint_external_card_from_seed32(rng_seed, "R0");
+
+    let existing: Vec<Vec<u8>> = vec![manifest
+        .owner_card_bytes()
+        .expect("encode succeeds on a verified card")
+        .expect("owner card present")];
+    share_block(
+        &identity,
+        &manifest,
+        NEW_BLOCK_UUID,
+        &existing,
+        &card_bytes,
+        DEVICE_UUID,
+        NOW_MS_BASE + 1_000,
+    )
+    .expect("sharing to a non-aliasing recipient must succeed (no TOFU collision)");
+
+    let post = manifest
+        .find_block(&NEW_BLOCK_UUID)
+        .expect("block findable after share");
+    assert!(
+        post.recipient_uuids.contains(&recipient.user_uuid),
+        "recipient {} missing from post-share manifest entry",
+        hex::encode(recipient.user_uuid),
+    );
 }


### PR DESCRIPTION
## What

`share_block_to_n_recipients_grows_recipient_list_atomically` (the #206 share-orchestration proptest) flakes intermittently in CI with:

```
share #0 failed: ContactAlreadyExists { uuid_hex: "bf08a3300cd994b877e1a15baa28df35" }.
minimal failing input: n = 1, seed = [160, 0, 0, 0]
```

## Root cause — a test bug, not a product bug

The proptest minted recipient identities with `ChaCha20Rng::from_seed([seed_byte; 32])`, a **256-identity space keyed on a single byte**. `golden_vault_001`'s three bundled contacts are minted from all-equal-byte seeds (per `golden_vault_001_inputs.json`):

| Contact | Seed | UUID |
|---|---|---|
| Owner | `[0xA0; 32]` | `bf08a330…` |
| Alice | `[0xA1; 32]` | `7921b6ed…` |
| Bob | `[0xA2; 32]` | `78d7ab1d…` |

…and all three already exist in the fixture's `contacts/` dir. `0xA0 = 160` — the exact failing `seed[0]`. When proptest drew `seed_byte ∈ {0xA0, 0xA1, 0xA2}`, the "fresh recipient" was byte-identical to an existing contact, so `share_block`'s TOFU non-overwrite guard **correctly** returned `ContactAlreadyExists`. ~1.2% per recipient draw → intermittent failures.

## Fix

Make the recipient identity space **disjoint from the fixture contacts by construction**:

- Add `mint_external_card_from_seed32` (full 32-byte seed) alongside the existing single-byte `mint_external_card`.
- The proptest builds each recipient seed as `[seed[0..4], i, 0, …, 0]`. A seed whose bytes are **not all equal** can never reproduce a fixture contact's `[k; 32]` identity — whatever `k` it might alias — so no draw can collide.
- A documented `FIXTURE_CONTACT_MINT_SEEDS` constant records the hazard for future authors.
- Adds a deterministic regression test pinning the worst case (drawn byte 0 == `0xA0`) so a future revert to all-equal-byte seeding fails loudly instead of flaking. (`.proptest-regressions` is gitignored repo-wide, so the guard is a committed test.)

No product / crypto / on-disk-format change; `share_block` behavior is unchanged and correct.

## Verification

- Reproduced RED deterministically via the CI-reported regression seed (`n=1, seed=[160,0,0,0]`).
- GREEN after fix at `PROPTEST_CASES=128` (full stress sweep).
- Both `share_block` test bins pass (11 + 2).
- `cargo clippy --release -p secretary-ffi-bridge --tests -- -D warnings` clean.
- `cargo fmt --all -- --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)