### PR TITLE
fix(ios): serialize UniffiVaultSession FFI-handle access under a lock + wiped guard (#300)

### DIFF
--- a/NEXT_SESSION.md
+++ b/NEXT_SESSION.md
@@ -1,1 +1,1 @@
-docs/handoffs/2026-06-25-once-mode-log-outcome-shipped.md
+docs/handoffs/2026-06-25-ios-readblock-wipe-race-shipped.md

--- a/docs/handoffs/2026-06-25-ios-readblock-wipe-race-shipped.md
+++ b/docs/handoffs/2026-06-25-ios-readblock-wipe-race-shipped.md
@@ -1,0 +1,87 @@
+# NEXT_SESSION.md — iOS UniffiVaultSession readBlock/wipe race (#300) ✅ SHIPPED (PR opening)
+
+**Session date:** 2026-06-25. Started from a clean baton — PR #303 (`8681f4e9`, the #295 once-mode RunOutcome forensics) had already merged to `main`, so the prior handoff's "PR opening" item was done. Removed the merged worktree/branch (`once-log-outcome` / `fix/once-mode-log-outcome`). User picked **#300** (`security`, iOS) over **#299** (uniffi lowering-buffer scrub, open-ended) and **#290** (D.4 allowlist — declined: collides with the still-active `.worktrees/d4-browser-autofill`). After investigation the design choice was **mirror Android's lock** (enforcement) over document-only; executed via **TDD** (red→green) in project-local worktree `.worktrees/ios-readblock-wipe-race`.
+
+**Status:** ✅ **SHIPPED — branch `fix/ios-readblock-wipe-race`, PR opening.** Spec commit + code/test commit; targeted tests RED→GREEN proven; full `SecretaryKitTests` 32/32 green; SwiftUI app compiles; reviewed clean by `code-reviewer` (no material issues).
+
+## (1) What we shipped this session
+
+iOS-only thread-safety hardening — **no Rust-core / on-disk-format / spec change**; `conformance.py` + Swift/Kotlin conformance harnesses untouched; no `FfiVaultError` variant; zero `core/` files touched → Rust `cargo`/`clippy`/CodeQL gates unaffected.
+
+**#300 — iOS `UniffiVaultSession.readBlock`/`wipe()` race on `currentBlock`.** PR #298 (#251 reveal-residency bound) added `currentBlock?.wipe()` inside `readBlock` (`ios/SecretaryKit/Sources/SecretaryKit/VaultAccess/UniffiVaultSession.swift`). Unlike the Android `UniffiVaultSession` (serializes `readBlock` vs `wipe()` under `sessionLock` + a `wiped` flag, #250), the iOS type was a plain `final class` with **no lock**. Both `readBlock` (mutates+wipes `currentBlock`) and `wipe()` (wipes `currentBlock`, then zeroizes `manifest`/`identity`) touch shared FFI state → concurrent calls race.
+
+**Investigation (proved iOS is safe *today*, then chose enforcement anyway):** the only prod caller of `wipe()` is `VaultBrowseViewModel.lock()` (`@MainActor`, incl. the scene-phase `.background` handler); `readBlock` is synchronous on `@MainActor`; and the type is non-`Sendable`, so the compiler already bars it from the one off-actor seam (`runOffMainActor`, which requires `@Sendable`). That's a sound proof — but it's a doc-comment-enforced convention a future off-actor `wipe()` could break. Per [[feedback_security_no_assumptions]] we chose enforcement.
+
+**Why not `@MainActor` on the type/protocol (the "obvious" enforcement):** ruled out — `UniffiVaultSession(output:)` is deliberately constructed **inside** `UniffiVaultOpenPort`'s `runOffMainActor` closure (off the main actor, so Argon2id open doesn't block the UI). Marking it `@MainActor` forces construction onto the main actor, requiring the non-`Sendable` `OpenVaultOutput` FFI handle to cross an actor hop — defeating the off-actor open.
+
+**Fix (mirror Android).** Add `private let lock = NSLock()` + `private var wiped = false`; wrap `blockSummaries()`, `readBlock()`, the private `write()` helper, and `wipe()` in `lock.withLock { … }`. `readBlock`: after the FFI decrypt (decrypt-first ordering, like Android), `if wiped { out.wipe(); return [] }`. `write`: `if wiped { throw .other("write on a wiped session") }` **before** touching handles. `wipe()`: set `wiped = true`, then the existing `currentBlock`→`manifest`→`identity` cascade. `vaultUuidHex` left unguarded (mirrors Android — read-only derived metadata). `NSLock` chosen over `OSAllocatedUnfairLock` because the latter's `withLock` return value carries a `Sendable` constraint `[RecordView]` (escaping reveal closures) can't satisfy.
+
+**Branch commits** (off `main` @ `8681f4e9`):
+| SHA | What |
+|---|---|
+| `240e8744` | **docs(spec)**: iOS readBlock/wipe race serialization design (#300) |
+| `36f75c55` | **fix(ios)**: serialize `UniffiVaultSession` FFI-handle access under a lock + `wiped` guard (#300) — impl + 3 integration tests |
+| (+ handoff commit) | this baton + retargeted `NEXT_SESSION.md` symlink |
+
+**Tests added (TDD red→green):** `ios/SecretaryKit/Tests/SecretaryKitTests/SessionWipeGuardIntegrationTests.swift` — opens a temp copy of `golden_vault_001` (never mutates the frozen KAT, per [[feedback_smoke_test_temp_copy_golden_vault]]) with a `FixedDeviceUuid` provider:
+- `testWriteAfterWipeThrowsWipedSessionError` — **the teeth**: after `wipe()`, `appendRecord` throws `.other("write on a wiped session")`. **RED** pre-fix (the FFI threw `.corruptVault("vault manifest handle has been wiped")` on dead handles — wrong variant), **GREEN** once the flag-guard short-circuits.
+- `testWipeIsIdempotent` — `wipe()` twice is a safe no-op; a subsequent write still throws the wiped error. (Also RED pre-fix for the same variant reason.)
+- `testReadBlockAfterWipeYieldsNoRecords` — after `wipe()`, `readBlock` must not return records. (Passed pre-fix too — FFI errors on dead handles → caught → no records; regression guard.)
+
+### Acceptance (verified this session, not assumed)
+```bash
+cd /Users/hherb/src/secretary/.worktrees/ios-readblock-wipe-race
+# xcframework already built this session (ios/Secretary.xcframework); rebuild if stale:
+#   bash ios/scripts/build-xcframework.sh
+SIM_ID="$(xcrun simctl list devices available | grep -E '^[[:space:]]*iPhone 16 \(' | head -1 \
+  | grep -oE '[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}')"
+cd ios/SecretaryKit
+xcodebuild test -scheme SecretaryKit -destination "platform=iOS Simulator,id=$SIM_ID" \
+  -only-testing:SecretaryKitTests/SessionWipeGuardIntegrationTests   # 3/3 GREEN (2 were RED pre-fix)
+xcodebuild test -scheme SecretaryKit -destination "platform=iOS Simulator,id=$SIM_ID"   # 32/32 GREEN
+cd .. && bash ios/scripts/build-app.sh                                # ** BUILD SUCCEEDED **
+```
+**RED→GREEN proof:** with the lock+seam absent, the two write-guard tests failed asserting the wrong error variant (`.corruptVault` from FFI-on-dead-handle vs the expected `.other("write on a wiped session")`); adding the `wiped`-before-body guard turned them green. Full `SecretaryKitTests` 32/32 and the app compile confirm the lock wrapping of `readBlock`/`blockSummaries`/writes introduced no regression.
+
+## (2) What's next
+**#300 done (PR open). Pick a fresh item.** Strongest carried/new candidates:
+- **#299** (`security`, FFI) — uniffi's generated lowering buffer for password/phrase isn't zeroized (residue beyond the adapter-owned `Data` that #229/#298 scrub). Open-ended research: may dead-end in a documented upstream-uniffi limitation in the memory-hygiene memo. #229 follow-up.
+- **#290** — allowlist the 3 D.4 freshness false-positives (`origin_binding`/`registrable_domain`/`exact_origin`); **check first** — `.worktrees/d4-browser-autofill` (`claude/intelligent-davinci-hriple`) was still active this session with post-merge commits beyond merged PR #242 (likely a parallel session). Collision risk.
+- **Concurrency-test depth for #300 (optional follow-up):** the `NSLock` mutual-exclusion under genuine concurrency is by-construction + documented, not unit-tested (a deterministic interleave needs an injected mid-`readBlock` seam; a stress test would be flaky). If wanted, run the SecretaryKit suite under Swift TSan (`-sanitize=thread`) in CI rather than adding a flaky stress test. Not filed as an issue — mention only.
+
+**Acceptance criteria template for the next pick:** a failing test that reproduces the gap on `main`, the typed-error/enforcement surface *proven* not assumed (security paths), the platform's full test gate green, and spec/`conformance.py` updated in lockstep if observable bytes/semantics change.
+
+**Open follow-up issues (carried):** #299 / #290 / #284 / #280 / #277 / #273 / #272 / #269 / #255 / #252 / #247 / #246 / #234 / #232 / #231 / #224 / #218 / #193 / #192 / #190 / #189 / #186 / #183. (#300 now closed by this PR; #295 closed by #303; #210 closed by #302; #251/#229 closed by #298.)
+
+## (3) Open decisions and risks
+- **Mirror-Android lock chosen over document-only** ([[feedback_security_no_assumptions]]): enforcement (thread-safe by construction) beats a plausibility comment a future off-actor caller could break. The lock is uncontended today (all callers `@MainActor`) — pure defense-in-depth that also closes the iOS/Android asymmetry the issue is about.
+- **Serialization extended to writes** (beyond the issue's literal `readBlock`/`wipe` scope): `wipe()` zeroizes `identity`/`manifest`, so write-vs-`wipe()` is the same race class. Mirroring Android's full serialization avoids fixing one side and leaving the sibling gap open. Don't narrow it back to readBlock-only.
+- **`vaultUuidHex` intentionally unguarded** — mirrors Android (read-only derived metadata; the `deviceUuid()` path that needs it already runs inside the `write` lock). Don't "fix" it into the lock without reason; it would diverge from Android.
+- **`NSLock` over `OSAllocatedUnfairLock`** — the latter's `withLock` constrains the return type to `Sendable`, which `[RecordView]` (escaping reveal closures, non-`Sendable`) can't satisfy. Don't swap it.
+- **README / ROADMAP unchanged (deliberate).** #300 adds **no new capability** — thread-safety hardening of already-shipped iOS browse behavior. README's "session wiped on background" remains accurate (grep-confirmed). Matches the pure-hardening rationale for #210/#251/#229/#295.
+- **Risk:** none to behavior. On the single-threaded `@MainActor` path the lock is uncontended and observable behavior is unchanged (existing 32 tests pass); the only new observable is the typed `.other("write on a wiped session")` on a write after lock (previously a `.corruptVault` FFI error) — a strictly clearer error.
+
+## (4) Exact commands to resume
+```bash
+cd /Users/hherb/src/secretary
+git fetch --prune origin && git checkout main && git pull --ff-only origin main
+# If PR merged: branch + worktree .worktrees/ios-readblock-wipe-race can be removed:
+#   git worktree remove .worktrees/ios-readblock-wipe-race && git branch -D fix/ios-readblock-wipe-race
+git worktree list && git status -s
+
+# Re-run this fix's gate (from the worktree if the PR is still open; xcframework already built):
+cd .worktrees/ios-readblock-wipe-race/ios/SecretaryKit
+SIM_ID="$(xcrun simctl list devices available | grep -E '^[[:space:]]*iPhone 16 \(' | head -1 \
+  | grep -oE '[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}')"
+xcodebuild test -scheme SecretaryKit -destination "platform=iOS Simulator,id=$SIM_ID"   # 32/32
+```
+
+## (5) Handoff file model
+`NEXT_SESSION.md` is a **relative symlink** to this file in `docs/handoffs/`. Authored once here; symlink retargeted in the same commit on the feature branch. New-path handoff → no add/add conflict. Branch was cut from current `origin/main` (`8681f4e9`) and `origin/main` had **not** advanced at handoff time (verified: `origin/main` == merge-base == `8681f4e9`), so no history-binding merge was needed.
+
+## Closing inventory
+- **State on close:** PR opening on `fix/ios-readblock-wipe-race` (spec `240e8744` + code/test `36f75c55` + handoff). Worktree `.worktrees/ios-readblock-wipe-race`.
+- **Acceptance:** local GREEN — 3/3 targeted wipe-guard tests (RED→GREEN proven on 2), full `SecretaryKitTests` 32/32, SwiftUI app compiles; reviewed clean by `code-reviewer`. Zero `core/` touched → conformance / Swift/Kotlin harnesses unaffected.
+- **README.md / ROADMAP.md:** unchanged (rationale in §3 — thread-safety hardening, no capability/milestone change).
+- **CLAUDE.md:** unchanged (the lock rationale lives in the type's doc-comment; no cross-cutting architectural guidance affected).
+- **NEXT_SESSION.md:** symlink → `docs/handoffs/2026-06-25-ios-readblock-wipe-race-shipped.md`.

--- a/docs/superpowers/specs/2026-06-25-ios-readblock-wipe-race-design.md
+++ b/docs/superpowers/specs/2026-06-25-ios-readblock-wipe-race-design.md
@@ -1,0 +1,102 @@
+# iOS `UniffiVaultSession.readBlock`/`wipe()` race — serialize FFI-handle access (#300)
+
+**Date:** 2026-06-25
+**Issue:** #300 (`security`, follow-up to #251 / PR #298)
+**Scope:** iOS only. No Rust-core / on-disk-format / spec / conformance change.
+
+## Problem
+
+PR #298 (#251 reveal-residency bound) added `currentBlock?.wipe()` inside
+`UniffiVaultSession.readBlock` (`ios/SecretaryKit/.../VaultAccess/UniffiVaultSession.swift`).
+The iOS `UniffiVaultSession` is a plain `final class` with **no lock**, unlike the
+Android `UniffiVaultSession`, which serializes `readBlock` vs `wipe()` under a
+`sessionLock` + a `wiped` race guard (per #250). On iOS both `readBlock` (mutates +
+wipes `currentBlock`) and `wipe()` (mutates + wipes `currentBlock`, then `manifest`,
+then `identity`) touch shared FFI state. If they ever run concurrently on different
+threads, they race.
+
+### Why iOS is safe *today* (proven, not assumed)
+
+- The only production caller of `UniffiVaultSession.wipe()` is
+  `VaultBrowseViewModel.lock()` (`@MainActor`), including the scene-phase
+  `.background` handler (`SecretaryApp.swift`), which runs on the main actor.
+- `readBlock` is synchronous and runs on the `@MainActor` VM via `reload`.
+- `UniffiVaultSession` is **non-`Sendable`**, and the only off-actor seam,
+  `runOffMainActor`, requires `@Sendable` work — so the compiler already bars the
+  session from crossing an actor boundary.
+
+This is a sound proof, but it is *convention enforced by a doc-comment a future
+maintainer can violate* (e.g. by introducing an off-actor `wipe()` path). On a
+security path we prefer enforcement over a plausibility argument.
+
+### Why `@MainActor` enforcement is ruled out
+
+Marking `UniffiVaultSession` / the `VaultSession` protocol `@MainActor` would force
+session **construction** onto the main actor. But `UniffiVaultSession(output:)` is
+deliberately built **inside** the `runOffMainActor` closure in `UniffiVaultOpenPort`
+(off the main actor, so Argon2id open does not block the UI). The session would then
+have to cross an actor hop carrying a non-`Sendable` `OpenVaultOutput` FFI handle —
+defeating the off-actor open or forcing unsafe contortions. Rejected.
+
+## Decision
+
+Mirror Android: make the iOS type **thread-safe by construction** with an internal
+lock + `wiped` guard, serializing *all* shared-FFI-handle access. This also closes
+the symmetric write-vs-`wipe()` race (a write touches `identity`/`manifest`, which
+`wipe()` zeroizes — the same race class as the issue's `readBlock`/`currentBlock`),
+so we do not fix one side and leave the sibling gap open.
+
+### Implementation
+
+`ios/SecretaryKit/Sources/SecretaryKit/VaultAccess/UniffiVaultSession.swift`:
+
+- Add `private let lock = NSLock()` and `private var wiped = false`.
+  (`NSLock.withLock` is available macOS 13 / iOS 16; targets are macOS 13 / iOS 17.
+  Chosen over `OSAllocatedUnfairLock.withLock`, whose return value carries a
+  `Sendable` constraint that `[RecordView]` — escaping reveal closures — cannot
+  satisfy.)
+- Wrap in `lock.withLock { … }`, mirroring Android's serialization:
+  - `blockSummaries()` — reads `manifest`.
+  - `readBlock(...)` — full body. Preserve decrypt-first ordering: decrypt, then
+    `if wiped { out.wipe(); return [] }`, then evict prior + retain new + build
+    `RecordView`s. (Same flag position as Android: a sequential post-`wipe()` read
+    hits the FFI error on dead handles first; the `wiped` branch is defensive depth
+    for the genuine concurrent-mid-read case.)
+  - private `write(...)` helper — `if wiped { throw .other("write on a wiped
+    session") }` **before** resolving device-uuid / running the body, so a write on a
+    wiped session short-circuits without touching zeroized handles.
+  - `wipe()` — set `wiped = true`, then the existing
+    `currentBlock` → `manifest` → `identity` cascade.
+- Leave `vaultUuidHex` unguarded (mirrors Android — read-only derived metadata).
+- Rewrite the class doc-comment to state the lock + `wiped` rationale and
+  cross-reference #300 / #250, matching Android's comment.
+
+Reveal closures (`makeFieldView`) are still invoked later, **outside** the lock, by
+the user — unchanged.
+
+## Tests (TDD)
+
+New integration file in `SecretaryKitTests`, opening a temp copy of
+`golden_vault_001` with a `FixedDeviceUuid` provider (mirrors
+`RecordEditIntegrationTests`; never mutates the frozen KAT):
+
+1. `write_afterWipe_throwsWipedSessionError` — **red→green teeth.** After `wipe()`,
+   `appendRecord` throws the wiped-session error. RED on current code (throws a
+   *different* FFI-on-dead-handle error), GREEN once the flag-guard short-circuits.
+2. `readBlock_afterWipe_yieldsNoRecords` — safety-contract guard: after `wipe()`,
+   `readBlock` must not return records (throws / empty).
+3. `wipe_isIdempotent` — calling `wipe()` twice is a safe no-op.
+
+Mutual exclusion under genuine concurrency is provided by `NSLock` and documented —
+not unit-tested. A deterministic concurrency test would need an injected
+mid-`readBlock` seam (over-engineering); a stress test would be flaky (which the
+project bans). This matches how Android shipped the same guard.
+
+## Out of scope / non-goals
+
+- No change to `readBlock`'s normal-path behavior (existing reveal-residency +
+  record-edit integration tests cover it).
+- No `@MainActor` annotation on the type or protocol (see "ruled out").
+- No `VaultAccessError` variant added — reuse `.other(String)`.
+- README / ROADMAP unchanged (forensic/thread-safety hardening of shipped behavior;
+  no new capability or milestone).

--- a/ios/SecretaryKit/Sources/SecretaryKit/VaultAccess/UniffiVaultSession.swift
+++ b/ios/SecretaryKit/Sources/SecretaryKit/VaultAccess/UniffiVaultSession.swift
@@ -8,10 +8,31 @@ import SecretaryVaultAccess
 /// `FieldHandle`) stay valid while the block is on screen. Prior blocks are
 /// wiped on each `readBlock` call (#251). `wipe()` releases the current block,
 /// then manifest, then identity.
+///
+/// Thread-safety (#300, mirror of the Android `UniffiVaultSession`, #250): every
+/// touch of the shared FFI state — the `identity`/`manifest` handles and
+/// `currentBlock` — is serialized under `lock`, and a `wiped` flag makes a read
+/// that loses the race to a concurrent `wipe()` zeroize its just-decrypted block
+/// (and a write short-circuit) instead of operating on handles a caller believed
+/// cleared. Today every production caller is `@MainActor` (`VaultBrowseViewModel`,
+/// including the scene-phase `.background` lock) and `readBlock` is synchronous, so
+/// the lock is uncontended; it makes the type thread-safe *by construction* rather
+/// than by an actor-isolation argument a future off-actor caller could silently
+/// break. (Marking the type `@MainActor` is not viable: the session is constructed
+/// off the main actor inside `UniffiVaultOpenPort`'s `runOffMainActor` so Argon2id
+/// open does not block the UI.) The lock is non-recursive — no method re-enters
+/// another; `currentBlock?.wipe()` is the FFI handle's own wipe, not `self.wipe()`.
 public final class UniffiVaultSession: VaultSession {
     private let identity: UnlockedIdentity
     private let manifest: OpenVaultManifest
     private let deviceUuids: DeviceUuidProviding?
+    /// Serializes all access to the FFI handles + `currentBlock`. The held section
+    /// spans the block decrypt, so a concurrent `wipe()` waits for an in-flight read
+    /// (bounded — one block decrypt is milliseconds).
+    private let lock = NSLock()
+    /// Set true by `wipe()`; a read that observes it must not retain its block and a
+    /// write must not touch the now-zeroized handles.
+    private var wiped = false
     /// The single retained decrypted block — the on-screen one. Bounding to one
     /// block (not a growing list) makes "≤1 block resident" a type-level invariant
     /// and dedups re-selection. The VM clears the reveal map on `selectBlock`, so no
@@ -40,44 +61,55 @@ public final class UniffiVaultSession: VaultSession {
     }
 
     public func blockSummaries() -> [SecretaryVaultAccess.BlockSummary] {
-        manifest.blockSummaries().map { s in
-            SecretaryVaultAccess.BlockSummary(
-                uuid: [UInt8](s.blockUuid),
-                name: s.blockName,
-                createdAtMs: s.createdAtMs,
-                lastModMs: s.lastModifiedMs)
+        lock.withLock {
+            manifest.blockSummaries().map { s in
+                SecretaryVaultAccess.BlockSummary(
+                    uuid: [UInt8](s.blockUuid),
+                    name: s.blockName,
+                    createdAtMs: s.createdAtMs,
+                    lastModMs: s.lastModifiedMs)
+            }
         }
     }
 
     public func readBlock(blockUuid: [UInt8], includeDeleted: Bool) throws -> [RecordView] {
-        let out: BlockReadOutput
-        do {
-            out = try SecretaryKit.readBlock(
-                identity: identity, manifest: manifest, blockUuid: Data(blockUuid),
-                includeDeleted: includeDeleted)
-        } catch let e as VaultError {
-            throw mapVaultAccessError(e)
-        }
-        // Decrypt-first ordering: `out` is already decoded above, so a thrown read
-        // left the prior block retained. Now evict it before retaining the new one.
-        currentBlock?.wipe()
-        currentBlock = out  // keep alive for reveal closures + wipe
-        let count = out.recordCount()
-        var records: [RecordView] = []
-        records.reserveCapacity(Int(count))
-        var i: UInt64 = 0
-        while i < count {
-            // An in-range `nil` on a freshly-decrypted, non-wiped block is not a
-            // routine skip — it signals corruption or an FFI bug. Surface it as a
-            // typed error rather than silently returning fewer records than the
-            // block declares (a silent drop could hide a tampered record).
-            guard let rec = out.recordAt(idx: i) else {
-                throw VaultAccessError.corruptVault("recordAt(\(i)) returned nil on an open block")
+        try lock.withLock {
+            let out: BlockReadOutput
+            do {
+                out = try SecretaryKit.readBlock(
+                    identity: identity, manifest: manifest, blockUuid: Data(blockUuid),
+                    includeDeleted: includeDeleted)
+            } catch let e as VaultError {
+                throw mapVaultAccessError(e)
             }
-            records.append(try makeRecordView(rec))
-            i += 1
+            // Lost the race to a concurrent wipe(): the session is closed. Zeroize the
+            // block we just decrypted rather than retain plaintext past the lock the
+            // caller believed cleared everything.
+            if wiped {
+                out.wipe()
+                return []
+            }
+            // Decrypt-first ordering: `out` is already decoded above, so a thrown read
+            // left the prior block retained. Now evict it before retaining the new one.
+            currentBlock?.wipe()
+            currentBlock = out  // keep alive for reveal closures + wipe
+            let count = out.recordCount()
+            var records: [RecordView] = []
+            records.reserveCapacity(Int(count))
+            var i: UInt64 = 0
+            while i < count {
+                // An in-range `nil` on a freshly-decrypted, non-wiped block is not a
+                // routine skip — it signals corruption or an FFI bug. Surface it as a
+                // typed error rather than silently returning fewer records than the
+                // block declares (a silent drop could hide a tampered record).
+                guard let rec = out.recordAt(idx: i) else {
+                    throw VaultAccessError.corruptVault("recordAt(\(i)) returned nil on an open block")
+                }
+                records.append(try makeRecordView(rec))
+                i += 1
+            }
+            return records
         }
-        return records
     }
 
     private func makeRecordView(_ rec: Record) throws -> RecordView {
@@ -123,10 +155,16 @@ public final class UniffiVaultSession: VaultSession {
     }
 
     public func wipe() {
-        currentBlock?.wipe()
-        currentBlock = nil
-        manifest.wipe()
-        identity.wipe()
+        // Under `lock` so an in-flight readBlock/write either completes before we
+        // zeroize the handles or observes `wiped` and bails. Idempotent — wipe may be
+        // called repeatedly (e.g. scene-phase `.background` then an explicit lock).
+        lock.withLock {
+            wiped = true
+            currentBlock?.wipe()
+            currentBlock = nil
+            manifest.wipe()
+            identity.wipe()
+        }
     }
 
     @discardableResult
@@ -206,17 +244,24 @@ public final class UniffiVaultSession: VaultSession {
     /// Resolve (device uuid, now-ms), run the FFI write, map errors. Centralizes
     /// the device-uuid resolve + `VaultError` mapping for every writer
     /// (append/edit/tombstone/resurrect + createBlock/renameBlock/moveRecord).
+    /// Serialized under `lock` with the `wiped` guard checked **before** touching the
+    /// handles, so a write on a wiped session short-circuits cleanly rather than
+    /// calling the FFI on zeroized `identity`/`manifest`.
     ///
-    /// - Throws: `VaultAccessError` for any FFI `VaultError`; additionally, the
-    ///   **first write** of a session may throw a `DeviceUuidStoreError` (an I/O
-    ///   error from resolving the per-vault device UUID) which is deliberately NOT
-    ///   mapped to a `VaultAccessError` — callers must handle both error types.
+    /// - Throws: `VaultAccessError.other` if the session has been wiped;
+    ///   `VaultAccessError` for any FFI `VaultError`; additionally, the **first
+    ///   write** of a session may throw a `DeviceUuidStoreError` (an I/O error from
+    ///   resolving the per-vault device UUID) which is deliberately NOT mapped to a
+    ///   `VaultAccessError` — callers must handle both error types.
     private func write(_ body: (_ deviceUuid: [UInt8], _ nowMs: UInt64) throws -> Void) throws {
-        let dev = try deviceUuid()
-        do {
-            try body(dev, Self.nowMs())
-        } catch let e as VaultError {
-            throw mapVaultAccessError(e)
+        try lock.withLock {
+            if wiped { throw VaultAccessError.other("write on a wiped session") }
+            let dev = try deviceUuid()
+            do {
+                try body(dev, Self.nowMs())
+            } catch let e as VaultError {
+                throw mapVaultAccessError(e)
+            }
         }
     }
 

--- a/ios/SecretaryKit/Tests/SecretaryKitTests/SessionWipeGuardIntegrationTests.swift
+++ b/ios/SecretaryKit/Tests/SecretaryKitTests/SessionWipeGuardIntegrationTests.swift
@@ -1,0 +1,90 @@
+import XCTest
+@testable import SecretaryKit
+import SecretaryVaultAccess
+
+/// #300: `UniffiVaultSession` must serialize FFI-handle access under a lock and a
+/// `wiped` guard (mirror of the Android session, #250). After `wipe()`, the session
+/// is closed: a write must short-circuit with a typed wiped-session error WITHOUT
+/// touching the zeroized `identity`/`manifest` handles, and a `readBlock` must never
+/// yield plaintext records. The lock's mutual exclusion under genuine concurrency is
+/// by-construction + documented (not unit-tested — a deterministic interleave would
+/// need an injected mid-read seam; a stress test would be flaky).
+///
+/// Opens a temp copy of the frozen `golden_vault_001` KAT (never mutates the
+/// original), mirroring `RecordEditIntegrationTests`.
+final class SessionWipeGuardIntegrationTests: XCTestCase {
+    private let goldenPassword = "correct horse battery staple"
+    private var vaultCopy: URL!
+
+    /// A device-uuid provider yielding a fixed UUID so writes are deterministic.
+    private struct FixedDeviceUuid: DeviceUuidProviding {
+        let value: [UInt8]
+        func deviceUuid(forVaultHex vaultHex: String) throws -> [UInt8] { value }
+    }
+
+    override func setUpWithError() throws {
+        let bundled = try XCTUnwrap(
+            Bundle.module.url(forResource: "golden_vault_001", withExtension: nil),
+            "golden_vault_001 not bundled — run ios/scripts/build-xcframework.sh")
+        let tmp = FileManager.default.temporaryDirectory
+            .appendingPathComponent("gv-wipeguard-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: tmp, withIntermediateDirectories: true)
+        vaultCopy = tmp.appendingPathComponent("golden_vault_001", isDirectory: true)
+        try FileManager.default.copyItem(at: bundled, to: vaultCopy)
+    }
+
+    override func tearDownWithError() throws {
+        if let vaultCopy { try? FileManager.default.removeItem(at: vaultCopy.deletingLastPathComponent()) }
+    }
+
+    private func openSession() throws -> UniffiVaultSession {
+        let out = try SecretaryKit.openVaultWithPassword(
+            folderPath: Data(vaultCopy.path.utf8), password: Data(goldenPassword.utf8))
+        return UniffiVaultSession(
+            output: out, deviceUuids: FixedDeviceUuid(value: [UInt8](repeating: 0x5A, count: 16)))
+    }
+
+    private func sampleRecord() -> RecordContentInput {
+        RecordContentInput(
+            recordType: "login", tags: ["work"],
+            fields: [FieldContentInput(name: "user", value: .text("alice"))])
+    }
+
+    /// The teeth: a write on a wiped session throws the typed wiped-session error,
+    /// short-circuiting BEFORE the FFI write touches the zeroized handles. Pre-fix,
+    /// the write reached the FFI and threw a different (decrypt-on-dead-handle) error.
+    func testWriteAfterWipeThrowsWipedSessionError() throws {
+        let session = try openSession()
+        let block = try XCTUnwrap(session.blockSummaries().first).uuid
+        session.wipe()
+        XCTAssertThrowsError(try session.appendRecord(blockUuid: block, content: sampleRecord())) { error in
+            XCTAssertEqual(error as? VaultAccessError, .other("write on a wiped session"))
+        }
+    }
+
+    /// A `readBlock` after `wipe()` must never return plaintext records — it either
+    /// throws a typed error or returns an empty slice, but never yields data.
+    func testReadBlockAfterWipeYieldsNoRecords() throws {
+        let session = try openSession()
+        let block = try XCTUnwrap(session.blockSummaries().first).uuid
+        session.wipe()
+        do {
+            let records = try session.readBlock(blockUuid: block, includeDeleted: false)
+            XCTAssertTrue(records.isEmpty, "a wiped session must not yield records")
+        } catch {
+            // Throwing a typed error is the equally-acceptable closed-session outcome.
+        }
+    }
+
+    /// `wipe()` is idempotent: calling it twice is a safe no-op, and the session stays
+    /// closed (a subsequent write still throws the wiped-session error).
+    func testWipeIsIdempotent() throws {
+        let session = try openSession()
+        let block = try XCTUnwrap(session.blockSummaries().first).uuid
+        session.wipe()
+        session.wipe()
+        XCTAssertThrowsError(try session.appendRecord(blockUuid: block, content: sampleRecord())) { error in
+            XCTAssertEqual(error as? VaultAccessError, .other("write on a wiped session"))
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Closes #300. iOS `UniffiVaultSession` was a plain `final class` with **no lock**, unlike the Android `UniffiVaultSession` which serializes `readBlock` vs `wipe()` under a `sessionLock` + a `wiped` flag (#250). After PR #298 (#251) added `currentBlock?.wipe()` inside `readBlock`, both `readBlock` (mutates+wipes `currentBlock`) and `wipe()` (wipes `currentBlock`, then zeroizes `manifest`/`identity`) touch shared FFI state, so a concurrent call would race on `currentBlock`.

This mirrors Android: adds `NSLock` + a `wiped` flag and serializes every shared-FFI access (`blockSummaries`, `readBlock`, the `write` helper, `wipe`). A read that loses the race to a concurrent `wipe()` zeroizes its just-decrypted block and returns `[]`; a write on a wiped session short-circuits with a typed error **before** touching the zeroized handles.

## Why a lock (not just a doc-comment)

iOS is provably safe *today* — the only prod caller of `wipe()` is `VaultBrowseViewModel.lock()` (`@MainActor`, incl. the scene-phase `.background` handler), `readBlock` is synchronous on `@MainActor`, and the non-`Sendable` type can't cross the one off-actor seam (`runOffMainActor`, which requires `@Sendable`). But that's a doc-comment-enforced convention a future off-actor `wipe()` could break. Per the project's "security paths enforce, don't assume" principle, this makes the type thread-safe **by construction**.

`@MainActor` on the type/protocol was ruled out: the session is deliberately constructed off the main actor inside `UniffiVaultOpenPort`'s `runOffMainActor` (so Argon2id open doesn't block the UI), so isolating it would force the non-`Sendable` `OpenVaultOutput` FFI handle across an actor hop.

The serialization extends to **writes** (beyond the issue's literal `readBlock`/`wipe` scope) because `wipe()` zeroizes `identity`/`manifest` — write-vs-`wipe()` is the same race class. Mirroring Android's full serialization avoids fixing one side and leaving the sibling gap open.

## Scope

iOS-only. **No** Rust-core / on-disk-format / spec / `conformance.py` change; no `FfiVaultError` variant; zero `core/` files touched → Rust `cargo`/`clippy`/CodeQL gates unaffected.

## Tests (TDD red→green)

New `SessionWipeGuardIntegrationTests` opens a temp copy of `golden_vault_001` (never mutates the frozen KAT) with a `FixedDeviceUuid` provider:

- `testWriteAfterWipeThrowsWipedSessionError` — **the teeth**: after `wipe()`, `appendRecord` throws `.other("write on a wiped session")`. **RED** pre-fix (FFI threw `.corruptVault("vault manifest handle has been wiped")` on dead handles — wrong variant), **GREEN** once the flag-guard short-circuits.
- `testWipeIsIdempotent` — `wipe()` twice is a safe no-op; a later write still throws the wiped error.
- `testReadBlockAfterWipeYieldsNoRecords` — after `wipe()`, `readBlock` returns no records (regression guard).

**Acceptance (local):** targeted tests 3/3 GREEN (2 RED pre-fix), full `SecretaryKitTests` **32/32** green, SwiftUI app compiles (`build-app.sh` → BUILD SUCCEEDED). Reviewed clean by `code-reviewer` (no material issues — lock discipline sound, no re-entrancy/deadlock, `NSLock.withLock` rethrows correctly, memory-hygiene invariants preserved).

Mutual exclusion under genuine concurrency is by-construction + documented, not unit-tested (a deterministic interleave needs an injected mid-`readBlock` seam; a stress test would be flaky). This matches how Android shipped the same guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)