### PR TITLE
fix(cli): log RunOutcome forensics on once-mode dispatch (#295)

### DIFF
--- a/NEXT_SESSION.md
+++ b/NEXT_SESSION.md
@@ -1,1 +1,1 @@
-docs/handoffs/2026-06-25-fuzz-monitor-loopback-bind-shipped.md
+docs/handoffs/2026-06-25-once-mode-log-outcome-shipped.md

--- a/cli/src/daemon.rs
+++ b/cli/src/daemon.rs
@@ -241,7 +241,13 @@ fn outcome_log(outcome: &RunOutcome) -> Option<OutcomeLog> {
 
 /// Emit the operator-visible log line (if any) for a successful sync
 /// outcome. The side-effecting edge over the pure [`outcome_log`].
-fn log_outcome(outcome: &RunOutcome) {
+///
+/// `pub` because both the daemon loop ([`after_sync`]) and the single-shot
+/// `once` dispatch (`main::once_ok_exit_code`, #295) route their `Ok`
+/// outcomes through it, so a `once` rollback/veto gets the same forensic
+/// log line — disk-vs-local vector clocks, auto-resolved veto counts — the
+/// daemon path emits, not just a bare exit code.
+pub fn log_outcome(outcome: &RunOutcome) {
     match outcome_log(outcome) {
         Some(OutcomeLog::RollbackRejected { disk, local }) => tracing::warn!(
             disk_clock = ?disk,

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -260,12 +260,23 @@ fn dispatch_once_subcommand(
         run_one(vault, identity, password, state, &mut ux, now)
     };
     match result {
-        Ok(outcome) => outcome_to_exit_code(outcome),
+        Ok(outcome) => once_ok_exit_code(outcome),
         Err(e) => {
             error!("pipeline error: {e}");
             ExitCode::from_sync_error(&e)
         }
     }
+}
+
+/// Handle a successful `once` outcome: emit the operator-visible forensic
+/// log line (#295 — the `once` path previously surfaced a manifest
+/// rollback / auto-resolved tombstone veto *only* via the exit code, losing
+/// the disk-vs-local vector-clock detail the daemon loop logs), then map the
+/// outcome to its [`ExitCode`]. Split out from [`dispatch_once_subcommand`]
+/// so the log-and-map step is unit-testable without standing up a vault.
+fn once_ok_exit_code(outcome: RunOutcome) -> ExitCode {
+    daemon::log_outcome(&outcome);
+    outcome_to_exit_code(outcome)
 }
 
 /// `run` dispatch: install signal handlers, build the [`DaemonConfig`],
@@ -360,6 +371,115 @@ fn now_ms() -> u64 {
 mod tests {
     use super::*;
     use secretary_core::sync::RollbackEvidence;
+    use secretary_core::vault::block::VectorClockEntry;
+    use std::sync::{Arc, Mutex};
+
+    /// A `tracing` writer that appends all formatted output into a shared
+    /// buffer, so a test can assert which operator-visible log line the
+    /// `once` path emitted (or that it stayed silent) without a real
+    /// subscriber or stderr.
+    #[derive(Clone)]
+    struct CaptureWriter(Arc<Mutex<Vec<u8>>>);
+
+    impl io::Write for CaptureWriter {
+        fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+            self.0
+                .lock()
+                .expect("capture buffer poisoned")
+                .extend_from_slice(buf);
+            Ok(buf.len())
+        }
+        fn flush(&mut self) -> io::Result<()> {
+            Ok(())
+        }
+    }
+
+    impl<'a> tracing_subscriber::fmt::MakeWriter<'a> for CaptureWriter {
+        type Writer = CaptureWriter;
+        fn make_writer(&'a self) -> Self::Writer {
+            self.clone()
+        }
+    }
+
+    /// Route `outcome` through [`once_ok_exit_code`] under a capturing
+    /// `tracing` subscriber, returning the resulting exit code and the
+    /// formatted log text. The seam that proves the `once` dispatch emits
+    /// the same forensic line the daemon loop does (#295).
+    fn capture_once_logs(outcome: RunOutcome) -> (ExitCode, String) {
+        let buf = Arc::new(Mutex::new(Vec::new()));
+        let subscriber = tracing_subscriber::fmt()
+            .with_writer(CaptureWriter(buf.clone()))
+            .with_ansi(false)
+            .without_time()
+            .finish();
+        let code = tracing::subscriber::with_default(subscriber, || once_ok_exit_code(outcome));
+        let text = String::from_utf8(buf.lock().expect("capture buffer poisoned").clone())
+            .expect("log output is valid UTF-8");
+        (code, text)
+    }
+
+    /// On a `once` invocation, a rejected manifest rollback must emit the
+    /// forensic warn line (threat-model §3.1 attack indicator) carrying the
+    /// disk-vs-local vector clocks — not just the `RollbackRejected` exit
+    /// code. This is the #295 teeth: it fails on the pre-fix code, where
+    /// `once_ok_exit_code` mapped the outcome to an exit code without
+    /// logging.
+    #[test]
+    fn once_logs_rollback_forensics_not_just_exit_code() {
+        let ev = RollbackEvidence {
+            disk_vector_clock: vec![VectorClockEntry {
+                device_uuid: [0x11; 16],
+                counter: 7,
+            }],
+            local_highest_seen: vec![VectorClockEntry {
+                device_uuid: [0x22; 16],
+                counter: 4,
+            }],
+        };
+        let (code, logs) = capture_once_logs(RunOutcome::RollbackRejected(ev));
+        assert!(matches!(code, ExitCode::RollbackRejected));
+        assert!(
+            logs.contains("manifest rollback rejected"),
+            "once path must log the rollback forensic line; got: {logs:?}"
+        );
+        assert!(
+            logs.contains("disk_clock") && logs.contains("local_clock"),
+            "rollback log must carry the disk-vs-local vector clocks; got: {logs:?}"
+        );
+    }
+
+    /// On a `once` invocation, auto-resolved tombstone vetoes must surface
+    /// the resolved count at `warn!` — otherwise they are invisible except
+    /// to a caller inspecting committed state.
+    #[test]
+    fn once_logs_auto_resolved_veto_count() {
+        let (code, logs) = capture_once_logs(RunOutcome::MergedAndCommitted { vetoes_resolved: 2 });
+        assert!(matches!(code, ExitCode::Success));
+        assert!(
+            logs.contains("auto-resolved 2 tombstone"),
+            "once path must log the auto-resolved veto count; got: {logs:?}"
+        );
+    }
+
+    /// The silent outcome arms (nothing to do, clean apply, silent merge,
+    /// and a zero-veto commit) must emit no operator-visible warning — the
+    /// `once` path stays as quiet as the daemon loop on a no-op pass.
+    #[test]
+    fn once_silent_arms_emit_no_warning() {
+        for outcome in [
+            RunOutcome::NothingToDo,
+            RunOutcome::AppliedAutomatically,
+            RunOutcome::SilentMerge,
+            RunOutcome::MergedAndCommitted { vetoes_resolved: 0 },
+        ] {
+            let (code, logs) = capture_once_logs(outcome);
+            assert!(matches!(code, ExitCode::Success));
+            assert!(
+                !logs.contains("manifest rollback") && !logs.contains("auto-resolved"),
+                "silent outcome arm must not emit a warning; got: {logs:?}"
+            );
+        }
+    }
 
     /// `RollbackRejected` (with empty evidence) must map to the
     /// `RollbackRejected` exit code, not `Success`.

--- a/docs/handoffs/2026-06-25-once-mode-log-outcome-shipped.md
+++ b/docs/handoffs/2026-06-25-once-mode-log-outcome-shipped.md
@@ -1,0 +1,76 @@
+# NEXT_SESSION.md — once-mode RunOutcome forensic logging (#295) ✅ SHIPPED (PR opening)
+
+**Session date:** 2026-06-25. Started from a clean baton — PR #302 (`224af0e1`, the #210 fuzz-monitor loopback bind) had already merged to `main`, so the prior handoff's "PR opening" item was done. Removed the merged worktree/branch (`fuzz-monitor-loopback` / `fix/fuzz-monitor-loopback-bind`). User picked **#295** (the only `[bug]`-labelled carried item, small pure-Rust/CLI) over the two new `security` follow-ups **#300** (iOS `readBlock`/`wipe` race) and **#299** (uniffi lowering-buffer scrub). Executed via **TDD** (red→green) in the project-local worktree `.worktrees/once-log-outcome`.
+
+**Status:** ✅ **SHIPPED — branch `fix/once-mode-log-outcome`, PR opening.** Single focused code commit; full `cargo test --workspace` + clippy `-D warnings` + fmt all green; reviewed clean by `code-reviewer`.
+
+## (1) What we shipped this session
+
+One pure-Rust/CLI forensic-logging gap — **no Rust-core / on-disk-format / spec change**; `conformance.py` + the Swift/Kotlin conformance harnesses untouched; no `FfiVaultError` variant; zero `core/` files touched.
+
+**#295 — `once` mode didn't log `RunOutcome` forensics beyond the exit code.** `cli/src/main.rs::dispatch_once_subcommand` mapped a successful `RunOutcome` straight to an `ExitCode` via `outcome_to_exit_code` and emitted **no** operator-visible log line. So on a single-shot `once` invocation, a rejected manifest rollback (threat-model §3.1 attack indicator, carrying the **disk-vs-local vector clocks**) surfaced only as exit code 10, and an auto-resolved tombstone-veto count (`MergedAndCommitted { vetoes_resolved > 0 }`) was invisible except to a caller inspecting committed state. The daemon `run` loop already logs both via the pure-classifier-backed `daemon::log_outcome` (#207); `once` was deliberately deferred out of that PR's scope and filed as #295.
+
+**Fix (logging-only).** Make `daemon::log_outcome` `pub`, and route the `once` `Ok` arm through a new `once_ok_exit_code(outcome)` seam in `main.rs` that calls `daemon::log_outcome(&outcome)` **before** mapping to the exit code — reusing the daemon's existing pure `outcome_log` classifier, so the `once` and `run` paths cannot drift. Exit-code mapping (`outcome_to_exit_code`, unchanged) and on-disk byte/merge semantics are untouched.
+
+**Branch commit** (off `main` @ `224af0e1`):
+| SHA | What |
+|---|---|
+| `c8d357ae` | **fix(cli)**: log RunOutcome forensics on once-mode dispatch (#295) — `pub log_outcome` + `once_ok_exit_code` seam + 3 tests |
+| (+ handoff commit) | this baton + retargeted `NEXT_SESSION.md` symlink |
+
+**Tests added (TDD red→green):** 3 cases in `cli/src/main.rs` `mod tests`, driven by an in-module capturing `tracing` subscriber (`CaptureWriter` + `tracing::subscriber::with_default`, thread-local so it can't collide with the global `logging` init or parallel test threads) — no new dependency (`tracing-subscriber` is already a `daemon`-feature dep):
+- `once_logs_rollback_forensics_not_just_exit_code` — the teeth: on `RunOutcome::RollbackRejected` the once path must emit `"manifest rollback rejected"` **and** the `disk_clock`/`local_clock` fields (fixture uses non-degenerate clocks `[0x11;16]/ctr 7` vs `[0x22;16]/ctr 4`). Failed on pre-fix code (`got: ""`).
+- `once_logs_auto_resolved_veto_count` — `MergedAndCommitted { vetoes_resolved: 2 }` must log `"auto-resolved 2 tombstone"`. Failed on pre-fix code.
+- `once_silent_arms_emit_no_warning` — the four no-op arms (`NothingToDo` / `AppliedAutomatically` / `SilentMerge` / `MergedAndCommitted { vetoes_resolved: 0 }`) emit no warning and stay `Success`. (Passed pre-fix; regression guard.)
+
+### Acceptance (verified this session, not assumed)
+```bash
+cd /Users/hherb/src/secretary/.worktrees/once-log-outcome
+cargo test --release -p secretary-cli --bin secretary-sync   # 5 passed (3 new)
+cargo test --release --workspace                             # green (exit 0)
+cargo clippy --release --workspace --tests -- -D warnings    # clean
+cargo fmt --all --check                                       # clean
+```
+**RED→GREEN proof:** with the seam in place but `daemon::log_outcome` not yet called, the two behavioral tests failed with `got: ""` (empty log); adding the one-line `daemon::log_outcome(&outcome)` turned them green. **No Rust-core / format / conformance surface changed** → `test.yml` + `rust-lint.yml` + CodeQL unaffected; Swift/Kotlin conformance harnesses not in play.
+
+## (2) What's next
+**#295 done (PR open). Pick a fresh item.** Strongest carried/new candidates:
+- **#300** (`security`, iOS) — `UniffiVaultSession.readBlock`/`wipe()` race on `currentBlock` (no lock vs Android's `sessionLock`). Likely resolves to *prove + document* the main-actor invariant (iOS callers are `@MainActor`-serialized; `wipe()` is idempotent), or mirror Android's lock if any off-actor `wipe()` path exists. #251 follow-up.
+- **#299** (`security`, FFI) — uniffi's generated lowering buffer for password/phrase isn't zeroized (residue beyond the adapter-owned `Data` that #229/#298 already scrub). Open-ended research: may dead-end in a documented upstream-uniffi limitation in the memory-hygiene memo. #229 follow-up.
+- **#290** — allowlist the 3 D.4 freshness false-positives (`origin_binding`/`registrable_domain`/`exact_origin`); **check first** — `.worktrees/d4-browser-autofill` was still active at handoff (`52d99aa3`).
+
+**Acceptance criteria template for the next pick:** a failing test that reproduces the gap on `main`, the typed-error/enforcement surface *proven* not assumed (security paths), full `cargo test --workspace` + clippy `-D warnings` green, and spec/`conformance.py` updated in lockstep if observable bytes/semantics change.
+
+**Open follow-up issues (carried):** #300 / #299 / #290 / #284 / #280 / #277 / #273 / #272 / #269 / #255 / #252 / #247 / #246 / #234 / #232 / #231 / #224 / #218 / #193 / #192 / #190 / #189 / #186 / #183. (#295 now closed by this PR; #210 closed by #302; #251/#229 closed by #298.)
+
+## (3) Open decisions and risks
+- **`pub fn log_outcome` is the minimal sharing surface.** `main.rs` is the `secretary-sync` *binary* crate; `daemon` lives in the `secretary_cli` *lib* crate, so the shared emitter must be `pub` (not `pub(crate)`) to be reachable. The new rustdoc names both call sites (`after_sync`, `once_ok_exit_code`) so the visibility is intentional, not accidental. Don't narrow it back.
+- **`once_ok_exit_code` seam is what makes the log testable.** A bare `daemon::log_outcome(&outcome)` inlined in the `Ok` arm couldn't be asserted without standing up a real vault + `run_one`. The seam takes `RunOutcome` directly, so the capturing-subscriber test reaches it. Don't inline it back into `dispatch_once_subcommand`.
+- **Reuses the daemon's pure classifier — no duplicate logic.** The decision of *what* to log stays in `daemon::outcome_log` (already exhaustively unit-tested in `daemon.rs`); `once` only borrows the thin emitter. So the `once`/`run` forensic output can't diverge. Don't add a parallel `once`-specific classifier.
+- **README / ROADMAP unchanged (deliberate).** #295 adds **no new capability** — pure forensic-observability hardening of already-shipped CLI behavior. Neither file references `once`-mode, `log_outcome`, or #295 (grep-confirmed), so both stay accurate. (Matches the prior pure-hardening rationale for #210/#251/#229.)
+- **Risk:** none to behavior. The fix only *adds* `warn!` lines on the `once` rollback/veto arms (silent arms unchanged, exit codes unchanged, no disk writes). Worst case is two extra log lines an operator now actually sees on a `once` attack-indicator — which is the point.
+
+## (4) Exact commands to resume
+```bash
+cd /Users/hherb/src/secretary
+git fetch --prune origin && git checkout main && git pull --ff-only origin main
+# If PR merged: branch + worktree .worktrees/once-log-outcome can be removed:
+#   git worktree remove .worktrees/once-log-outcome && git branch -D fix/once-mode-log-outcome
+git worktree list && git status -s
+
+# Re-run this fix's gate locally (from the worktree if the PR is still open):
+cd .worktrees/once-log-outcome
+cargo test --release -p secretary-cli --bin secretary-sync   # 5 passed
+cargo test --release --workspace                             # green
+cargo clippy --release --workspace --tests -- -D warnings    # clean
+```
+
+## (5) Handoff file model
+`NEXT_SESSION.md` is a **relative symlink** to this file in `docs/handoffs/`. Authored once here; symlink retargeted in the same commit on the feature branch. New-path handoff → no add/add conflict. Branch was cut from current `origin/main` (`224af0e1`) and `origin/main` had **not** advanced at handoff time (verified: `origin/main` == HEAD == merge-base), so no history-binding merge was needed this session.
+
+## Closing inventory
+- **State on close:** PR opening on `fix/once-mode-log-outcome` (1 code commit `c8d357ae` + handoff). Worktree `.worktrees/once-log-outcome`.
+- **Acceptance:** local GREEN — 5/5 bin tests (3 new), full `cargo test --workspace` exit 0, clippy `-D warnings` clean, fmt clean; reviewed clean by `code-reviewer`. RED→GREEN proven (empty-log failure → one-line fix). Zero `core/` touched → conformance / Swift/Kotlin harnesses unaffected.
+- **README.md / ROADMAP.md:** unchanged (rationale in §3 — forensic-observability hardening, no capability/milestone change).
+- **CLAUDE.md:** unchanged (no architectural guidance affected).
+- **NEXT_SESSION.md:** symlink → `docs/handoffs/2026-06-25-once-mode-log-outcome-shipped.md`.


### PR DESCRIPTION
Closes #295.

## Problem
`cli/src/main.rs::dispatch_once_subcommand` mapped a successful `RunOutcome` straight to an `ExitCode` and emitted **no** operator-visible log line. On a single-shot `once` invocation:
- a rejected manifest rollback (threat-model §3.1 attack indicator, carrying the **disk-vs-local vector clocks**) surfaced only as exit code 10 — the forensic clock detail was lost;
- an auto-resolved tombstone-veto count (`MergedAndCommitted { vetoes_resolved > 0 }`) was invisible except to a caller inspecting committed state.

The daemon `run` loop already logs both via the pure-classifier-backed `daemon::log_outcome` (#207); `once` was deliberately deferred out of that PR's scope and filed as #295.

## Fix (logging-only)
- Make `daemon::log_outcome` `pub` (the `secretary-sync` binary crate needs to reach the `secretary_cli` lib emitter).
- Route the `once` `Ok` arm through a new `once_ok_exit_code(outcome)` seam that calls `daemon::log_outcome(&outcome)` **before** mapping to the exit code, reusing the daemon's pure `outcome_log` classifier so the `once` and `run` paths cannot drift.

Exit-code mapping (`outcome_to_exit_code`, unchanged) and on-disk byte/merge semantics are untouched. No `core/` files, no spec, no `conformance.py` / Swift / Kotlin conformance surface, no `FfiVaultError` variant.

## Tests (TDD red→green)
3 cases in `cli/src/main.rs`, driven by an in-module capturing `tracing` subscriber (thread-local; no new dependency):
- `once_logs_rollback_forensics_not_just_exit_code` — once path must emit `"manifest rollback rejected"` **and** the `disk_clock`/`local_clock` fields (non-degenerate clock fixture). Failed pre-fix with `got: ""`.
- `once_logs_auto_resolved_veto_count` — `vetoes_resolved: 2` must log `"auto-resolved 2 tombstone"`. Failed pre-fix.
- `once_silent_arms_emit_no_warning` — the four no-op arms stay silent + `Success` (regression guard).

## Verification
- `cargo test --release -p secretary-cli --bin secretary-sync` — 5 passed (3 new)
- `cargo test --release --workspace` — green
- `cargo clippy --release --workspace --tests -- -D warnings` — clean
- `cargo fmt --all --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)