### PR TITLE
test(ios): TSan concurrency coverage for UniffiVaultSession lock (#300 follow-up)

### DIFF
--- a/.github/workflows/ios-tsan.yml
+++ b/.github/workflows/ios-tsan.yml
@@ -30,11 +30,18 @@ jobs:
   ios-tsan:
     name: SecretaryKit ThreadSanitizer
     runs-on: macos-latest
+    # Bound the heaviest job: Argon2id under TSan runs ~5-15x slower, so a
+    # pathological hang would otherwise burn the default 6h macOS budget. 60 min
+    # is generous headroom over a healthy run; revisit once first-run duration is
+    # known.
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@v4
       - name: Cache cargo build
         uses: Swatinem/rust-cache@v2
       # Builds the uniffi xcframework (compiles the Rust core for the iOS-sim
       # target) then runs the whole SecretaryKit suite under -enableThreadSanitizer.
+      # If a future macos-latest image drops the "iPhone 16" simulator, set the
+      # IOS_SIM env to an available device name (run-ios-tsan.sh honors it).
       - name: SecretaryKit suite under ThreadSanitizer
         run: bash ios/scripts/run-ios-tsan.sh

--- a/.github/workflows/ios-tsan.yml
+++ b/.github/workflows/ios-tsan.yml
@@ -1,0 +1,40 @@
+name: iOS TSan
+
+# #300 follow-up: run the SecretaryKit XCTest suite under ThreadSanitizer so the
+# UniffiVaultSession lock is exercised under genuine concurrency
+# (SessionConcurrencyIntegrationTests). macOS-only and heavy (builds the uniffi
+# xcframework, then runs the suite instrumented), so it is path-gated to iOS
+# changes. A separate workflow file is the cleanest no-third-party-action way to
+# scope this without gating test.yml's rust/desktop/conformance jobs (which must
+# run on every PR).
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'ios/**'
+      - '.github/workflows/ios-tsan.yml'
+  pull_request:
+    paths:
+      - 'ios/**'
+      - '.github/workflows/ios-tsan.yml'
+
+concurrency:
+  group: ios-tsan-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  ios-tsan:
+    name: SecretaryKit ThreadSanitizer
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Cache cargo build
+        uses: Swatinem/rust-cache@v2
+      # Builds the uniffi xcframework (compiles the Rust core for the iOS-sim
+      # target) then runs the whole SecretaryKit suite under -enableThreadSanitizer.
+      - name: SecretaryKit suite under ThreadSanitizer
+        run: bash ios/scripts/run-ios-tsan.sh

--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,9 @@ lib64/
 # would otherwise mask this directory wholesale.
 !desktop/src/lib/
 !desktop/src/lib/**
+# iOS script helpers — same `lib/` exception for the bash shared library.
+!ios/scripts/lib/
+!ios/scripts/lib/**
 parts/
 sdist/
 var/

--- a/NEXT_SESSION.md
+++ b/NEXT_SESSION.md
@@ -1,1 +1,1 @@
-docs/handoffs/2026-06-25-ios-readblock-wipe-race-shipped.md
+docs/handoffs/2026-06-25-ios-tsan-concurrency-shipped.md

--- a/docs/handoffs/2026-06-25-ios-tsan-concurrency-shipped.md
+++ b/docs/handoffs/2026-06-25-ios-tsan-concurrency-shipped.md
@@ -1,0 +1,86 @@
+# NEXT_SESSION.md — iOS UniffiVaultSession TSan concurrency coverage (#300 follow-up) ✅ SHIPPED (PR opening)
+
+**Session date:** 2026-06-25. Started from a clean baton — PR #304 (`3cba686c`, the #300 readBlock/wipe lock) had already merged to `main`, so the prior handoff's "PR opening" was done; removed the merged worktree/branch (`ios-readblock-wipe-race` / `fix/ios-readblock-wipe-race`). User picked the **#300 TSan follow-up** (the optional, unfiled item the prior handoff flagged: "run the SecretaryKit suite under Swift TSan in CI rather than a flaky stress test"). Executed via full **brainstorm → spec → plan → subagent-driven-development** flow in project-local worktree `.worktrees/ios-tsan-concurrency`.
+
+**Status:** ✅ **SHIPPED — branch `test/ios-tsan-concurrency`, PR opening.** Spec + plan committed; 3 tasks each TDD'd, implemented, and task-reviewed clean; final whole-branch review (opus) = **Ready to merge: Yes** (no Critical/Important); all Minors fixed per [[feedback_fix_all_review_issues]].
+
+## (1) What we shipped this session
+
+iOS **test + CI only** — **no** Rust-core / on-disk-format / spec / `conformance.py` change; **no** `FfiVaultError` variant; **no** `UniffiVaultSession` production-code change (the TDD red step temporarily neutered the lock, then fully reverted). Zero `core/` files touched → Rust `cargo`/`clippy`/CodeQL/conformance/Swift+Kotlin-conformance gates unaffected.
+
+**The gap (#300 follow-up).** PR #304 made `UniffiVaultSession` thread-safe (`NSLock` + `wiped` flag serializing the mutable stored properties `currentBlock` / `wiped` / `cachedDeviceUuid`), but that mutual exclusion was asserted **by construction + doc-comment only** — no test drove it under concurrency, so a future lock regression would pass the suite. This session closes that with a TSan-verified concurrency suite + a CI job that runs it.
+
+**Why a concurrency test is NOT flaky here:** TSan detects races via happens-before tracking (NSLock is TSan-aware), so it flags an unsynchronized stored-property access *regardless of interleaving*. The flakiness the prior handoff feared comes only from asserting a *specific race winner* — which we deliberately never do (assertions are no-crash + count/contents that hold under any valid order).
+
+**Three deliverables:**
+1. **`ios/scripts/run-ios-tsan.sh`** (new) — builds the xcframework, runs the **whole** `SecretaryKit` suite under `xcodebuild ... -enableThreadSanitizer YES`. The ~20-line simulator-name→UDID resolver was extracted into a sourceable **`ios/scripts/lib/resolve-simulator.sh`** shared with `run-ios-tests.sh` (pure extraction; only semantic delta `exit 2`→`return 2`, correct for a sourced fn under `set -e` command-substitution).
+2. **`SessionConcurrencyIntegrationTests.swift`** (new) — 3 tests over a temp copy of `golden_vault_001` ([[feedback_smoke_test_temp_copy_golden_vault]]), sharing the non-`Sendable` session via an `@unchecked Sendable` box (the deliberate, documented bypass — the lock is what makes it safe; preserves the zero-warning bar): `testConcurrentReadsAreRaceFree` (drives `currentBlock` evict/replace), `testConcurrentReadAndWipeAreRaceFree` (drives `currentBlock`/`wiped`), `testConcurrentWritesAreRaceFree` (drives `write()` + `cachedDeviceUuid`). Counts via named constants (`concurrentWorkers=8`, `wipeRaceSessions=4`). Plus retired the now-stale "not unit-tested … flaky" caveat in `SessionWipeGuardIntegrationTests`'s docstring.
+3. **`.github/workflows/ios-tsan.yml`** (new) — path-gated (`ios/**` + the workflow file, on push-to-main + PR) `macos-latest` job running `run-ios-tsan.sh`. A **separate workflow file** (documented deviation from the spec's "in test.yml") because workflow-level `paths:` is the only clean no-third-party-action way to gate one heavy macOS job without gating test.yml's rust/desktop/conformance jobs. `timeout-minutes: 60` + `IOS_SIM` escape-hatch note added per final review.
+
+**Branch commits** (off `main` @ `3cba686c`):
+| SHA | What |
+|---|---|
+| `94a09898` | **docs(spec)**: TSan concurrency coverage design |
+| `69840e1e` | **docs(plan)**: implementation plan |
+| `6e1db18b` | **test(ios)**: `run-ios-tsan.sh` + extracted shared simulator resolver |
+| `57907b0f` | **test(ios)**: concurrency tests under TSan + retired docstring caveat |
+| `bcb531d7` | **ci(ios)**: path-gated macOS ThreadSanitizer job |
+| `d159ef2d` | **test(ios)**: review polish (docstring wrap + clarifying comment) |
+| `6a431ca0` | **ci(ios)**: TSan job `timeout-minutes` + `IOS_SIM` note |
+| (+ handoff commit) | this baton + retargeted `NEXT_SESSION.md` symlink |
+
+### Acceptance (verified this session — RED→GREEN, not assumed)
+```bash
+cd /Users/hherb/src/secretary/.worktrees/ios-tsan-concurrency
+bash ios/scripts/run-ios-tsan.sh   # builds xcframework, runs whole suite under TSan
+```
+- **RED (TDD teeth):** with the `lock.withLock` wrappers temporarily commented out in `UniffiVaultSession.{readBlock,wipe,write}`, `run-ios-tsan.sh` produced **6 `ThreadSanitizer: data race` reports** naming `readBlock` / `wipe()`.
+- **GREEN (lock restored):** full `SecretaryKitTests` **35/35 pass, 0 TSan races**; `run-ios-tests.sh` still `** TEST SUCCEEDED **` (32 tests) after the resolver extraction; `actionlint` clean on the workflow.
+- Final whole-branch review (opus) verified the tests *would not pass if the lock regressed* (each scenario targets a real unsynchronized site) — i.e. they genuinely guard #300.
+
+## (2) What's next
+**#300 follow-up done (PR open). Pick a fresh item.** Strongest carried/new candidates:
+- **#299** (`security`, FFI) — uniffi's generated lowering buffer for password/phrase isn't zeroized (residue beyond the adapter-owned `Data` that #229/#298 scrub). Open-ended research: may dead-end in a documented upstream-uniffi limitation in the memory-hygiene memo. #229 follow-up. **NOTE:** a parallel session appears to be working `ios-android-memory-hygiene` (a worktree + a `docs/handoffs/2026-06-25-ios-android-memory-hygiene-shipped.md` exist) — check for collision/overlap before starting #299.
+- **#290** — allowlist the 3 D.4 freshness false-positives; **still collision-risky** — `.worktrees/d4-browser-autofill` (`claude/intelligent-davinci-hriple`) was active again this session with post-merge commits.
+- **First real CI run of `ios-tsan.yml`:** confirm `macos-latest` actually has an `iPhone 16` simulator and capture observed job duration into the next baton, so the `timeout-minutes: 60` value is grounded in data (final-review recommendation #2 — not yet observable until the PR runs CI).
+
+**Acceptance criteria template for the next pick:** a failing test that reproduces the gap on `main`, the typed-error/enforcement surface *proven* not assumed (security paths, [[feedback_verify_deferred_items]]), the platform's full test gate green, and spec/`conformance.py` updated in lockstep if observable bytes/semantics change.
+
+**Open follow-up issues (carried):** #299 / #290 / #284 / #280 / #277 / #273 / #272 / #269 / #255 / #252 / #247 / #246 / #234 / #232 / #231 / #224 / #218 / #193 / #192 / #190 / #189 / #186 / #183.
+
+## (3) Open decisions and risks
+- **Separate CI workflow file over a job in `test.yml`** (documented spec deviation, final-review-endorsed): `test.yml` has no workflow-level `paths:` filter and runs all jobs on every PR, so a `paths:`-gated job can't live there without gating everything; the alternatives (inline `git diff` job-guard, or a third-party paths-filter action) are fragile/greenwash-prone and forbidden by the no-unpinned-action constraint. The separate file is the clean mechanism.
+- **Whole suite under TSan, not just the new tests** — defense-in-depth (any future race anywhere is caught); the 3 new tests are the teeth. Existing 32-test suite was already TSan-clean (0 races) → **no suppressions file needed**.
+- **`@unchecked Sendable` boxes confined to the test target** — `UncheckedBox` (immutable; the unsafety is the property under test) + `Collector` (its own `NSLock`, genuinely thread-safe). Don't widen them out of the test target.
+- **Mutual-exclusion proof is by TSan happens-before, not a deterministic interleave** — there is intentionally NO test asserting a specific race winner (that *would* be flaky). Don't add one.
+- **`vaultUuidHex` / read-only metadata stays unguarded in production** (unchanged from #304) — not in scope here.
+- **README / ROADMAP unchanged (deliberate).** Test/CI hardening with no new capability or milestone — no ROADMAP item to tick (TSan coverage was never a planned milestone), README's "session wiped on background" stays accurate. Matches the #210/#251/#229/#300 pure-hardening precedent.
+- **Risk:** none to product behavior (no production code changed). CI risk: the macOS TSan job is heavy (~5-15× slower Argon2id under TSan); `timeout-minutes: 60` bounds a pathological hang, and `IOS_SIM` overrides the sim if a future runner image drops `iPhone 16`. First real run duration is unobserved until the PR triggers CI.
+
+## (4) Exact commands to resume
+```bash
+cd /Users/hherb/src/secretary
+git fetch --prune origin && git checkout main && git pull --ff-only origin main
+# If PR merged: branch + worktree .worktrees/ios-tsan-concurrency can be removed:
+#   git worktree remove .worktrees/ios-tsan-concurrency && git branch -D test/ios-tsan-concurrency
+git worktree list && git status -s
+
+# Re-run this fix's gate (from the worktree if the PR is still open):
+cd .worktrees/ios-tsan-concurrency
+bash ios/scripts/run-ios-tsan.sh        # 35/35 GREEN, 0 TSan races
+# Focused (faster) run of just the new concurrency tests:
+SIM_ID="$(bash -c 'source ios/scripts/lib/resolve-simulator.sh; resolve_simulator "iPhone 16"')"
+cd ios/SecretaryKit && xcodebuild test -scheme SecretaryKit \
+  -destination "platform=iOS Simulator,id=$SIM_ID" \
+  -only-testing:SecretaryKitTests/SessionConcurrencyIntegrationTests
+```
+
+## (5) Handoff file model
+`NEXT_SESSION.md` is a **relative symlink** to this file in `docs/handoffs/`. Authored once here; symlink retargeted in the same commit on the feature branch. New-path handoff → no add/add conflict. Branch was cut from `origin/main` (`3cba686c`) and `origin/main` had **not** advanced at handoff time (verified: `origin/main` == merge-base == `3cba686c`), so no history-binding merge was needed.
+
+## Closing inventory
+- **State on close:** PR opening on `test/ios-tsan-concurrency` (spec `94a09898` + plan `69840e1e` + 3 task commits `6e1db18b`/`57907b0f`/`bcb531d7` + review polish `d159ef2d`/`6a431ca0` + handoff). Worktree `.worktrees/ios-tsan-concurrency`.
+- **Acceptance:** local GREEN — RED→GREEN proven (6 TSan races with lock removed → 0 with lock); full `SecretaryKitTests` 35/35; `run-ios-tests.sh` 32 tests still green post-refactor; `actionlint` clean. Final whole-branch review (opus): Ready to merge, no Critical/Important; all Minors fixed. Zero `core/` touched → conformance / Swift/Kotlin harnesses unaffected.
+- **README.md / ROADMAP.md:** unchanged (rationale in §3 — test/CI hardening, no capability/milestone change).
+- **CLAUDE.md:** unchanged.
+- **NEXT_SESSION.md:** symlink → `docs/handoffs/2026-06-25-ios-tsan-concurrency-shipped.md`.

--- a/docs/superpowers/plans/2026-06-25-ios-tsan-concurrency.md
+++ b/docs/superpowers/plans/2026-06-25-ios-tsan-concurrency.md
@@ -1,0 +1,514 @@
+# iOS `UniffiVaultSession` TSan concurrency coverage — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a TSan-verified concurrency test suite that genuinely drives `UniffiVaultSession`'s lock-protected paths (readBlock / wipe / writes) from multiple threads, plus a path-gated macOS CI job that runs the SecretaryKit suite under ThreadSanitizer — closing the "by-construction + doc-comment only" gap left by PR #304 (#300).
+
+**Architecture:** Three XCTest cases drive the session concurrently against a temp copy of `golden_vault_001`, sharing the non-`Sendable` session through an explicit `@unchecked Sendable` box. A new lean `run-ios-tsan.sh` builds the xcframework and runs the whole suite with `-enableThreadSanitizer YES`; the simulator-name→UDID resolver is extracted into a sourceable helper shared with the existing `run-ios-tests.sh`. A dedicated path-gated workflow runs it in CI.
+
+**Tech Stack:** Swift / XCTest, `xcodebuild` (iOS Simulator), ThreadSanitizer, bash, GitHub Actions.
+
+## Global Constraints
+
+- **iOS test + CI only.** No `core/` change, no `docs/crypto-design.md` / `docs/vault-format.md` change, no `conformance.py` change, no `FfiVaultError` variant, no `UniffiVaultSession` production-code change.
+- **Zero-warning bar.** Swift must compile with no concurrency / unused warnings (see [[project_secretary_ios_value_types_sendable_offload]]).
+- **No magic numbers.** Thread/iteration/session counts are named constants.
+- **Never mutate the frozen KAT.** Tests open a `cp -R` temp copy of `golden_vault_001`, never the tracked fixture ([[feedback_smoke_test_temp_copy_golden_vault]]).
+- **No unpinned third-party GitHub Action.** Reuse only actions already established in the repo (`actions/checkout@v4`, `Swatinem/rust-cache@v2`).
+- **Assertions must be timing-independent** — no-crash + count/contents that hold under any valid interleaving. Never assert a specific race outcome (that would be flaky).
+- **Golden vault password:** `correct horse battery staple` (matches the existing iOS integration tests).
+- **Default simulator:** `iPhone 16`, overridable via `IOS_SIM`.
+
+---
+
+## File Structure
+
+- **Create** `ios/scripts/lib/resolve-simulator.sh` — sourceable helper: one function resolving a simulator name to a UDID.
+- **Modify** `ios/scripts/run-ios-tests.sh` — source the helper instead of inlining the resolver (pure extraction; behavior identical).
+- **Create** `ios/scripts/run-ios-tsan.sh` — build xcframework + run whole SecretaryKit suite under TSan.
+- **Create** `ios/SecretaryKit/Tests/SecretaryKitTests/SessionConcurrencyIntegrationTests.swift` — the three concurrency tests.
+- **Modify** `ios/SecretaryKit/Tests/SecretaryKitTests/SessionWipeGuardIntegrationTests.swift` — update the docstring that claims concurrency is "not unit-tested".
+- **Create** `.github/workflows/ios-tsan.yml` — path-gated macOS TSan job.
+
+> **Spec deviation (documented):** the spec placed the CI job "in `test.yml`". The plan uses a **separate workflow file** instead, because workflow-level `paths:` filtering is the only clean, no-third-party-action way to path-gate this one heavy macOS job without also gating `test.yml`'s rust/desktop/conformance jobs (which must run on every PR). Same constraints, cleaner mechanism.
+
+---
+
+### Task 1: Extract the simulator resolver + add the TSan runner script
+
+**Files:**
+- Create: `ios/scripts/lib/resolve-simulator.sh`
+- Modify: `ios/scripts/run-ios-tests.sh:31-61` (replace the inlined resolver block with a `source` + call)
+- Create: `ios/scripts/run-ios-tsan.sh`
+
+**Interfaces:**
+- Produces: `resolve_simulator <sim-name>` — bash function; echoes the resolved UDID on stdout; on no match prints the available-device list to stderr and `return 2`.
+- Consumes: existing `ios/scripts/build-xcframework.sh` (builds the xcframework + stages `golden_vault_001`).
+
+- [ ] **Step 1: Create the resolver helper**
+
+Create `ios/scripts/lib/resolve-simulator.sh`:
+
+```bash
+#!/usr/bin/env bash
+# Resolve an iOS simulator *name* to a concrete UDID. Sourced by run-ios-tests.sh
+# and run-ios-tsan.sh so the resolution logic lives in exactly one place.
+#
+# Usage:  source .../lib/resolve-simulator.sh; SIM_ID="$(resolve_simulator 'iPhone 16')"
+# Echoes the UDID on stdout. On no match it prints the available-device list to
+# stderr and returns 2 — the caller, under `set -e` with command substitution,
+# aborts. (Bash note: `SIM_ID="$(resolve_simulator …)"` does propagate a non-zero
+# return under `set -e`.)
+resolve_simulator() {
+    local sim_name="$1"
+    local devices sim_id
+    # Capture the device list ONCE: a genuine `simctl` failure aborts here under
+    # `set -e` rather than being swallowed by the `|| true` below and misreported
+    # as a missing device. The `|| true` then guards ONLY the grep pipeline, where
+    # a no-match is legitimately empty.
+    devices="$(xcrun simctl list devices available)"
+    # Anchor the match to "<name> (" so "iPhone 16" does not also match
+    # "iPhone 16 Pro" / "iPhone 16 Plus" / "iPhone 16e". `head -1` takes the first
+    # matching device regardless of runtime (simctl groups by runtime); it assumes
+    # every installed runtime is >= the Package.swift deployment floor (iOS 17).
+    # NB: $sim_name is interpolated into an ERE — fine for real device names, which
+    # contain no regex metacharacters.
+    sim_id="$(printf '%s\n' "$devices" \
+        | grep -E "^[[:space:]]*${sim_name} \(" \
+        | head -1 \
+        | grep -oE '[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}' || true)"
+    if [[ -z "$sim_id" ]]; then
+        echo "ERROR: no available simulator named '$sim_name'. Available devices:" >&2
+        printf '%s\n' "$devices" >&2
+        echo "Set IOS_SIM to one of the device names listed above." >&2
+        return 2
+    fi
+    printf '%s\n' "$sim_id"
+}
+```
+
+- [ ] **Step 2: Refactor `run-ios-tests.sh` to use the helper**
+
+Replace the current Step-3 block in `ios/scripts/run-ios-tests.sh` (lines 31-61, the `# --- Step 3: resolve the simulator name to a concrete UDID ---` comment through the closing `echo "    -> $SIM_ID"`) with:
+
+```bash
+# --- Step 3: resolve the simulator name to a concrete UDID ---
+echo "==> resolving simulator: $SIM_NAME"
+# shellcheck source=lib/resolve-simulator.sh
+source "$SCRIPT_DIR/lib/resolve-simulator.sh"
+SIM_ID="$(resolve_simulator "$SIM_NAME")"
+echo "    -> $SIM_ID"
+```
+
+Leave all other steps (1, 2, 4, 5) of `run-ios-tests.sh` unchanged.
+
+- [ ] **Step 3: Create the TSan runner**
+
+Create `ios/scripts/run-ios-tsan.sh`:
+
+```bash
+#!/usr/bin/env bash
+# TSan acceptance entry point (#300 follow-up): build the Secretary.xcframework,
+# then run the full SecretaryKit XCTest suite under ThreadSanitizer on an iOS
+# simulator. The SessionConcurrencyIntegrationTests are the teeth — they drive
+# UniffiVaultSession's readBlock/wipe/writes concurrently, so TSan flags any
+# unsynchronized access to its mutable state (the #300 lock).
+#
+# Run from anywhere — paths resolve relative to this script.
+# Override the simulator with IOS_SIM, e.g.  IOS_SIM='iPhone 15' run-ios-tsan.sh
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+IOS_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+PKG_DIR="$IOS_DIR/SecretaryKit"
+SIM_NAME="${IOS_SIM:-iPhone 16}"
+
+# --- Step 1: build the framework + stage fixtures (golden_vault_001) ---
+echo "==> build-xcframework.sh"
+bash "$SCRIPT_DIR/build-xcframework.sh"
+
+# --- Step 2: resolve the simulator name to a concrete UDID ---
+echo "==> resolving simulator: $SIM_NAME"
+# shellcheck source=lib/resolve-simulator.sh
+source "$SCRIPT_DIR/lib/resolve-simulator.sh"
+SIM_ID="$(resolve_simulator "$SIM_NAME")"
+echo "    -> $SIM_ID"
+
+# --- Step 3: run the whole suite under ThreadSanitizer ---
+# -enableThreadSanitizer YES instruments the Swift build. The uniffi Rust dylib is
+# opaque to TSan (calls into it carry no happens-before), which is fine: the races
+# #300 guards are on Swift-side mutable stored properties (currentBlock / wiped /
+# cachedDeviceUuid), which NSLock (TSan-aware) synchronizes. xcodebuild's exit
+# status is the acceptance result; it is the last command, so `set -e` propagates a
+# non-zero test/TSan failure as this script's exit code.
+echo "==> xcodebuild test -enableThreadSanitizer YES (simulator: $SIM_NAME / $SIM_ID)"
+cd "$PKG_DIR"
+xcodebuild test -scheme SecretaryKit \
+    -destination "platform=iOS Simulator,id=$SIM_ID" \
+    -enableThreadSanitizer YES
+```
+
+- [ ] **Step 4: Make the new scripts executable**
+
+Run:
+```bash
+chmod +x ios/scripts/lib/resolve-simulator.sh ios/scripts/run-ios-tsan.sh
+```
+
+- [ ] **Step 5: Verify the resolver function in isolation (fast)**
+
+Run (from repo root):
+```bash
+bash -c 'set -e; source ios/scripts/lib/resolve-simulator.sh; resolve_simulator "iPhone 16"'
+```
+Expected: prints a single UDID line (e.g. `A1B2C3D4-...`). If it prints the device list + a non-zero exit, set `IOS_SIM` to an available device name and retry.
+
+- [ ] **Step 6: Verify `run-ios-tests.sh` still works after the refactor**
+
+Run:
+```bash
+bash ios/scripts/run-ios-tests.sh
+```
+Expected: same behavior as before — host swift tests pass, xcframework builds, `xcodebuild test` reports `** TEST SUCCEEDED **` (32 tests), app builds. (This is the regression check for the pure extraction.)
+
+- [ ] **Step 7: Verify the existing suite is TSan-clean (before adding new tests)**
+
+Run:
+```bash
+bash ios/scripts/run-ios-tsan.sh
+```
+Expected: `** TEST SUCCEEDED **` with **no** `ThreadSanitizer: data race` lines in the output.
+**Contingency:** if TSan reports a race originating in the uninstrumented Rust dylib or a system framework (not in `SecretaryKit` Swift code), add a narrowly-scoped, commented suppressions file `ios/SecretaryKit/Tests/SecretaryKitTests/Resources/tsan-suppressions.txt` and pass it via `TSAN_OPTIONS=suppressions=...` in `run-ios-tsan.sh` (stage it like the golden vault if it must be bundled). Resolve every report explicitly — real Swift-side race vs. opaque-FFI false positive; do NOT blanket-suppress. If the existing suite is clean, skip this contingency.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add ios/scripts/lib/resolve-simulator.sh ios/scripts/run-ios-tests.sh ios/scripts/run-ios-tsan.sh
+git commit -m "test(ios): add run-ios-tsan.sh + extract shared simulator resolver (#300)"
+```
+
+---
+
+### Task 2: Concurrency tests + retire the "not unit-tested" caveat
+
+**Files:**
+- Create: `ios/SecretaryKit/Tests/SecretaryKitTests/SessionConcurrencyIntegrationTests.swift`
+- Modify: `ios/SecretaryKit/Tests/SecretaryKitTests/SessionWipeGuardIntegrationTests.swift` (docstring only)
+- Test: the file itself; run via `xcodebuild test`.
+
+**Interfaces:**
+- Consumes (existing SecretaryKit API): `SecretaryKit.openVaultWithPassword(folderPath: Data, password: Data) -> OpenVaultOutput`; `UniffiVaultSession(output:deviceUuids:)`; `UniffiVaultSession.blockSummaries() -> [BlockSummary]` (each `.uuid: [UInt8]`); `readBlock(blockUuid: [UInt8], includeDeleted: Bool) throws -> [RecordView]` (each `.uuid: [UInt8]`); `appendRecord(blockUuid: [UInt8], content: RecordContentInput) throws -> [UInt8]`; `wipe()`; `RecordContentInput(recordType:tags:fields:)`; `FieldContentInput(name:value:)` with `.text(String)`; `DeviceUuidProviding`.
+- Produces: nothing consumed by later tasks.
+
+- [ ] **Step 1: Write the concurrency test file**
+
+Create `ios/SecretaryKit/Tests/SecretaryKitTests/SessionConcurrencyIntegrationTests.swift`:
+
+```swift
+import XCTest
+@testable import SecretaryKit
+import SecretaryVaultAccess
+
+/// #300 concurrency coverage: drive `UniffiVaultSession`'s lock-protected paths
+/// (readBlock / wipe / writes) from multiple threads at once. Run under
+/// ThreadSanitizer (`ios/scripts/run-ios-tsan.sh`) these prove the `NSLock` +
+/// `wiped` guard actually serialize access to the mutable stored properties
+/// `currentBlock`, `wiped`, and `cachedDeviceUuid`: with the lock TSan sees a clean
+/// happens-before; remove the lock and TSan reports a data race here. Assertions are
+/// deliberately timing-independent (no-crash + count/contents that hold under any
+/// interleaving), so the tests are NOT flaky — only race *detection*, which TSan
+/// does deterministically.
+///
+/// Opens a temp copy of the frozen `golden_vault_001` KAT (never mutates the
+/// original), mirroring `SessionWipeGuardIntegrationTests`.
+final class SessionConcurrencyIntegrationTests: XCTestCase {
+    private let goldenPassword = "correct horse battery staple"
+    private var vaultCopy: URL!
+
+    /// Concurrent worker threads per scenario — large enough that accesses reliably
+    /// overlap, small enough to keep the (TSan-slowed) run quick.
+    private static let concurrentWorkers = 8
+    /// Fresh sessions for the read-vs-wipe scenario: each session's `wipe()` is
+    /// terminal, so every concurrent read-vs-wipe sample needs its own session.
+    private static let wipeRaceSessions = 4
+
+    /// Shares a non-`Sendable` value across threads. The unsafety is the POINT under
+    /// test: `UniffiVaultSession`'s lock is what makes the concurrent access
+    /// race-free. Confined to this test target.
+    private final class UncheckedBox<T>: @unchecked Sendable {
+        let value: T
+        init(_ value: T) { self.value = value }
+    }
+
+    /// Thread-safe accumulator for results gathered across worker threads.
+    private final class Collector<T>: @unchecked Sendable {
+        private var items: [T] = []
+        private let lock = NSLock()
+        func add(_ item: T) { lock.withLock { items.append(item) } }
+        var snapshot: [T] { lock.withLock { items } }
+    }
+
+    private struct FixedDeviceUuid: DeviceUuidProviding {
+        let value: [UInt8]
+        func deviceUuid(forVaultHex vaultHex: String) throws -> [UInt8] { value }
+    }
+
+    override func setUpWithError() throws {
+        let bundled = try XCTUnwrap(
+            Bundle.module.url(forResource: "golden_vault_001", withExtension: nil),
+            "golden_vault_001 not bundled — run ios/scripts/build-xcframework.sh")
+        let tmp = FileManager.default.temporaryDirectory
+            .appendingPathComponent("gv-concurrency-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: tmp, withIntermediateDirectories: true)
+        vaultCopy = tmp.appendingPathComponent("golden_vault_001", isDirectory: true)
+        try FileManager.default.copyItem(at: bundled, to: vaultCopy)
+    }
+
+    override func tearDownWithError() throws {
+        if let vaultCopy {
+            try? FileManager.default.removeItem(at: vaultCopy.deletingLastPathComponent())
+        }
+    }
+
+    private func openSession() throws -> UniffiVaultSession {
+        let out = try SecretaryKit.openVaultWithPassword(
+            folderPath: Data(vaultCopy.path.utf8), password: Data(goldenPassword.utf8))
+        return UniffiVaultSession(
+            output: out, deviceUuids: FixedDeviceUuid(value: [UInt8](repeating: 0x5A, count: 16)))
+    }
+
+    private func firstBlockUuid(_ session: UniffiVaultSession) throws -> [UInt8] {
+        try XCTUnwrap(session.blockSummaries().first).uuid
+    }
+
+    /// Concurrent reads of the same block are race-free. Exercises the `currentBlock`
+    /// evict-and-replace path under contention; every read sees the same fully
+    /// decoded block as a single-threaded read.
+    func testConcurrentReadsAreRaceFree() throws {
+        let session = try openSession()
+        let block = try firstBlockUuid(session)
+        let baseline = try session.readBlock(blockUuid: block, includeDeleted: false).count
+        let box = UncheckedBox(session)
+        let blockBox = UncheckedBox(block)
+        DispatchQueue.concurrentPerform(iterations: Self.concurrentWorkers) { _ in
+            let records = (try? box.value.readBlock(blockUuid: blockBox.value, includeDeleted: false)) ?? []
+            XCTAssertEqual(records.count, baseline, "a concurrent read saw a different record count")
+        }
+    }
+
+    /// Concurrent reads racing one `wipe()` must not crash. Each read either returns
+    /// records, returns empty, or throws — all valid open/closed outcomes. The
+    /// assertion is reaching the end without a crash or a TSan report on the
+    /// `currentBlock`/`wiped` race.
+    func testConcurrentReadAndWipeAreRaceFree() throws {
+        for _ in 0..<Self.wipeRaceSessions {
+            let session = try openSession()
+            let block = try firstBlockUuid(session)
+            let box = UncheckedBox(session)
+            let blockBox = UncheckedBox(block)
+            let group = DispatchGroup()
+            let queue = DispatchQueue(label: "secretary.concurrency.readwipe", attributes: .concurrent)
+            for _ in 0..<Self.concurrentWorkers {
+                queue.async(group: group) {
+                    _ = try? box.value.readBlock(blockUuid: blockBox.value, includeDeleted: false)
+                }
+            }
+            queue.async(group: group) { box.value.wipe() }
+            group.wait()
+        }
+    }
+
+    /// Concurrent writes are race-free and all land. Exercises `write()`
+    /// serialization + the first-write `cachedDeviceUuid` memoization; every appended
+    /// record is present on a final single-threaded read.
+    func testConcurrentWritesAreRaceFree() throws {
+        let session = try openSession()
+        let block = try firstBlockUuid(session)
+        let box = UncheckedBox(session)
+        let blockBox = UncheckedBox(block)
+        let appended = Collector<Data>()
+        DispatchQueue.concurrentPerform(iterations: Self.concurrentWorkers) { i in
+            let content = RecordContentInput(
+                recordType: "login", tags: ["concurrent"],
+                fields: [FieldContentInput(name: "idx", value: .text("\(i)"))])
+            if let uuid = try? box.value.appendRecord(blockUuid: blockBox.value, content: content) {
+                appended.add(Data(uuid))
+            }
+        }
+        let got = appended.snapshot
+        XCTAssertEqual(got.count, Self.concurrentWorkers, "every concurrent append must succeed")
+        let records = try session.readBlock(blockUuid: block, includeDeleted: false)
+        let present = Set(records.map { Data($0.uuid) })
+        for uuid in got {
+            XCTAssertTrue(present.contains(uuid), "an appended record was missing after concurrent writes")
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Run the new tests (normal build) to confirm they pass**
+
+Run:
+```bash
+SIM_ID="$(bash -c 'source ios/scripts/lib/resolve-simulator.sh; resolve_simulator "iPhone 16"')"
+cd ios/SecretaryKit
+xcodebuild test -scheme SecretaryKit -destination "platform=iOS Simulator,id=$SIM_ID" \
+  -only-testing:SecretaryKitTests/SessionConcurrencyIntegrationTests
+cd ../..
+```
+Expected: `** TEST SUCCEEDED **`, 3 tests pass. (They pass because the #304 lock is present; this confirms the tests are correct and don't deadlock/crash.)
+
+- [ ] **Step 3: Prove the tests have teeth (TDD red, under TSan)**
+
+Temporarily neuter the lock to confirm TSan flags the race. In `ios/SecretaryKit/Sources/SecretaryKit/VaultAccess/UniffiVaultSession.swift`, comment out the `lock.withLock {` wrappers in `readBlock`, `wipe`, and `write` (and their matching closing braces) so the bodies run unguarded. Then run:
+```bash
+bash ios/scripts/run-ios-tsan.sh 2>&1 | tee /tmp/tsan-red.log
+grep -c "ThreadSanitizer: data race" /tmp/tsan-red.log
+```
+Expected: one or more `ThreadSanitizer: data race` reports naming `UniffiVaultSession` / `currentBlock` / `wiped` / `cachedDeviceUuid` (count ≥ 1), and/or a crash. **Capture this output for the handoff** (evidence the tests have teeth).
+
+- [ ] **Step 4: Restore the lock and confirm green under TSan**
+
+`git checkout ios/SecretaryKit/Sources/SecretaryKit/VaultAccess/UniffiVaultSession.swift` to undo the temporary edit, then:
+```bash
+bash ios/scripts/run-ios-tsan.sh 2>&1 | tee /tmp/tsan-green.log
+grep -c "ThreadSanitizer: data race" /tmp/tsan-green.log   # expect 0
+```
+Expected: `** TEST SUCCEEDED **`, full suite (35 tests) passes, **zero** `ThreadSanitizer: data race` lines.
+
+- [ ] **Step 5: Update the wipe-guard docstring**
+
+In `ios/SecretaryKit/Tests/SecretaryKitTests/SessionWipeGuardIntegrationTests.swift`, replace the docstring sentence:
+
+```swift
+/// The lock's mutual exclusion under genuine concurrency is
+/// by-construction + documented (not unit-tested — a deterministic interleave would
+/// need an injected mid-read seam; a stress test would be flaky).
+```
+
+with:
+
+```swift
+/// The lock's mutual exclusion under genuine concurrency is exercised separately by
+/// `SessionConcurrencyIntegrationTests` (run under ThreadSanitizer via
+/// `ios/scripts/run-ios-tsan.sh`); this file covers the single-threaded `wiped`-guard
+/// semantics.
+```
+
+- [ ] **Step 6: Re-run the full suite (normal build) to confirm no regression**
+
+Run:
+```bash
+SIM_ID="$(bash -c 'source ios/scripts/lib/resolve-simulator.sh; resolve_simulator "iPhone 16"')"
+cd ios/SecretaryKit
+xcodebuild test -scheme SecretaryKit -destination "platform=iOS Simulator,id=$SIM_ID"
+cd ../..
+```
+Expected: `** TEST SUCCEEDED **`, 35 tests (32 existing + 3 new).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add ios/SecretaryKit/Tests/SecretaryKitTests/SessionConcurrencyIntegrationTests.swift \
+        ios/SecretaryKit/Tests/SecretaryKitTests/SessionWipeGuardIntegrationTests.swift
+git commit -m "test(ios): concurrency tests for UniffiVaultSession lock under TSan (#300)"
+```
+
+---
+
+### Task 3: Path-gated macOS TSan CI job
+
+**Files:**
+- Create: `.github/workflows/ios-tsan.yml`
+
+**Interfaces:**
+- Consumes: `ios/scripts/run-ios-tsan.sh` (Task 1).
+- Produces: nothing.
+
+- [ ] **Step 1: Write the workflow**
+
+Create `.github/workflows/ios-tsan.yml`:
+
+```yaml
+name: iOS TSan
+
+# #300 follow-up: run the SecretaryKit XCTest suite under ThreadSanitizer so the
+# UniffiVaultSession lock is exercised under genuine concurrency
+# (SessionConcurrencyIntegrationTests). macOS-only and heavy (builds the uniffi
+# xcframework, then runs the suite instrumented), so it is path-gated to iOS
+# changes. A separate workflow file is the cleanest no-third-party-action way to
+# scope this without gating test.yml's rust/desktop/conformance jobs (which must
+# run on every PR).
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'ios/**'
+      - '.github/workflows/ios-tsan.yml'
+  pull_request:
+    paths:
+      - 'ios/**'
+      - '.github/workflows/ios-tsan.yml'
+
+concurrency:
+  group: ios-tsan-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  ios-tsan:
+    name: SecretaryKit ThreadSanitizer
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Cache cargo build
+        uses: Swatinem/rust-cache@v2
+      # Builds the uniffi xcframework (compiles the Rust core for the iOS-sim
+      # target) then runs the whole SecretaryKit suite under -enableThreadSanitizer.
+      - name: SecretaryKit suite under ThreadSanitizer
+        run: bash ios/scripts/run-ios-tsan.sh
+```
+
+- [ ] **Step 2: Validate the workflow YAML**
+
+Run (uses the pinned actionlint container; no global install):
+```bash
+docker run --rm -v "$(pwd):/repo" --workdir /repo rhysd/actionlint:latest -color .github/workflows/ios-tsan.yml
+```
+Expected: no errors. If `docker` is unavailable, instead confirm valid YAML:
+```bash
+python3 -c "import yaml,sys; yaml.safe_load(open('.github/workflows/ios-tsan.yml')); print('ok')"
+```
+Expected: `ok`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .github/workflows/ios-tsan.yml
+git commit -m "ci(ios): path-gated macOS ThreadSanitizer job for SecretaryKit (#300)"
+```
+
+---
+
+## Self-Review
+
+**1. Spec coverage:**
+- Concurrency tests (reads / read+wipe / writes) → Task 2, Step 1. ✓
+- `@unchecked Sendable` box → Task 2 (`UncheckedBox`). ✓
+- Timing-independent assertions → Task 2 (count/contents/no-crash only). ✓
+- No magic numbers → Task 2 (`concurrentWorkers`, `wipeRaceSessions` constants). ✓
+- Temp-copy golden vault → Task 2 (`setUpWithError` `copyItem`). ✓
+- `run-ios-tsan.sh` whole suite under TSan → Task 1, Step 3. ✓
+- Extracted shared resolver → Task 1, Steps 1-2. ✓
+- Path-gated CI, no unpinned third-party action → Task 3. ✓
+- TDD red→green proof → Task 2, Steps 3-4. ✓
+- Docstring update → Task 2, Step 5. ✓
+- README/ROADMAP/spec/conformance untouched → Global Constraints + no task touches them. ✓
+- TSan-suppressions contingency for FFI false positives → Task 1, Step 7 contingency. ✓
+
+**2. Placeholder scan:** No TBD/TODO/"add error handling"/"similar to" — all steps carry concrete code/commands. ✓
+
+**3. Type consistency:** `resolve_simulator` used identically in both scripts; `UncheckedBox`/`Collector` defined and used within one file; `RecordView.uuid: [UInt8]` and `appendRecord -> [UInt8]` both bridged via `Data(...)` for the `Set<Data>` membership check; `concurrentWorkers`/`wipeRaceSessions` referenced exactly as named. ✓

--- a/docs/superpowers/specs/2026-06-25-ios-tsan-concurrency-design.md
+++ b/docs/superpowers/specs/2026-06-25-ios-tsan-concurrency-design.md
@@ -1,0 +1,148 @@
+# iOS `UniffiVaultSession` TSan concurrency coverage — design
+
+**Date:** 2026-06-25
+**Issue:** #300 follow-up (TSan depth — flagged in the #300 handoff as an optional, unfiled follow-up).
+**Scope:** iOS test + CI only. **No** Rust-core / on-disk-format / spec / `conformance.py` change; **no** `UniffiVaultSession` production-code change.
+
+## Problem
+
+PR #304 (#300) made `UniffiVaultSession` thread-safe by serializing every touch of
+its mutable FFI-adjacent state under an `NSLock` plus a `wiped` flag (mirror of the
+Android session, #250). But that mutual-exclusion property is currently asserted
+**by construction and by doc-comment only** — the existing
+`SessionWipeGuardIntegrationTests` exercises the `wiped`-guard semantics on a single
+thread and its own docstring states the concurrency property is "not unit-tested …
+a stress test would be flaky."
+
+That leaves a gap: nothing actually drives the lock under genuine concurrency, so a
+future change that drops or narrows the lock (e.g. a new off-actor `wipe()` caller)
+could reintroduce the race with the suite still green.
+
+## Why a concurrency test is *not* flaky here
+
+ThreadSanitizer detects data races via happens-before tracking, not by observing a
+race manifest as corruption. `NSLock` is TSan-aware, so:
+
+- **With** the lock, TSan sees a clean happens-before edge between any two critical
+  sections → no report.
+- **Without** the lock, TSan flags the unsynchronized accesses to the three
+  **mutable stored properties** the lock protects — `currentBlock`, `wiped`,
+  `cachedDeviceUuid` — regardless of the exact interleaving.
+
+The flakiness the #300 handoff worried about comes only from asserting a *specific
+timing-dependent outcome* (e.g. "wipe definitely won the race"). This design asserts
+**only** timing-independent invariants (no crash, TSan-clean, plus a count/contents
+check that holds under any valid interleaving). The FFI handles `identity`/`manifest`
+are immutable `let`s — reading them from two threads is not a Swift-level race — so
+they are not the subject under test; the three mutable stored properties are.
+
+## Deliverables
+
+### 1. Concurrency tests — `SessionConcurrencyIntegrationTests.swift`
+
+New file under `ios/SecretaryKit/Tests/SecretaryKitTests/`, reusing the
+temp-copy-of-`golden_vault_001` harness pattern from
+`SessionWipeGuardIntegrationTests` (never mutates the frozen KAT — see
+[[feedback_smoke_test_temp_copy_golden_vault]]). Three tests, each asserting only
+timing-independent invariants:
+
+1. **`testConcurrentReadsAreRaceFree`** — N threads call `readBlock` on the same
+   block concurrently. Exercises the `currentBlock` evict-and-replace path
+   (`currentBlock?.wipe(); currentBlock = out`). Assert: every read returns the same
+   record count as a single-threaded baseline; no throw; no crash.
+   *Without the lock:* `currentBlock` write/write race + a double `BlockReadOutput.wipe()`
+   (use-after-free) → TSan report and/or crash.
+
+2. **`testConcurrentReadAndWipeAreRaceFree`** — across M fresh sessions, several
+   reader threads run concurrently with one `wipe()` on each session. Exercises the
+   `currentBlock` + `wiped` race. Assert: no crash; each read either returns records,
+   returns empty, or throws a typed error (all are valid open/closed outcomes).
+   *Without the lock:* `currentBlock`/`wiped` read-write race → TSan report.
+
+3. **`testConcurrentWritesAreRaceFree`** — N threads call `appendRecord`
+   concurrently on one session. Exercises the `write()` serialization and the
+   first-write `cachedDeviceUuid` memoization. Assert: no crash; a final
+   single-threaded read shows exactly the N appended records.
+   *Without the lock:* `cachedDeviceUuid` write/write race + concurrent FFI writes →
+   TSan report.
+
+**Sharing the non-`Sendable` session across threads:** an explicit
+`@unchecked Sendable` box (a tiny `final class` holding the session), documented as
+the deliberate bypass — the entire point under test is that the lock makes this
+otherwise-unsafe sharing safe. This keeps the project's zero-warning bar
+(see [[project_secretary_ios_value_types_sendable_offload]]) instead of tripping
+Swift 6 concurrency diagnostics on a raw capture.
+
+**No magic numbers:** thread/iteration counts are named constants — modest enough to
+keep the normal (non-TSan) suite fast, large enough that concurrent accesses reliably
+overlap.
+
+### 2. Scripts — `run-ios-tsan.sh` + extracted simulator resolver
+
+- **`ios/scripts/lib/resolve-simulator.sh`** (new) — a sourceable helper exposing one
+  function that resolves a simulator *name* to a concrete UDID (echoes the UDID, or
+  exits non-zero with the available-device list). This is the ~20-line block currently
+  inlined in `run-ios-tests.sh`, extracted verbatim so both scripts share one
+  implementation (prefer pure, reusable units — see [[feedback_pure_functions]]).
+
+- **`ios/scripts/run-ios-tests.sh`** (modified) — source the helper instead of
+  inlining the resolver. Behavior identical; this is a pure extraction.
+
+- **`ios/scripts/run-ios-tsan.sh`** (new) — single responsibility: build the
+  xcframework (`build-xcframework.sh`), resolve the simulator via the shared helper,
+  then `xcodebuild test -scheme SecretaryKit -destination "…,id=$SIM_ID"
+  -enableThreadSanitizer YES` over the **whole** `SecretaryKitTests` suite
+  (defense-in-depth — any future race anywhere is caught, and the three new tests are
+  the teeth). It does **not** run the host-only `swift test` packages or build the app
+  (no concurrency to instrument; already covered by `run-ios-tests.sh`). Honors the
+  same `IOS_SIM` override.
+
+### 3. CI job — `ios-tsan` in `.github/workflows/test.yml`
+
+- `runs-on: macos-latest`; `actions/checkout@v4`; `Swatinem/rust-cache@v2`; then
+  `bash ios/scripts/run-ios-tsan.sh`.
+- **Path-gated to `ios/**` (plus the workflow file).** A workflow-level `paths:`
+  filter is unsuitable — the other jobs (rust/desktop/conformance) must still run on
+  non-iOS PRs. Instead a lightweight guard makes the job a no-op when no iOS files
+  changed, implemented **without an unpinned third-party action** (consistent with the
+  repo's existing stance — cf. the kotlin-conformance snap comment), e.g. an inline
+  `git diff --name-only` guard step whose output gates the heavy steps. Exact
+  mechanism finalized in the plan; the constraint is: no unpinned third-party action,
+  and the job must not fire on PRs that don't touch `ios/**`.
+
+## TDD red→green proof
+
+The lock already exists (#304 merged), so "red" is demonstrated by temporarily
+reverting it in the worktree: comment out the `lock.withLock { … }` wrappers in
+`UniffiVaultSession`, run `run-ios-tsan.sh`, and capture the TSan data-race report
+(and/or crash) on `currentBlock` / `wiped` / `cachedDeviceUuid`. Restore the lock →
+green (TSan-clean, full suite passes). The actual red output is recorded in the
+handoff as evidence the tests have teeth (see [[feedback_verify_deferred_items]] —
+prove enforcement, don't assume it).
+
+## Docs
+
+- Update the `SessionWipeGuardIntegrationTests` docstring that claims concurrency is
+  "not unit-tested … a stress test would be flaky" → reference the new TSan-verified
+  tests.
+- **README.md / ROADMAP.md: no change** — this adds test/CI coverage, not a capability
+  or milestone (same rationale as the #300 pure-hardening work).
+- **Spec / `conformance.py`: untouched** — zero `core/` change, no observable
+  byte/semantic change, no `FfiVaultError` variant.
+
+## Risks
+
+- **TSan false positives from the uninstrumented Rust dylib / system frameworks.** If
+  the suite isn't TSan-clean out of the box, add a narrowly-scoped, commented
+  `TSAN_OPTIONS=suppressions=…` file rather than weakening TSan. Resolve any report
+  explicitly (real Swift-side race vs. opaque-FFI false positive) — do not blanket-
+  suppress.
+- **CI time.** The Argon2id open (m=256 MiB) runs ~5–15× slower under TSan; expected
+  to stay within runner limits, but watch the job duration on first run.
+
+## Out of scope (YAGNI)
+
+- No change to `UniffiVaultSession` production code.
+- No Android-side TSan (Kotlin equivalent is a separate concern).
+- No app build under TSan.
+- No stress test that asserts a specific interleaving outcome (that *would* be flaky).

--- a/ios/SecretaryKit/Tests/SecretaryKitTests/SessionConcurrencyIntegrationTests.swift
+++ b/ios/SecretaryKit/Tests/SecretaryKitTests/SessionConcurrencyIntegrationTests.swift
@@ -1,0 +1,139 @@
+import XCTest
+@testable import SecretaryKit
+import SecretaryVaultAccess
+
+/// #300 concurrency coverage: drive `UniffiVaultSession`'s lock-protected paths
+/// (readBlock / wipe / writes) from multiple threads at once. Run under
+/// ThreadSanitizer (`ios/scripts/run-ios-tsan.sh`) these prove the `NSLock` +
+/// `wiped` guard actually serialize access to the mutable stored properties
+/// `currentBlock`, `wiped`, and `cachedDeviceUuid`: with the lock TSan sees a clean
+/// happens-before; remove the lock and TSan reports a data race here. Assertions are
+/// deliberately timing-independent (no-crash + count/contents that hold under any
+/// interleaving), so the tests are NOT flaky — only race *detection*, which TSan
+/// does deterministically.
+///
+/// Opens a temp copy of the frozen `golden_vault_001` KAT (never mutates the
+/// original), mirroring `SessionWipeGuardIntegrationTests`.
+final class SessionConcurrencyIntegrationTests: XCTestCase {
+    private let goldenPassword = "correct horse battery staple"
+    private var vaultCopy: URL!
+
+    /// Concurrent worker threads per scenario — large enough that accesses reliably
+    /// overlap, small enough to keep the (TSan-slowed) run quick.
+    private static let concurrentWorkers = 8
+    /// Fresh sessions for the read-vs-wipe scenario: each session's `wipe()` is
+    /// terminal, so every concurrent read-vs-wipe sample needs its own session.
+    private static let wipeRaceSessions = 4
+
+    /// Shares a non-`Sendable` value across threads. The unsafety is the POINT under
+    /// test: `UniffiVaultSession`'s lock is what makes the concurrent access
+    /// race-free. Confined to this test target.
+    private final class UncheckedBox<T>: @unchecked Sendable {
+        let value: T
+        init(_ value: T) { self.value = value }
+    }
+
+    /// Thread-safe accumulator for results gathered across worker threads.
+    private final class Collector<T>: @unchecked Sendable {
+        private var items: [T] = []
+        private let lock = NSLock()
+        func add(_ item: T) { lock.withLock { items.append(item) } }
+        var snapshot: [T] { lock.withLock { items } }
+    }
+
+    private struct FixedDeviceUuid: DeviceUuidProviding {
+        let value: [UInt8]
+        func deviceUuid(forVaultHex vaultHex: String) throws -> [UInt8] { value }
+    }
+
+    override func setUpWithError() throws {
+        let bundled = try XCTUnwrap(
+            Bundle.module.url(forResource: "golden_vault_001", withExtension: nil),
+            "golden_vault_001 not bundled — run ios/scripts/build-xcframework.sh")
+        let tmp = FileManager.default.temporaryDirectory
+            .appendingPathComponent("gv-concurrency-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: tmp, withIntermediateDirectories: true)
+        vaultCopy = tmp.appendingPathComponent("golden_vault_001", isDirectory: true)
+        try FileManager.default.copyItem(at: bundled, to: vaultCopy)
+    }
+
+    override func tearDownWithError() throws {
+        if let vaultCopy {
+            try? FileManager.default.removeItem(at: vaultCopy.deletingLastPathComponent())
+        }
+    }
+
+    private func openSession() throws -> UniffiVaultSession {
+        let out = try SecretaryKit.openVaultWithPassword(
+            folderPath: Data(vaultCopy.path.utf8), password: Data(goldenPassword.utf8))
+        return UniffiVaultSession(
+            output: out, deviceUuids: FixedDeviceUuid(value: [UInt8](repeating: 0x5A, count: 16)))
+    }
+
+    private func firstBlockUuid(_ session: UniffiVaultSession) throws -> [UInt8] {
+        try XCTUnwrap(session.blockSummaries().first).uuid
+    }
+
+    /// Concurrent reads of the same block are race-free. Exercises the `currentBlock`
+    /// evict-and-replace path under contention; every read sees the same fully
+    /// decoded block as a single-threaded read.
+    func testConcurrentReadsAreRaceFree() throws {
+        let session = try openSession()
+        let block = try firstBlockUuid(session)
+        let baseline = try session.readBlock(blockUuid: block, includeDeleted: false).count
+        let box = UncheckedBox(session)
+        let blockBox = UncheckedBox(block)
+        DispatchQueue.concurrentPerform(iterations: Self.concurrentWorkers) { _ in
+            let records = (try? box.value.readBlock(blockUuid: blockBox.value, includeDeleted: false)) ?? []
+            XCTAssertEqual(records.count, baseline, "a concurrent read saw a different record count")
+        }
+    }
+
+    /// Concurrent reads racing one `wipe()` must not crash. Each read either returns
+    /// records, returns empty, or throws — all valid open/closed outcomes. The
+    /// assertion is reaching the end without a crash or a TSan report on the
+    /// `currentBlock`/`wiped` race.
+    func testConcurrentReadAndWipeAreRaceFree() throws {
+        for _ in 0..<Self.wipeRaceSessions {
+            let session = try openSession()
+            let block = try firstBlockUuid(session)
+            let box = UncheckedBox(session)
+            let blockBox = UncheckedBox(block)
+            let group = DispatchGroup()
+            let queue = DispatchQueue(label: "secretary.concurrency.readwipe", attributes: .concurrent)
+            for _ in 0..<Self.concurrentWorkers {
+                queue.async(group: group) {
+                    _ = try? box.value.readBlock(blockUuid: blockBox.value, includeDeleted: false)
+                }
+            }
+            queue.async(group: group) { box.value.wipe() }
+            group.wait()
+        }
+    }
+
+    /// Concurrent writes are race-free and all land. Exercises `write()`
+    /// serialization + the first-write `cachedDeviceUuid` memoization; every appended
+    /// record is present on a final single-threaded read.
+    func testConcurrentWritesAreRaceFree() throws {
+        let session = try openSession()
+        let block = try firstBlockUuid(session)
+        let box = UncheckedBox(session)
+        let blockBox = UncheckedBox(block)
+        let appended = Collector<Data>()
+        DispatchQueue.concurrentPerform(iterations: Self.concurrentWorkers) { i in
+            let content = RecordContentInput(
+                recordType: "login", tags: ["concurrent"],
+                fields: [FieldContentInput(name: "idx", value: .text("\(i)"))])
+            if let uuid = try? box.value.appendRecord(blockUuid: blockBox.value, content: content) {
+                appended.add(Data(uuid))
+            }
+        }
+        let got = appended.snapshot
+        XCTAssertEqual(got.count, Self.concurrentWorkers, "every concurrent append must succeed")
+        let records = try session.readBlock(blockUuid: block, includeDeleted: false)
+        let present = Set(records.map { Data($0.uuid) })
+        for uuid in got {
+            XCTAssertTrue(present.contains(uuid), "an appended record was missing after concurrent writes")
+        }
+    }
+}

--- a/ios/SecretaryKit/Tests/SecretaryKitTests/SessionConcurrencyIntegrationTests.swift
+++ b/ios/SecretaryKit/Tests/SecretaryKitTests/SessionConcurrencyIntegrationTests.swift
@@ -130,6 +130,8 @@ final class SessionConcurrencyIntegrationTests: XCTestCase {
         }
         let got = appended.snapshot
         XCTAssertEqual(got.count, Self.concurrentWorkers, "every concurrent append must succeed")
+        // All workers have finished (concurrentPerform joined), so read directly from
+        // `session` — the same object as `box.value`, now with no concurrent access.
         let records = try session.readBlock(blockUuid: block, includeDeleted: false)
         let present = Set(records.map { Data($0.uuid) })
         for uuid in got {

--- a/ios/SecretaryKit/Tests/SecretaryKitTests/SessionWipeGuardIntegrationTests.swift
+++ b/ios/SecretaryKit/Tests/SecretaryKitTests/SessionWipeGuardIntegrationTests.swift
@@ -6,9 +6,10 @@ import SecretaryVaultAccess
 /// `wiped` guard (mirror of the Android session, #250). After `wipe()`, the session
 /// is closed: a write must short-circuit with a typed wiped-session error WITHOUT
 /// touching the zeroized `identity`/`manifest` handles, and a `readBlock` must never
-/// yield plaintext records. The lock's mutual exclusion under genuine concurrency is
-/// by-construction + documented (not unit-tested — a deterministic interleave would
-/// need an injected mid-read seam; a stress test would be flaky).
+/// yield plaintext records. The lock's mutual exclusion under genuine concurrency is exercised separately by
+/// `SessionConcurrencyIntegrationTests` (run under ThreadSanitizer via
+/// `ios/scripts/run-ios-tsan.sh`); this file covers the single-threaded `wiped`-guard
+/// semantics.
 ///
 /// Opens a temp copy of the frozen `golden_vault_001` KAT (never mutates the
 /// original), mirroring `RecordEditIntegrationTests`.

--- a/ios/SecretaryKit/Tests/SecretaryKitTests/SessionWipeGuardIntegrationTests.swift
+++ b/ios/SecretaryKit/Tests/SecretaryKitTests/SessionWipeGuardIntegrationTests.swift
@@ -6,10 +6,10 @@ import SecretaryVaultAccess
 /// `wiped` guard (mirror of the Android session, #250). After `wipe()`, the session
 /// is closed: a write must short-circuit with a typed wiped-session error WITHOUT
 /// touching the zeroized `identity`/`manifest` handles, and a `readBlock` must never
-/// yield plaintext records. The lock's mutual exclusion under genuine concurrency is exercised separately by
-/// `SessionConcurrencyIntegrationTests` (run under ThreadSanitizer via
-/// `ios/scripts/run-ios-tsan.sh`); this file covers the single-threaded `wiped`-guard
-/// semantics.
+/// yield plaintext records. The lock's mutual exclusion under genuine concurrency
+/// is exercised separately by `SessionConcurrencyIntegrationTests` (run under
+/// ThreadSanitizer via `ios/scripts/run-ios-tsan.sh`); this file covers the
+/// single-threaded `wiped`-guard semantics.
 ///
 /// Opens a temp copy of the frozen `golden_vault_001` KAT (never mutates the
 /// original), mirroring `RecordEditIntegrationTests`.

--- a/ios/scripts/lib/resolve-simulator.sh
+++ b/ios/scripts/lib/resolve-simulator.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Resolve an iOS simulator *name* to a concrete UDID. Sourced by run-ios-tests.sh
+# and run-ios-tsan.sh so the resolution logic lives in exactly one place.
+#
+# Usage:  source .../lib/resolve-simulator.sh; SIM_ID="$(resolve_simulator 'iPhone 16')"
+# Echoes the UDID on stdout. On no match it prints the available-device list to
+# stderr and returns 2 — the caller, under `set -e` with command substitution,
+# aborts. (Bash note: `SIM_ID="$(resolve_simulator …)"` does propagate a non-zero
+# return under `set -e`.)
+resolve_simulator() {
+    local sim_name="$1"
+    local devices sim_id
+    # Capture the device list ONCE: a genuine `simctl` failure aborts here under
+    # `set -e` rather than being swallowed by the `|| true` below and misreported
+    # as a missing device. The `|| true` then guards ONLY the grep pipeline, where
+    # a no-match is legitimately empty.
+    devices="$(xcrun simctl list devices available)"
+    # Anchor the match to "<name> (" so "iPhone 16" does not also match
+    # "iPhone 16 Pro" / "iPhone 16 Plus" / "iPhone 16e". `head -1` takes the first
+    # matching device regardless of runtime (simctl groups by runtime); it assumes
+    # every installed runtime is >= the Package.swift deployment floor (iOS 17).
+    # NB: $sim_name is interpolated into an ERE — fine for real device names, which
+    # contain no regex metacharacters.
+    sim_id="$(printf '%s\n' "$devices" \
+        | grep -E "^[[:space:]]*${sim_name} \(" \
+        | head -1 \
+        | grep -oE '[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}' || true)"
+    if [[ -z "$sim_id" ]]; then
+        echo "ERROR: no available simulator named '$sim_name'. Available devices:" >&2
+        printf '%s\n' "$devices" >&2
+        echo "Set IOS_SIM to one of the device names listed above." >&2
+        return 2
+    fi
+    printf '%s\n' "$sim_id"
+}

--- a/ios/scripts/run-ios-tests.sh
+++ b/ios/scripts/run-ios-tests.sh
@@ -29,35 +29,10 @@ echo "==> build-xcframework.sh"
 bash "$SCRIPT_DIR/build-xcframework.sh"
 
 # --- Step 3: resolve the simulator name to a concrete UDID ---
-# The bare `name=` destination is ambiguous when multiple runtimes/arches share
-# a device name (xcodebuild errors with "Unable to find a device matching the
-# provided destination specifier"), so we resolve to a UDID and target by id=.
-# Anchor the match to "<name> (" so an exact name like "iPhone 16" does not also
-# match "iPhone 16 Pro" / "iPhone 16 Plus" / "iPhone 16e".
 echo "==> resolving simulator: $SIM_NAME"
-# Capture the device list ONCE: a genuine `simctl` failure aborts here under
-# `set -e` (rather than being swallowed by the `|| true` below and misreported
-# as a missing device). The `|| true` then guards ONLY the grep pipeline, where
-# a no-match is legitimately empty.
-# NB: $SIM_NAME is interpolated into an ERE, so a device name containing regex
-# metacharacters (. + ( etc.) could mis-match — fine for real device names
-# ("iPhone 16", "iPhone 15"), which contain none.
-# `head -1` takes the FIRST matching device regardless of which iOS runtime it
-# is paired with. `simctl` lists devices grouped by runtime, so this is whatever
-# runtime simctl emits first; it assumes every installed runtime is >= the
-# Package.swift deployment floor (iOS 17). If a sub-floor runtime is ever
-# installed and emitted first, pin the runtime via IOS_SIM or extend this match.
-DEVICES="$(xcrun simctl list devices available)"
-SIM_ID="$(printf '%s\n' "$DEVICES" \
-    | grep -E "^[[:space:]]*${SIM_NAME} \(" \
-    | head -1 \
-    | grep -oE '[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}' || true)"
-if [[ -z "$SIM_ID" ]]; then
-    echo "ERROR: no available simulator named '$SIM_NAME'. Available devices:" >&2
-    printf '%s\n' "$DEVICES" >&2
-    echo "Set IOS_SIM to one of the device names listed above." >&2
-    exit 2
-fi
+# shellcheck source=lib/resolve-simulator.sh
+source "$SCRIPT_DIR/lib/resolve-simulator.sh"
+SIM_ID="$(resolve_simulator "$SIM_NAME")"
 echo "    -> $SIM_ID"
 
 # --- Step 4: run the XCTest on the simulator ---

--- a/ios/scripts/run-ios-tsan.sh
+++ b/ios/scripts/run-ios-tsan.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# TSan acceptance entry point (#300 follow-up): build the Secretary.xcframework,
+# then run the full SecretaryKit XCTest suite under ThreadSanitizer on an iOS
+# simulator. The SessionConcurrencyIntegrationTests are the teeth — they drive
+# UniffiVaultSession's readBlock/wipe/writes concurrently, so TSan flags any
+# unsynchronized access to its mutable state (the #300 lock).
+#
+# Run from anywhere — paths resolve relative to this script.
+# Override the simulator with IOS_SIM, e.g.  IOS_SIM='iPhone 15' run-ios-tsan.sh
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+IOS_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+PKG_DIR="$IOS_DIR/SecretaryKit"
+SIM_NAME="${IOS_SIM:-iPhone 16}"
+
+# --- Step 1: build the framework + stage fixtures (golden_vault_001) ---
+echo "==> build-xcframework.sh"
+bash "$SCRIPT_DIR/build-xcframework.sh"
+
+# --- Step 2: resolve the simulator name to a concrete UDID ---
+echo "==> resolving simulator: $SIM_NAME"
+# shellcheck source=lib/resolve-simulator.sh
+source "$SCRIPT_DIR/lib/resolve-simulator.sh"
+SIM_ID="$(resolve_simulator "$SIM_NAME")"
+echo "    -> $SIM_ID"
+
+# --- Step 3: run the whole suite under ThreadSanitizer ---
+# -enableThreadSanitizer YES instruments the Swift build. The uniffi Rust dylib is
+# opaque to TSan (calls into it carry no happens-before), which is fine: the races
+# #300 guards are on Swift-side mutable stored properties (currentBlock / wiped /
+# cachedDeviceUuid), which NSLock (TSan-aware) synchronizes. xcodebuild's exit
+# status is the acceptance result; it is the last command, so `set -e` propagates a
+# non-zero test/TSan failure as this script's exit code.
+echo "==> xcodebuild test -enableThreadSanitizer YES (simulator: $SIM_NAME / $SIM_ID)"
+cd "$PKG_DIR"
+xcodebuild test -scheme SecretaryKit \
+    -destination "platform=iOS Simulator,id=$SIM_ID" \
+    -enableThreadSanitizer YES


### PR DESCRIPTION
## What & why

Closes the "by-construction + doc-comment only" gap left by PR #304 (#300): `UniffiVaultSession` was made thread-safe (`NSLock` + `wiped` flag serializing the mutable stored properties `currentBlock` / `wiped` / `cachedDeviceUuid`), but **nothing exercised that lock under concurrency** — a future lock regression would still pass the suite. This branch adds a TSan-verified concurrency suite and a CI job that runs it.

**iOS test + CI only.** No `core/`, spec, `conformance.py`, `FfiVaultError`, or `UniffiVaultSession` production-code change. Rust `cargo`/`clippy`/CodeQL and the Swift/Kotlin conformance harnesses are unaffected.

## Changes

1. **`ios/scripts/run-ios-tsan.sh`** — builds the xcframework, runs the whole `SecretaryKit` suite under `-enableThreadSanitizer YES`. Simulator-name→UDID resolver extracted into a sourceable **`ios/scripts/lib/resolve-simulator.sh`** shared with `run-ios-tests.sh` (behavior-preserving).
2. **`SessionConcurrencyIntegrationTests.swift`** — 3 tests over a temp copy of `golden_vault_001`, driving `readBlock`/`wipe`/writes concurrently via an `@unchecked Sendable` box. Assertions are timing-independent (no-crash + count/contents) — **not** flaky. Retires the stale "not unit-tested … flaky" docstring caveat in `SessionWipeGuardIntegrationTests`.
3. **`.github/workflows/ios-tsan.yml`** — path-gated (`ios/**`) `macos-latest` job, `timeout-minutes: 60`, `IOS_SIM` escape hatch. Separate workflow file so workflow-level `paths:` can gate this one heavy macOS job without gating `test.yml`'s rust/desktop/conformance jobs.

## Why a concurrency test isn't flaky

TSan detects races via happens-before tracking (NSLock is TSan-aware), so it flags an unsynchronized stored-property access regardless of interleaving. We never assert a specific race winner — only invariants that hold under any valid order.

## Acceptance (RED→GREEN, verified locally)

- **RED:** with the `lock.withLock` wrappers temporarily removed, `run-ios-tsan.sh` produced **6 `ThreadSanitizer: data race`** reports naming `readBlock` / `wipe()`.
- **GREEN:** lock restored → full `SecretaryKitTests` **35/35, 0 races**; `run-ios-tests.sh` still 32/32 after the resolver extraction; `actionlint` clean.

> The macOS TSan CI job will run on this PR (it path-matches `ios/**`); first-run duration is unobserved — see the handoff for the follow-up to ground `timeout-minutes`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)