### PR TITLE
fix(fuzz): bind monitor dashboard to loopback only (#210)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,8 +70,9 @@ uv run core/tests/python/conformance.py
 # flag allowlist entries whose underlying citation now resolves)
 uv run core/tests/python/spec_test_name_freshness.py
 
-# Run the fuzz monitor's pytest suite
-cd core/fuzz && uv run --with pytest pytest test_monitor.py -v
+# Run the fuzz monitor's pytest suite (test_monitor imports monitor.py, which
+# imports nicegui at module load, so the dashboard dep must be on the path too)
+cd core/fuzz && uv run --with pytest --with "nicegui>=2" pytest test_monitor.py -v
 
 # Launch the NiceGUI fuzz dashboard at http://localhost:8080
 uv run core/fuzz/monitor.py

--- a/NEXT_SESSION.md
+++ b/NEXT_SESSION.md
@@ -1,1 +1,1 @@
-docs/handoffs/2026-06-25-ios-android-memory-hygiene-shipped.md
+docs/handoffs/2026-06-25-fuzz-monitor-loopback-bind-shipped.md

--- a/core/fuzz/monitor.py
+++ b/core/fuzz/monitor.py
@@ -950,6 +950,34 @@ class MonitorApp:
                 ui.button("Stop", on_click=on_stop).props("color=negative")
 
 
+# Loopback-only bind. The dashboard's Start/Stop buttons spawn and kill
+# `cargo fuzz` subprocess groups with no authentication, so it must never be
+# reachable beyond the local host. NiceGUI's non-native default is 0.0.0.0
+# (all interfaces), which would expose unauthenticated process control plus
+# local-path/crash-filename disclosure to anyone on the LAN (issue #210).
+# Binding 127.0.0.1 makes the no-auth posture acceptable for this dev-only
+# tool and matches the "http://localhost:8080" the docs already advertise.
+_BIND_HOST = "127.0.0.1"
+_DASHBOARD_PORT = 8080
+
+
+def run_kwargs() -> dict:
+    """Return the keyword arguments for `ui.run`, isolated as a pure value.
+
+    Pulled out of `main` so the security-critical bind host (#210) is unit-
+    assertable without launching the server. `show=False` keeps a headless
+    host from popping a browser; `reload=False` keeps a file-watcher
+    subprocess from spawning.
+    """
+    return {
+        "host": _BIND_HOST,
+        "port": _DASHBOARD_PORT,
+        "show": False,
+        "reload": False,
+        "title": "Fuzz monitor",
+    }
+
+
 def main() -> None:
     """Entry point — launch the NiceGUI app."""
     cargo_toml_text = _CARGO_TOML.read_text()
@@ -966,7 +994,7 @@ def main() -> None:
     def index() -> None:
         app.render()
 
-    ui.run(port=8080, show=False, reload=False, title="Fuzz monitor")
+    ui.run(**run_kwargs())
 
 
 if __name__ == "__main__" or __name__ == "__mp_main__":

--- a/core/fuzz/monitor.py
+++ b/core/fuzz/monitor.py
@@ -994,6 +994,9 @@ def main() -> None:
     def index() -> None:
         app.render()
 
+    # The loopback bind (#210) lives entirely in run_kwargs(); TestRunKwargs
+    # guards it. Keep this `**run_kwargs()` spread — inlining literal args here
+    # would reintroduce the 0.0.0.0 exposure with the tests still green.
     ui.run(**run_kwargs())
 
 

--- a/core/fuzz/test_monitor.py
+++ b/core/fuzz/test_monitor.py
@@ -32,6 +32,7 @@ from monitor import (
     parse_runs_cap,
     parse_targets,
     render_log_tail_html,
+    run_kwargs,
     status_badge_class,
     terminate_process_group,
 )
@@ -1270,3 +1271,28 @@ class TestTerminateProcessGroup:
             return proc.returncode
 
         assert asyncio.run(run()) == 0
+
+
+class TestRunKwargs:
+    """The dashboard spawns/kills `cargo fuzz` subprocesses from unauthenticated
+    button handlers, so it MUST bind loopback only (issue #210). `run_kwargs`
+    isolates the `ui.run(...)` arguments as a pure value so the bind host is
+    assertable without launching the server."""
+
+    def test_binds_loopback_not_all_interfaces(self):
+        # The whole point of #210: never 0.0.0.0 (NiceGUI's non-native default,
+        # which exposes the process-control panel to the whole LAN).
+        kwargs = run_kwargs()
+        assert kwargs["host"] == "127.0.0.1"
+        assert kwargs["host"] != "0.0.0.0"
+
+    def test_port_matches_documented_dashboard_port(self):
+        # CLAUDE.md / README both point users at http://localhost:8080.
+        assert run_kwargs()["port"] == 8080
+
+    def test_no_dev_server_reload_or_browser_autolaunch(self):
+        # reload spins up a watcher subprocess; show would pop a browser on a
+        # headless CI host. Both stay off (regression guard on the call shape).
+        kwargs = run_kwargs()
+        assert kwargs["reload"] is False
+        assert kwargs["show"] is False

--- a/docs/handoffs/2026-06-25-fuzz-monitor-loopback-bind-shipped.md
+++ b/docs/handoffs/2026-06-25-fuzz-monitor-loopback-bind-shipped.md
@@ -1,0 +1,77 @@
+# NEXT_SESSION.md — fuzz monitor loopback bind (#210) ✅ SHIPPED (PR opening)
+
+**Session date:** 2026-06-25. Started from a clean baton — PR #298 (#251 + #229 iOS/Android memory-hygiene) had merged to `main` (`cc7b21c9`), and PR #301 (`602b3af0`) was the new tip. Removed the two merged worktrees/branches (`ios-android-memory-hygiene`, `fix-share-proptest-seed-collision`). User picked **#210** (fuzz dashboard auth, the only `security`-labelled quick win) over #295 / #290 (#290 still blocked by the active `d4-browser-autofill` worktree). Executed via **TDD** (red→green) in the project-local worktree.
+
+**Status:** ✅ **SHIPPED — branch `fix/fuzz-monitor-loopback-bind`, PR opening.** Single focused commit; 142/142 monitor tests green; runtime bind verified.
+
+## (1) What we shipped this session
+
+One pre-existing security gap in the **dev-only fuzz dashboard** — no Rust-core / on-disk-format / spec change; `conformance.py` + the Swift/Kotlin conformance harnesses untouched; zero Rust files touched.
+
+**#210 — NiceGUI fuzz dashboard bound `0.0.0.0` with no auth.** `core/fuzz/monitor.py` called `ui.run(port=8080, show=False, reload=False, title=...)` with **no `host=`**, so in non-native mode NiceGUI defaults to `0.0.0.0` (all interfaces). The Start/Stop button handlers `asyncio.create_subprocess_exec("cargo", "fuzz", "run", ...)` and `os.killpg(...)` **with no authentication**, so anyone on the same LAN got an unauthenticated start/kill panel for full-CPU `cargo build` + libFuzzer campaigns, plus disclosure of local paths / crash filenames in the live log tails — while CLAUDE.md and `core/fuzz/README.md` both describe it as a `localhost:8080` dashboard. Blast radius was already bounded (fixed argv, no command injection, stderr `html.escape`d), hence the issue's Low–Medium severity.
+
+**Fix.** Bind `127.0.0.1` explicitly. Rather than burying a literal in `ui.run`, the bind host + port are now named constants (`_BIND_HOST = "127.0.0.1"`, `_DASHBOARD_PORT = 8080` — no magic numbers) and the entire `ui.run` argument set is isolated in a pure `run_kwargs() -> dict`, so the loopback bind is **unit-assertable without launching the server**. `main()` now calls `ui.run(**run_kwargs())`. The fix makes the code match its own docs (loopback bind makes the no-auth posture acceptable for a dev-only tool).
+
+**Incidental fix (surfaced during the task):** the documented test command in CLAUDE.md (`uv run --with pytest pytest test_monitor.py -v`) omitted `--with nicegui` and therefore **failed in a clean env** — `test_monitor` imports `monitor.py`, which imports `nicegui` at module load. Corrected to `uv run --with pytest --with "nicegui>=2" pytest test_monitor.py -v` (verified verbatim).
+
+**Branch commit** (off `main` @ `602b3af0`):
+| SHA | What |
+|---|---|
+| `d72846a9` | **fix(fuzz)**: bind monitor dashboard to loopback only (#210) — `run_kwargs()` + named consts + 3 tests + CLAUDE.md test-cmd fix |
+| (+ handoff commit) | this baton + retargeted `NEXT_SESSION.md` symlink |
+
+**Tests added (TDD red→green):** `TestRunKwargs` in `core/fuzz/test_monitor.py` (3 cases):
+- `test_binds_loopback_not_all_interfaces` — `run_kwargs()["host"] == "127.0.0.1"` and `!= "0.0.0.0"` (the teeth assertion; fails on the pre-fix no-`host=` code, which had no `run_kwargs` at all).
+- `test_port_matches_documented_dashboard_port` — port stays the documented `8080`.
+- `test_no_dev_server_reload_or_browser_autolaunch` — `reload`/`show` stay `False` (regression guard on the call shape).
+
+### Acceptance (verified by the controller this session, not assumed)
+```bash
+cd /Users/hherb/src/secretary/.worktrees/fuzz-monitor-loopback/core/fuzz
+uv run --with pytest --with "nicegui>=2" pytest test_monitor.py -v    # 142 passed (3 new)
+# Runtime bind proof (stronger than the kwarg assertion):
+uv run monitor.py &                                                   # then:
+lsof -nP -iTCP:8080 -sTCP:LISTEN                                       # -> TCP 127.0.0.1:8080 (LISTEN), NOT 0.0.0.0
+```
+**CI note:** the workflows do **not** run the monitor pytest suite (grep-clean in `.github/workflows/`), so this fix is gated by local runs + the runtime `lsof` proof above, not CI. No Rust / format / conformance surface changed → `test.yml` + `rust-lint.yml` + CodeQL unaffected.
+
+## (2) What's next
+**#210 done (PR open). Pick a fresh item.** Remaining backlog (carried):
+- **#295** — `once` mode doesn't `log_outcome` (rollback/veto surfaced only via exit code, no forensic clocks). Small, pure-Rust/cli; spinoff of the daemon cluster. Call `daemon::log_outcome` on the `Ok` arm of `dispatch_once_subcommand`.
+- **#290** — allowlist the 3 D.4 freshness false-positives (`origin_binding`/`registrable_domain`/`exact_origin`) once the `d4-browser-autofill` session settles (worktree `.worktrees/d4-browser-autofill` was still active at handoff — check before picking).
+- Larger sync/daemon + tooling backlog otherwise unchanged (see carried-issues list below).
+
+**Acceptance criteria template for the next pick:** a failing test that reproduces the gap on `main`, the typed-error/enforcement surface *proven* not assumed (security paths), full `cargo test --workspace` + clippy `-D warnings` green, and spec/`conformance.py` updated in lockstep if observable bytes/semantics change.
+
+**Open follow-up issues (carried):** #295 / #290 / #284 / #280 / #277 / #273 / #272 / #269 / #255 / #252 / #247 / #246 / #234 / #232 / #231 / #224 / #218 / #193 / #192 / #190 / #189 / #186 / #183. (#210 now closed by this PR; #251 / #229 closed by #298; #206–#209 / #205 / #293 / #301 closed earlier.)
+
+## (3) Open decisions and risks
+- **#210: explicit `127.0.0.1`, not `localhost` (deliberate).** Binding the IPv4 loopback literal is strictly more restrictive than `0.0.0.0` and matches the issue's exact recommendation; `localhost` could resolve to `::1` and muddies the assertion. Don't "generalise" it back to a hostname.
+- **#210: `run_kwargs()` pure-split is what makes the bind testable.** `ui.run` actually launches the server, so a literal `host=` arg buried in `main` couldn't be asserted without standing up a socket. The pure `dict`-returning helper is the seam; the runtime `lsof` check is the belt-and-braces proof that NiceGUI honours the kwarg. Don't inline it back into `main`.
+- **No auth added (scope).** The fix is loopback-bind only; it does **not** add a `storage_secret`/auth middleware. That's the correct, proportionate fix for a dev-only single-operator tool per the issue — loopback makes no-auth acceptable. Adding auth would be over-engineering; file a follow-up only if the dashboard ever needs to be reachable off-host.
+- **README / ROADMAP unchanged (deliberate).** #210 adds **no new capability** — pure security hardening of already-shipped dev tooling. The README dashboard mention (`core/fuzz/monitor.py`, "running and watching campaigns") makes no bind/network claim, so it stays accurate; ROADMAP has no #210 reference and no milestone moved. (Matches the prior session's pure-hardening rationale for #251/#229.)
+- **Risk:** none to honest single-operator use. Loopback bind only removes off-host reachability; a developer browsing `http://localhost:8080` on their own machine is unaffected (full 142-test suite green; runtime socket confirmed `127.0.0.1:8080`).
+
+## (4) Exact commands to resume
+```bash
+cd /Users/hherb/src/secretary
+git fetch --prune origin && git checkout main && git pull --ff-only origin main
+# If PR merged: branch + worktree .worktrees/fuzz-monitor-loopback can be removed:
+#   git worktree remove .worktrees/fuzz-monitor-loopback && git branch -D fix/fuzz-monitor-loopback-bind
+git worktree list && git status -s
+
+# Re-run this fix's gate locally (from the worktree if the PR is still open):
+cd core/fuzz && uv run --with pytest --with "nicegui>=2" pytest test_monitor.py -v
+# Runtime bind proof:
+uv run monitor.py & sleep 3; lsof -nP -iTCP:8080 -sTCP:LISTEN; kill %1
+```
+
+## (5) Handoff file model
+`NEXT_SESSION.md` is a **relative symlink** to this file in `docs/handoffs/`. Authored once here; symlink retargeted in the same commit on the feature branch. New-path handoff → no add/add conflict. Branch was cut from current `origin/main` (`602b3af0`) and `origin/main` had **not** advanced at handoff time (verified: `origin/main` == merge-base), so no history-binding merge was needed this session.
+
+## Closing inventory
+- **State on close:** PR opening on `fix/fuzz-monitor-loopback-bind` (1 code commit + handoff). Worktree `.worktrees/fuzz-monitor-loopback`.
+- **Acceptance:** local GREEN — 142/142 monitor tests (3 new), runtime socket confirmed `127.0.0.1:8080` (not `0.0.0.0`), documented test command fixed + verified verbatim. Zero Rust touched → cargo/clippy/conformance unaffected; CI does not run the monitor suite (local + lsof proof is the gate).
+- **README.md / ROADMAP.md:** unchanged (rationale in §3 — internal hardening, no capability/milestone change).
+- **CLAUDE.md:** updated — the documented fuzz-monitor test command now includes `--with nicegui` (was broken in a clean env); no architectural guidance changed.
+- **NEXT_SESSION.md:** symlink → `docs/handoffs/2026-06-25-fuzz-monitor-loopback-bind-shipped.md`.


### PR DESCRIPTION
## Summary

Closes #210. The NiceGUI fuzz dashboard (`core/fuzz/monitor.py`) called `ui.run(...)` with **no `host=`**, so in non-native mode NiceGUI defaults to **`0.0.0.0`** (all interfaces). Its Start/Stop button handlers spawn (`cargo fuzz run`) and `os.killpg` subprocess groups with **no authentication**, so anyone on the same LAN got an unauthenticated process-control panel plus disclosure of local paths / crash filenames in the live log tails — while CLAUDE.md and `core/fuzz/README.md` both describe it as a `localhost:8080` dashboard.

## Fix

- Bind **`127.0.0.1`** explicitly (the issue's exact recommendation; loopback makes the no-auth posture acceptable for a dev-only tool, and makes the code match its own docs).
- Bind host + port are now named constants (`_BIND_HOST` / `_DASHBOARD_PORT` — no magic numbers).
- The `ui.run` argument set is isolated in a pure `run_kwargs() -> dict`, so the security-critical bind host is **unit-assertable without launching the server**. `main()` calls `ui.run(**run_kwargs())`.

## Tests (TDD red→green)

New `TestRunKwargs` (3 cases) in `core/fuzz/test_monitor.py`:
- `test_binds_loopback_not_all_interfaces` — host is `127.0.0.1`, never `0.0.0.0`.
- `test_port_matches_documented_dashboard_port` — port stays the documented `8080`.
- `test_no_dev_server_reload_or_browser_autolaunch` — `reload`/`show` stay `False`.

```
142 passed (3 new)
```

**Runtime bind proof** (stronger than the kwarg assertion — confirms NiceGUI honours `host=`):
```
$ uv run monitor.py & ; lsof -nP -iTCP:8080 -sTCP:LISTEN
TCP 127.0.0.1:8080 (LISTEN)   # was 0.0.0.0:8080 before the fix
```

## Incidental fix

The documented monitor test command in CLAUDE.md omitted `--with nicegui` (test_monitor imports monitor.py → imports nicegui at module load) and failed in a clean env. Corrected and verified verbatim.

## Scope notes

- **No Rust / on-disk-format / spec change** — zero core files touched; `conformance.py` + Swift/Kotlin conformance harnesses unaffected.
- **No auth added** — loopback bind only, the proportionate fix for a dev-only single-operator tool.
- **README / ROADMAP unchanged** — pure internal hardening, no new capability or milestone change.
- CI does not run the monitor pytest suite, so this is gated by local runs + the runtime `lsof` proof.

🤖 Generated with [Claude Code](https://claude.com/claude-code)