### PR TITLE
docs(#299): document uniffi value-marshalling secret residue as accepted FFI-boundary limitation

### DIFF
--- a/NEXT_SESSION.md
+++ b/NEXT_SESSION.md
@@ -1,1 +1,1 @@
-docs/handoffs/2026-06-25-ios-tsan-concurrency-shipped.md
+docs/handoffs/2026-06-26-uniffi-secret-residue-299-shipped.md

--- a/core/tests/python/spec_freshness_allowlist.txt
+++ b/core/tests/python/spec_freshness_allowlist.txt
@@ -61,3 +61,22 @@ docs/manual/contributors/ffi-secret-handling-internal.md::FfiUnlockError::WrongP
 
 # reason: ffi/secretary-ffi-bridge/src/error.rs::FfiUnlockError — FFI error type, not in core/
 docs/manual/contributors/ffi-secret-handling-internal.md::FfiUnlockError::WrongMnemonicOrCorrupt
+
+# --- uniffi inbound marshalling-residue section (#299). FFI-crate + upstream
+# --- uniffi symbols cited in the "Accepted limitation" subsection; none live
+# --- under core/, so they register as bare-unresolved.
+
+# reason: ffi/secretary-ffi-uniffi/src/namespace/mod.rs::open_vault_with_password — uniffi-projected fn, not in core/
+docs/manual/contributors/ffi-secret-handling-internal.md::open_vault_with_password
+
+# reason: ffi/secretary-ffi-uniffi/src/namespace/mod.rs::open_vault_with_recovery — uniffi-projected fn, not in core/
+docs/manual/contributors/ffi-secret-handling-internal.md::open_vault_with_recovery
+
+# reason: ffi/secretary-ffi-uniffi/src/secretary.udl::create_vault_in_folder — uniffi-projected fn, not in core/
+docs/manual/contributors/ffi-secret-handling-internal.md::create_vault_in_folder
+
+# reason: upstream uniffi_core crate name (the binding generator's runtime), not a project symbol
+docs/manual/contributors/ffi-secret-handling-internal.md::uniffi_core
+
+# reason: upstream uniffi-generated RustBuffer-free scaffolding symbol, not a project symbol
+docs/manual/contributors/ffi-secret-handling-internal.md::uniffi_rustbuffer_free

--- a/docs/handoffs/2026-06-26-uniffi-secret-residue-299-shipped.md
+++ b/docs/handoffs/2026-06-26-uniffi-secret-residue-299-shipped.md
@@ -1,0 +1,81 @@
+# NEXT_SESSION.md — #299 uniffi value-marshalling secret residue (investigate-upstream → document) ✅ SHIPPED (PR opening)
+
+**Session date:** 2026-06-25 (rolled into 2026-06-26). Started from a clean baton — PR #305 (`cf708b28`, the #300 TSan concurrency follow-up) had merged to `main`; removed the merged worktree/branch (`ios-tsan-concurrency` / `test/ios-tsan-concurrency`). Observed the open #300 follow-up resolved itself: `ios-tsan.yml` ran **green** on both the PR (11m17s) and the merge-to-main (10m31s) — `iPhone 16` sim exists on `macos-latest`, runtime ~10–11 min vs the 60-min cap (comfortable margin). User picked **#299** (`security`). Executed via brainstorm → spec → (lightweight, docs-only) implement, in project-local worktree `.worktrees/uniffi-secret-residue`.
+
+**Status:** ✅ **SHIPPED — branch `docs/uniffi-secret-residue-299`, PR opening.** Docs-only; **no production code change** (the residue is in generated code we don't author, and upstream declined to fix it). `Closes #299` rides in the PR body so #299 closes on merge.
+
+## (1) What we shipped this session
+
+**The task (#299).** PR #298 (#229) scrubs the iOS adapter-owned `Data` and the uniffi namespace wrappers `zeroize()` the Rust `Vec<u8>` param — but a user-entered password / recovery phrase still lingers in **uniffi's generated value-marshalling buffers**, which neither side can reach. The chosen appetite was **investigate upstream uniffi** → document findings, comment upstream if warranted.
+
+**Investigation (grounded, not assumed):**
+- Regenerated the **actual** `secretary.swift` (uniffi 0.31, via the `build-xcframework.sh` bindgen step) and read `uniffi_core` v0.31.0. Confirmed **two uncontrolled copies** of an inbound `bytes` secret: (1) the Swift `writer: [UInt8]` in `FfiConverterRustBuffer.lower`, freed without zeroize; (2) the Rust-allocated `RustBuffer`, freed via `uniffi_rustbuffer_free → RustBuffer::destroy → drop(Vec<u8>)` (plain drop, no scrub) **before** our namespace wrapper body runs, so `password.zeroize()` can't reach it.
+- **Not closeable in-scope:** uniffi 0.31.2 (current head, 2026-06-16) exposes no zeroize/sensitive hook, no per-arg allocator (only the coarse global `#[global_allocator]`, which still misses copy #1), and `custom_type!` routes through the same un-scrubbed `FfiConverter`. Upstream [mozilla/uniffi-rs#2080](https://github.com/mozilla/uniffi-rs/issues/2080) is **closed wontfix** (maintainers: "uniffi makes many copies … zeroize seems pointless").
+- **Android has the identical residue** (Kotlin `ByteArray` → `RustBuffer` → `Vec<u8>`), distinct from the #229 "no adapter copy" finding (different allocations).
+- Threat framing: worst case = one secret copy in freed-not-yet-reused heap; not a logic bug; core `Sensitive<T>` discipline unaffected.
+
+**Three deliverables:**
+1. **Memo section** — "Accepted limitation: uniffi value-marshalling secret residue (#299)" added to [`docs/manual/contributors/ffi-secret-handling-internal.md`](docs/manual/contributors/ffi-secret-handling-internal.md)'s "What is *not* covered" (the **inbound** sibling of the existing outbound `expose_*`/`take_*` caveat), with the two-copy path, the in-scope-unfixable evidence, the Android note, threat framing, and the Arc-handle mitigation. Cross-linked from the memory-hygiene memo's Cross-FFI out-of-scope bullet. *(Home adjusted from the spec's "memory-hygiene memo" to the dedicated FFI-secret memo — better matches the existing doc architecture; memory-hygiene gets the pointer.)*
+2. **Upstream comment on #2080** — posted a constructive secrets-manager-consumer data point + the opt-in `#[uniffi(zeroize)]` ask: <https://github.com/mozilla/uniffi-rs/issues/2080#issuecomment-4805641279>. No new issue (the question was already asked and declined).
+3. **Close #299** — via `Closes #299` in the PR body (closes when the docs land on `main`, not before).
+
+**Branch commits** (off `main` @ `cf708b28`):
+| SHA | What |
+|---|---|
+| `3d091fdd` | **docs(spec)**: investigation/disposition design |
+| `a2c3b574` | **docs(memo)**: #299 inbound marshalling residue section + cross-link |
+| `181d1dfa` | **docs(freshness)**: allowlist the 5 uniffi FFI symbols cited in the memo |
+| (+ handoff commit) | this baton + retargeted `NEXT_SESSION.md` symlink |
+
+### Acceptance (verified this session)
+```bash
+cd /Users/hherb/src/secretary/.worktrees/uniffi-secret-residue
+uv run core/tests/python/spec_test_name_freshness.py   # 3 unresolved = the pre-existing #290 set ONLY (my 5 allowlisted)
+git diff --name-only main...HEAD | grep -v '^docs/' || echo "docs-only"   # docs-only (incl. the allowlist .txt under core/tests/python)
+```
+- Zero `core/` Rust / FFI-crate source / on-disk-format / `conformance.py` change → cargo / clippy / CodeQL / Swift+Kotlin-conformance gates unaffected.
+- Freshness checker (NOT a CI gate) net-clean: my 5 new FFI-symbol citations allowlisted following the existing precedent; the only remaining 3 hits are the pre-existing #290 `threat-model.md` false-positives (untouched — that's a parallel session's issue).
+
+## (2) What's next
+**#299 done (PR open). Pick a fresh item.** Carried candidates:
+- **#290** — allowlist the 3 D.4 freshness false-positives (`origin_binding`/`registrable_domain`/`exact_origin` in `threat-model.md`). **Still collision-risky:** `.worktrees/d4-browser-autofill` (`claude/intelligent-davinci-hriple`) is active. *Trivially* closeable now (the allowlist mechanism + precedent are right there — 3 entries), but coordinate with that worktree first.
+- **#252** (Android) — `UniffiVaultSession` read-only path (`blockSummaries`/`vaultUuidHex`) lacks the wiped guard; mirrors the iOS #304 hardening for Kotlin.
+- **#231** (iOS) — enable `-strict-concurrency=complete` on the SwiftPM targets (natural follow-on to the #300 TSan work).
+- **#193** (Rust core) — `pipeline.rs` dedup `copy_clocks` + pipeline-level real-race stale test + split >500 lines (good Rust-learning task, no platform collision).
+
+**Acceptance criteria template:** a failing test reproducing the gap on `main`, the typed-error/enforcement surface *proven* not assumed (security paths, [[feedback_verify_deferred_items]]), the platform's full test gate green, spec/`conformance.py` updated in lockstep if observable bytes/semantics change.
+
+**Open follow-up issues (carried):** #290 / #284 / #280 / #277 / #273 / #272(STALE — see §3) / #269 / #255 / #252 / #247 / #246 / #234 / #232 / #231 / #224 / #218 / #193 / #192 / #190 / #189 / #186 / #183.
+
+## (3) Open decisions and risks
+- **#272 is stale and closeable.** `cargo fmt --all --check` passes on `main` (exit 0); the drift was fixed by `f498206c` (#288), which also added the fmt/clippy CI gate. Close #272 with that evidence next session (didn't close it this session to stay scoped to #299).
+- **Memo home = FFI-secret memo, not the memory-hygiene memo** (documented spec deviation): the FFI-secret memo already houses the cross-FFI residue caveats (codec-boundary, foreign-runtime heap-copy) and has a "What is *not* covered" section; the memory-hygiene memo's Cross-FFI bullet now points to it. This matches the existing doc architecture better than the spec's original placement.
+- **No new upstream issue filed** (per user decision): #2080 already covers it and was declined; we commented instead of refiling a likely-unwelcome duplicate.
+- **Outbound secret-return residue** (`take_phrase`/`take_secret`, Rust→Swift) has the *mirror* gap but is out of #299's scope; noted in the memo for completeness (and the OUTBOUND root fix already shipped as #261).
+- **README / ROADMAP unchanged (deliberate).** Documenting an accepted FFI-boundary limitation is no capability/milestone — matches the #210/#251/#229/#300 pure-hardening precedent (contrast #261, an actual UDL fix that *did* get a ROADMAP line).
+- **Risk:** none to product behavior (no production code touched). The residue itself remains an accepted limitation until/unless upstream uniffi adds an opt-in scrub.
+- **Process note (parallel-session hazard hit & recovered):** a `git stash`/`checkout main` dance to get a checker baseline accidentally `pop`ped a *pre-existing parallel-session stash* (`stash@{0}: On main: stale main-checkout spec drafts superseded by #182`), conflicting `docs/vault-format.md`. Recovered cleanly — restored the file to HEAD, the stash stays intact in the list for that session. **Lesson: never stash-dance on a shared worktree; use `git show <ref>:<path>` or a throwaway worktree for baselines.**
+
+## (4) Exact commands to resume
+```bash
+cd /Users/hherb/src/secretary
+git fetch --prune origin && git checkout main && git pull --ff-only origin main
+# If PR merged: branch + worktree can be removed:
+#   git worktree remove .worktrees/uniffi-secret-residue && git branch -D docs/uniffi-secret-residue-299
+git worktree list && git status -s
+
+# Re-verify this session's gate (from the worktree if the PR is still open):
+cd .worktrees/uniffi-secret-residue
+uv run core/tests/python/spec_test_name_freshness.py   # 3 unresolved = #290 set only
+git diff --name-only main...HEAD | grep -v '^docs/' || echo "docs-only"
+```
+
+## (5) Handoff file model
+`NEXT_SESSION.md` is a **relative symlink** to this file in `docs/handoffs/`. Authored once here; symlink retargeted in the same commit on the feature branch. New-path handoff → no add/add conflict. Branch cut from `origin/main` (`cf708b28`); `origin/main` had **not** advanced at handoff time (verified `origin/main` == merge-base == `cf708b28`), so no history-binding merge was needed.
+
+## Closing inventory
+- **State on close:** PR opening on `docs/uniffi-secret-residue-299` (spec `3d091fdd` + memo `a2c3b574` + allowlist `181d1dfa` + handoff). Worktree `.worktrees/uniffi-secret-residue`.
+- **Acceptance:** docs-only; freshness checker net-clean (5 new citations allowlisted, only the pre-existing #290 trio remains). Zero `core/` Rust / FFI-crate source / `conformance.py` touched → all language gates unaffected. Upstream #2080 comment posted; #299 closes via the PR.
+- **README.md / ROADMAP.md:** unchanged (rationale in §3).
+- **CLAUDE.md:** unchanged.
+- **NEXT_SESSION.md:** symlink → `docs/handoffs/2026-06-26-uniffi-secret-residue-299-shipped.md`.

--- a/docs/manual/contributors/ffi-secret-handling-internal.md
+++ b/docs/manual/contributors/ffi-secret-handling-internal.md
@@ -364,19 +364,43 @@ the `ByteArray` directly): the adapter copy and the generated-marshalling
 copy are different allocations; the marshalling residue applies to both
 bindings.
 
-**Not closeable in-scope.** uniffi 0.31 (current head 0.31.2, 2026-06-16)
-exposes no config flag, attribute, trait, custom-type mechanism, or
-"sensitive"/"secret" wire type that scrubs marshalling buffers —
-`custom_type!` only maps to an existing bridge type and then runs the
-*standard* `FfiConverter`, producing the same un-scrubbed copies. The
-RustBuffer allocator is only the cdylib's global `#[global_allocator]`;
-a zeroizing allocator would zero-on-free for the *entire* crate's heap
-traffic (heavyweight) and still would not touch copy #1. Upstream
+**Not closeable in any *released* uniffi (as of 0.31.2, 2026-06-16).**
+The latest release exposes no config flag, attribute, trait, custom-type
+mechanism, or "sensitive"/"secret" wire type that scrubs marshalling
+buffers — `custom_type!` only maps to an existing bridge type and then
+runs the *standard* `FfiConverter`, producing the same un-scrubbed
+copies. The RustBuffer allocator is only the cdylib's global
+`#[global_allocator]`; a zeroizing allocator would zero-on-free for the
+*entire* crate's heap traffic (heavyweight) and still would not touch
+copy #1. Upstream
 [mozilla/uniffi-rs#2080](https://github.com/mozilla/uniffi-rs/issues/2080)
-is **closed** with maintainers explicitly declining zeroize ("uniffi
-makes many copies … zeroize seems, frankly, pointless"); an opt-in
-`#[uniffi(zeroize)]` was floated but met "probably no appetite". We have
-registered the specific secrets-manager consumer ask on #2080.
+(zeroize-on-drop) is **closed** with maintainers explicitly declining
+zeroize ("uniffi makes many copies … zeroize seems, frankly,
+pointless"); an opt-in `#[uniffi(zeroize)]` was floated but met "probably
+no appetite". We have registered the specific secrets-manager consumer
+ask on #2080.
+
+**Remediation on the horizon — zero-copy `[ByRef] bytes` (uniffi
+[#2864](https://github.com/mozilla/uniffi-rs/issues/2864) /
+[#2878](https://github.com/mozilla/uniffi-rs/pull/2878)).** Rather than
+scrubbing the marshalling copies, upstream chose to *avoid* them:
+[#2878](https://github.com/mozilla/uniffi-rs/pull/2878) (merged to
+`main` 2026-05-10, **unreleased** as of 0.31.2) lets an inbound `bytes`
+argument declared `[ByRef] bytes` (UDL) / `&[u8]` (proc-macro) travel as
+a `ForeignBytes` (pointer + length) — a borrow of foreign memory —
+**instead of being copied through a `RustBuffer`.** For synchronous
+calls (which all our unlock entry points are) this eliminates *both*
+residue copies above: copy #2 (the Rust `RustBuffer`) never exists, and
+on Swift the `Data` is passed by pointer with no `createWriter` /
+`RustBuffer(bytes:)` dance, so copy #1 never exists either. The foreign
+side retains ownership of its buffer, which makes #298's
+`withZeroizingData` scrub of the adapter `Data` the *complete* scrub.
+(Async args still revert to copying; not applicable here. Kotlin
+call sites must pass a *direct* `java.nio.ByteBuffer` rather than a
+`ByteArray`.) Once a uniffi release ships #2878, migrating the inbound
+secret args (`open_vault_with_password` / `open_vault_with_recovery` /
+`create_vault_in_folder`, currently `Vec<u8>`) to `&[u8]` closes this
+limitation. Tracked as #307.
 
 **Threat framing.** Worst case is a residency window for one secret copy
 in freed-but-not-yet-reused heap — not a logic bug. The core
@@ -384,8 +408,10 @@ in freed-but-not-yet-reused heap — not a logic bug. The core
 idiomatic mitigation (keep secret material behind Rust-owned `Arc`
 handles, as the device-unlock path already does) is applied wherever the
 secret is *not* user-entered. For inbound user-entered password / phrase
-there is no avoidance path in any released uniffi; this is accepted as an
-inherent property of uniffi's value-marshalling model. See
+there is no avoidance path in any *released* uniffi as of 0.31.2, so this
+is accepted as a limitation of the released value-marshalling model —
+**not** an inherent one: the unreleased `[ByRef] bytes` zero-copy path
+above is the remediation once it ships. See
 [`docs/superpowers/specs/2026-06-25-uniffi-secret-residue-investigation-design.md`](../../superpowers/specs/2026-06-25-uniffi-secret-residue-investigation-design.md)
 for the full investigation record.
 

--- a/docs/manual/contributors/ffi-secret-handling-internal.md
+++ b/docs/manual/contributors/ffi-secret-handling-internal.md
@@ -319,6 +319,76 @@ foreign-runtime heap-copy caveat documented per accessor is not a
 of the FFI boundary that the bridge documents and works around with
 the opaque-handle + `wipe()` primitive.
 
+### Accepted limitation: uniffi value-marshalling secret residue (#299)
+
+The per-accessor foreign-runtime caveat above concerns the **outbound**
+direction (`expose_*` / `take_*` returns: Rust → foreign). The
+**inbound** direction — a user-entered master password or 24-word
+recovery phrase travelling foreign → Rust (`open_vault_with_password` /
+`open_vault_with_recovery` / `create_vault_in_folder` / sync) — has a
+*distinct*, symmetric residue that no side can scrub. #229 / #298 added
+`withZeroizingData` to scrub the iOS adapter-owned `Data` copy, and the
+uniffi namespace wrappers (`ffi/secretary-ffi-uniffi/src/namespace/
+mod.rs`) `zeroize()` the `Vec<u8>` parameter on both success and error
+paths — but **uniffi's generated value-marshalling allocates two further
+intermediate copies that neither scrub reaches.**
+
+Confirmed against the actual generated `secretary.swift` (uniffi 0.31,
+regenerated via `ios/scripts/build-xcframework.sh`'s bindgen step) and
+`uniffi_core` @ `v0.31.0`. For `bytes` arguments, `FfiConverterData.lower`
+→ `FfiConverterRustBuffer.lower` does:
+
+```swift
+var writer = createWriter()        // [UInt8]  ← residue copy #1 (Swift-side)
+write(value, into: &writer)        // appends the plaintext secret bytes
+return RustBuffer(bytes: writer)   // memcpy into a Rust-allocated RustBuffer ← copy #2
+```
+
+1. **Copy #1 — the Swift `writer: [UInt8]`** holds the plaintext and is
+   freed (out of scope at the end of `lower`) **without** zeroize. It is a
+   *different* allocation from the adapter `Data` that `withZeroizingData`
+   scrubs (`write` only reads *from* the `Data`), so #298 cannot reach it.
+2. **Copy #2 — the Rust-allocated `RustBuffer`** is lifted into the
+   `Vec<u8>` parameter (which the namespace wrapper *does* `zeroize()`),
+   then freed by `uniffi_rustbuffer_free` → `RustBuffer::destroy` →
+   `drop(self.destroy_into_vec())`: a **plain `drop` of a `Vec<u8>` with no
+   overwrite before `dealloc`.** This free runs in generated scaffolding
+   **before** our wrapper body executes, so the wrapper's `password.
+   zeroize()` cannot reach copy #2 either.
+
+**Android has the identical residue.** The generated Kotlin
+`FfiConverterByteArray.lower` writes the secret into a `ByteBuffer` /
+`RustBuffer` with the same lifecycle. This is *distinct* from the #229
+finding that Android has no *adapter-owned* copy to scrub (Kotlin forwards
+the `ByteArray` directly): the adapter copy and the generated-marshalling
+copy are different allocations; the marshalling residue applies to both
+bindings.
+
+**Not closeable in-scope.** uniffi 0.31 (current head 0.31.2, 2026-06-16)
+exposes no config flag, attribute, trait, custom-type mechanism, or
+"sensitive"/"secret" wire type that scrubs marshalling buffers —
+`custom_type!` only maps to an existing bridge type and then runs the
+*standard* `FfiConverter`, producing the same un-scrubbed copies. The
+RustBuffer allocator is only the cdylib's global `#[global_allocator]`;
+a zeroizing allocator would zero-on-free for the *entire* crate's heap
+traffic (heavyweight) and still would not touch copy #1. Upstream
+[mozilla/uniffi-rs#2080](https://github.com/mozilla/uniffi-rs/issues/2080)
+is **closed** with maintainers explicitly declining zeroize ("uniffi
+makes many copies … zeroize seems, frankly, pointless"); an opt-in
+`#[uniffi(zeroize)]` was floated but met "probably no appetite". We have
+registered the specific secrets-manager consumer ask on #2080.
+
+**Threat framing.** Worst case is a residency window for one secret copy
+in freed-but-not-yet-reused heap — not a logic bug. The core
+`Sensitive<T>` / `SecretBytes` discipline is unaffected, and the
+idiomatic mitigation (keep secret material behind Rust-owned `Arc`
+handles, as the device-unlock path already does) is applied wherever the
+secret is *not* user-entered. For inbound user-entered password / phrase
+there is no avoidance path in any released uniffi; this is accepted as an
+inherent property of uniffi's value-marshalling model. See
+[`docs/superpowers/specs/2026-06-25-uniffi-secret-residue-investigation-design.md`](../../superpowers/specs/2026-06-25-uniffi-secret-residue-investigation-design.md)
+for the full investigation record.
+
 ### Sub-project D platform concerns (carved out)
 
 When the platform UI (Sub-project D, currently in flight as the

--- a/docs/manual/contributors/memory-hygiene-audit-internal.md
+++ b/docs/manual/contributors/memory-hygiene-audit-internal.md
@@ -362,7 +362,12 @@ verify both crates' drop discipline at their pinned versions.
   the foreign-runtime heap-copy caveat (Python `bytes`, Swift `String`,
   Kotlin `ByteArray` not being authoritatively zeroizable from the
   bridge) remains an inherent property of the FFI boundary and is
-  documented per-accessor on the bridge side.
+  documented per-accessor on the bridge side. The symmetric *inbound*
+  residue — uniffi's generated value-marshalling buffers for a
+  user-entered password / recovery phrase (#299) — is likewise an
+  accepted, in-scope-unfixable FFI-boundary limitation; see
+  [`ffi-secret-handling-internal.md`](ffi-secret-handling-internal.md)
+  → "Accepted limitation: uniffi value-marshalling secret residue".
 - **Clipboard hygiene** (Sub-project D): when a user copies a
   password to the system clipboard, the clipboard daemon owns a copy
   the Rust core has no visibility into. Mitigation is platform-UI

--- a/docs/superpowers/specs/2026-06-25-uniffi-secret-residue-investigation-design.md
+++ b/docs/superpowers/specs/2026-06-25-uniffi-secret-residue-investigation-design.md
@@ -108,12 +108,14 @@ case and is accepted.
 ## Disposition (the deliverables)
 
 1. **Memo section** — add an "Accepted limitation: uniffi value-marshalling secret residue
-   (#299)" subsection to `docs/manual/contributors/memory-hygiene-audit-internal.md` capturing
+   (#299)" subsection to `docs/manual/contributors/ffi-secret-handling-internal.md` capturing
    the residue path, the two copies, the in-scope-unfixable evidence (uniffi 0.31.2 + #2080),
    the Android-equivalent note, threat framing, and the idiomatic mitigation. This is the
-   durable home (the memo is the principal handoff doc for the paid external review and already
-   has a "Deferred items" / "Out of scope" structure for exactly this kind of accepted
-   residual).
+   durable home: the FFI-secret memo already houses the outbound cross-FFI residue caveats
+   (`expose_*` / `take_*`) under a "What is *not* covered" section, so the symmetric inbound
+   residue is its natural sibling. `memory-hygiene-audit-internal.md` gets a cross-link pointer
+   from its Cross-FFI out-of-scope bullet. *(This refines the original plan, which placed the
+   section in the memory-hygiene memo; the FFI-secret memo is the better architectural fit.)*
 
 2. **Upstream comment on #2080** — a constructive comment from a real secrets-manager consumer:
    precise residue locations (the two copies above) + the specific opt-in `#[uniffi(zeroize)]`

--- a/docs/superpowers/specs/2026-06-25-uniffi-secret-residue-investigation-design.md
+++ b/docs/superpowers/specs/2026-06-25-uniffi-secret-residue-investigation-design.md
@@ -1,0 +1,147 @@
+# Design: uniffi value-marshalling secret residue — investigation & disposition (#299)
+
+**Date:** 2026-06-25
+**Issue:** #299 (`security`) — "Scrub uniffi-generated lowering buffer for password/phrase
+(full FFI-boundary scrub, #229 follow-up)"
+**Type:** Investigation + documentation + issue disposition. **No production code change.**
+
+## Problem
+
+PR #298 (#229) added `withZeroizingData` and scrubs the **adapter-owned** `Data` copy at the
+iOS password/phrase FFI sites in `ios/SecretaryKit/Sources/SecretaryKit/VaultAccess/`. The
+Rust namespace wrappers (`ffi/secretary-ffi-uniffi/src/namespace/mod.rs`) additionally
+`zeroize()` the `Vec<u8>` parameter on both success and error paths.
+
+Neither scrub reaches the **uniffi-generated marshalling buffers** that the secret transits on
+its way across the FFI boundary. A copy of the password / recovery phrase therefore lingers in
+generated-code-owned heap after the call returns, beyond what either side can scrub. #299 asks
+whether that gap can be closed — the chosen appetite (this session) is to **investigate
+upstream uniffi** and document findings, commenting upstream if warranted.
+
+## Investigation findings (grounded)
+
+### The residue path — two uncontrolled copies
+
+Confirmed by reading the **actual** generated `secretary.swift` (uniffi 0.31, regenerated from
+the host cdylib via `ios/scripts/build-xcframework.sh`'s bindgen step) and `uniffi_core`
+@ `v0.31.0`:
+
+Inbound secret, Swift → Rust (e.g. `openVaultWithPassword(folderPath:password:)`):
+
+1. `FfiConverterData.lower(password)` → `FfiConverterRustBuffer.lower` (generated
+   `secretary.swift`):
+   ```swift
+   public static func lower(_ value: SwiftType) -> RustBuffer {
+       var writer = createWriter()        // [UInt8]  ← residue copy #1
+       write(value, into: &writer)        // appends the plaintext secret bytes
+       return RustBuffer(bytes: writer)   // copies into a Rust-allocated RustBuffer ← residue copy #2
+   }
+   ```
+   - **Copy #1 — Swift `writer: [UInt8]`:** holds the plaintext; goes out of scope at the end
+     of `lower` and is freed **without** zeroize. Not reachable from `withZeroizingData` (that
+     scrubs the adapter `Data`, a *different* allocation that `write` reads *from*).
+   - **Copy #2 — the Rust-allocated `RustBuffer`:** `RustBuffer(bytes:)` →
+     `RustBuffer.from(ptr)` → `ffi_secretary_ffi_uniffi_rustbuffer_from_bytes(ForeignBytes(...))`
+     memcpys the bytes into a buffer allocated by Rust's global allocator.
+
+2. On the Rust side, the uniffi scaffolding lifts copy #2 into the `Vec<u8>` parameter (which
+   our namespace wrapper *does* `zeroize()`), then frees the `RustBuffer` via
+   `uniffi_rustbuffer_free` → `RustBuffer::destroy` → `drop(self.destroy_into_vec())`. That is a
+   **plain `drop` of a `Vec<u8>` — no overwrite before `dealloc`.** Critically, this free runs
+   in generated scaffolding **before** our `open_vault_with_password` body executes, so our
+   `password.zeroize()` cannot reach copy #2 either.
+
+Net: a plaintext copy survives in (a) the freed Swift `writer` array and (b) the freed Rust
+`RustBuffer` allocation, until each heap region is reused. Both are in code we do not author.
+
+### Is it closeable in-scope? No.
+
+- **No hook in uniffi 0.31.** uniffi 0.31 (current head 0.31.2, released 2026-06-16) exposes no
+  config flag, attribute, trait, custom-type mechanism, or "sensitive"/"secret" wire type that
+  scrubs marshalling buffers. `custom_type!` / `custom_newtype!` only transform a Rust type into
+  an existing bridge type (e.g. `Vec<u8>`); the lift/lower then runs the *standard*
+  `FfiConverter`, producing the **same** un-scrubbed copies. The CHANGELOG through `Unreleased`
+  has zero entries mentioning zeroize / secret / sensitive / scrub.
+- **The allocator is a coarse global knob, not a per-type hook.** RustBuffer alloc/free are
+  monomorphized per component, but the only override point is the cdylib's
+  `#[global_allocator]`. A zeroizing `GlobalAlloc` would zero-on-free for the *entire* crate's
+  heap traffic (heavyweight) and **still would not touch copy #1** (the Swift-side array). Not
+  proportionate to "one secret copy in freed heap".
+- **Upstream has already declined.** Issue
+  [mozilla/uniffi-rs#2080](https://github.com/mozilla/uniffi-rs/issues/2080) ("Deriving
+  `uniffi::Record` together with `ZeroizeOnDrop` does not compile. Solvable?") is **closed**.
+  Maintainer position: @jplatte — "for zeroize in particular I think you'd be defeating the
+  purpose of that derive since UniFFI would be creating copies of the bytes that don't get
+  zeroized on drop"; he floated an opt-in `#[uniffi(zeroize)]` but added "probably no appetite
+  for it by the maintainers." @mhammond — "uniffi makes *many* copies … zeroize seems, frankly,
+  pointless." This treats the residue as an **inherent property of the value-marshalling
+  model**, not a bug.
+- **No newer release helps.** There is no uniffi > 0.31.2 as of 2026-06; no migration closes
+  the gap.
+
+### Android has the identical residue
+
+The generated Kotlin `FfiConverterByteArray.lower` writes the secret into a `ByteBuffer` /
+`RustBuffer` with the same lifecycle (lifted into `Vec<u8>` Rust-side, then freed unscrubbed).
+Note this is **distinct** from the #229 finding that Android has *no adapter-owned copy* to
+scrub (Kotlin forwards the `ByteArray` directly): the adapter copy and the
+generated-marshalling copy are different allocations. The marshalling residue applies equally
+to both bindings.
+
+### Threat framing
+
+Worst case is a **residency window for one secret copy in freed-but-not-yet-reused heap** —
+not a logic bug, and the core `Sensitive<T>` / `SecretBytes` zeroize discipline is unaffected.
+An attacker would need to read process heap (a core-dump / live-memory capture) in the window
+between the call returning and the allocator reusing those regions. This is the same residual
+class the issue itself anticipated and labelled lower-priority than the core discipline.
+
+### Idiomatic mitigation (already in use where applicable)
+
+The uniffi-blessed way to minimize residue is to keep secret material **behind Rust-owned
+`Arc` handles** rather than ferrying raw bytes across the boundary — exactly the existing
+device-unlock shape (the secret goes in, the work happens behind the FFI, no raw key material
+is returned). For **inbound user-entered** secrets (master password / 24-word recovery phrase)
+there is no way to avoid the marshalling copies in any released uniffi; this is the unavoidable
+case and is accepted.
+
+## Disposition (the deliverables)
+
+1. **Memo section** — add an "Accepted limitation: uniffi value-marshalling secret residue
+   (#299)" subsection to `docs/manual/contributors/memory-hygiene-audit-internal.md` capturing
+   the residue path, the two copies, the in-scope-unfixable evidence (uniffi 0.31.2 + #2080),
+   the Android-equivalent note, threat framing, and the idiomatic mitigation. This is the
+   durable home (the memo is the principal handoff doc for the paid external review and already
+   has a "Deferred items" / "Out of scope" structure for exactly this kind of accepted
+   residual).
+
+2. **Upstream comment on #2080** — a constructive comment from a real secrets-manager consumer:
+   precise residue locations (the two copies above) + the specific opt-in `#[uniffi(zeroize)]`
+   ask that @jplatte himself floated. No new issue (the question was already asked and declined;
+   a duplicate would be unwelcome). The comment text is reviewed before posting.
+
+3. **Close #299** referencing the memo section + #2080 with the documented rationale.
+
+## Out of scope
+
+- Any change to generated code, the uniffi version, or a custom FFI shim (the residue is
+  inherent to value marshalling; a non-uniffi raw-pointer shim collides with the workspace
+  `#![forbid(unsafe_code)]` invariant and is disproportionate to the threat).
+- VM-owned input-array scrubbing (separate concern, already documented under #229).
+- The outbound (Rust → Swift) secret-return path (`take_phrase` / `take_secret`): it has the
+  *mirror* residue, but #299 is scoped to the inbound password/phrase path. Noted in the memo
+  for completeness, not addressed here.
+
+## Testing
+
+None. There is no code or observable behavior change to test. Verification is:
+- the generated-code residue path is grounded in the actual regenerated `secretary.swift`
+  (re-checkable via the bindgen step) and `uniffi_core` v0.31.0 source;
+- `cargo`/`clippy`/conformance/Swift+Kotlin-conformance gates are unaffected (zero `core/` and
+  zero FFI-crate source files touched);
+- the memo edit is prose-only.
+
+## README / ROADMAP
+
+Unchanged. Documentation of an accepted FFI-boundary limitation introduces no capability and
+ticks no milestone — matching the pure-hardening precedent (#210 / #251 / #229 / #300).

--- a/docs/superpowers/specs/2026-06-25-uniffi-secret-residue-investigation-design.md
+++ b/docs/superpowers/specs/2026-06-25-uniffi-secret-residue-investigation-design.md
@@ -54,7 +54,7 @@ Inbound secret, Swift → Rust (e.g. `openVaultWithPassword(folderPath:password:
 Net: a plaintext copy survives in (a) the freed Swift `writer` array and (b) the freed Rust
 `RustBuffer` allocation, until each heap region is reused. Both are in code we do not author.
 
-### Is it closeable in-scope? No.
+### Is it closeable today? No in any released uniffi — but a queued upstream remediation closes it.
 
 - **No hook in uniffi 0.31.** uniffi 0.31 (current head 0.31.2, released 2026-06-16) exposes no
   config flag, attribute, trait, custom-type mechanism, or "sensitive"/"secret" wire type that
@@ -74,10 +74,23 @@ Net: a plaintext copy survives in (a) the freed Swift `writer` array and (b) the
   purpose of that derive since UniFFI would be creating copies of the bytes that don't get
   zeroized on drop"; he floated an opt-in `#[uniffi(zeroize)]` but added "probably no appetite
   for it by the maintainers." @mhammond — "uniffi makes *many* copies … zeroize seems, frankly,
-  pointless." This treats the residue as an **inherent property of the value-marshalling
-  model**, not a bug.
-- **No newer release helps.** There is no uniffi > 0.31.2 as of 2026-06; no migration closes
-  the gap.
+  pointless." Note this declines *zeroize-on-drop* specifically — it does **not** mean the
+  residue is permanent (see the zero-copy remediation below).
+- **No newer *release* helps yet — but `main` does.** There is no uniffi > 0.31.2 as of
+  2026-06, so no released migration closes the gap. However, upstream chose to *avoid* the
+  copies rather than scrub them: [mozilla/uniffi-rs#2878](https://github.com/mozilla/uniffi-rs/pull/2878)
+  (part of [#2864](https://github.com/mozilla/uniffi-rs/issues/2864) "zero copy byte buffers",
+  merged to `main` 2026-05-10, **unreleased** as of 0.31.2) makes an inbound `[ByRef] bytes`
+  (UDL) / `&[u8]` (proc-macro) argument travel as a `ForeignBytes` (pointer + length) — a
+  borrow of foreign memory — **instead of a `RustBuffer` copy**. For synchronous calls (all our
+  unlock entry points) this eliminates *both* residue copies: copy #2 (the Rust `RustBuffer`)
+  never exists, and on Swift the `Data` is passed by pointer (no `createWriter` /
+  `RustBuffer(bytes:)`), so copy #1 never exists either — leaving #298's `withZeroizingData`
+  scrub of the foreign-owned `Data` as the complete scrub. Async args still copy (n/a here);
+  Kotlin call sites must pass a *direct* `java.nio.ByteBuffer`. Once a uniffi release ships
+  #2878, migrating the inbound secret args (`open_vault_with_password` /
+  `open_vault_with_recovery` / `create_vault_in_folder`, currently `Vec<u8>`) to `&[u8]` closes
+  this limitation. **Tracked as #307** so the migration isn't forgotten when the release lands.
 
 ### Android has the identical residue
 
@@ -102,8 +115,9 @@ The uniffi-blessed way to minimize residue is to keep secret material **behind R
 `Arc` handles** rather than ferrying raw bytes across the boundary — exactly the existing
 device-unlock shape (the secret goes in, the work happens behind the FFI, no raw key material
 is returned). For **inbound user-entered** secrets (master password / 24-word recovery phrase)
-there is no way to avoid the marshalling copies in any released uniffi; this is the unavoidable
-case and is accepted.
+there is no way to avoid the marshalling copies in any *released* uniffi (≤ 0.31.2); this is
+accepted **until** the queued zero-copy `[ByRef] bytes` path (above) ships in a release, at
+which point the inbound args migrate to `&[u8]` and the copies disappear.
 
 ## Disposition (the deliverables)
 
@@ -124,11 +138,18 @@ case and is accepted.
 
 3. **Close #299** referencing the memo section + #2080 with the documented rationale.
 
+4. **Follow-up issue #307** — migrate the inbound secret args to zero-copy `[ByRef] bytes`
+   / `&[u8]` once a uniffi release ships [#2878](https://github.com/mozilla/uniffi-rs/pull/2878),
+   so the accepted-until-then limitation is actually retired when the release lands rather than
+   silently lingering.
+
 ## Out of scope
 
-- Any change to generated code, the uniffi version, or a custom FFI shim (the residue is
-  inherent to value marshalling; a non-uniffi raw-pointer shim collides with the workspace
-  `#![forbid(unsafe_code)]` invariant and is disproportionate to the threat).
+- Any change to generated code, a uniffi version *bump to an unreleased build*, or a custom FFI
+  shim (the released-uniffi residue is unavoidable today, and a non-uniffi raw-pointer shim
+  collides with the workspace `#![forbid(unsafe_code)]` invariant and is disproportionate to the
+  threat). The *released* zero-copy `[ByRef] bytes` migration is the deliberate follow-up
+  (deliverable 4), not in-scope for this docs-only pass.
 - VM-owned input-array scrubbing (separate concern, already documented under #229).
 - The outbound (Rust → Swift) secret-return path (`take_phrase` / `take_secret`): it has the
   *mirror* residue, but #299 is scoped to the inbound password/phrase path. Noted in the memo


### PR DESCRIPTION
## What & why

Closes #299. Investigation + documentation of the uniffi-generated secret-marshalling residue that #298 (#229) could not reach. **Docs-only — no production code change** (the residue is in generated code we don't author, and upstream has declined to fix it).

#298 scrubs the iOS adapter-owned `Data`; the uniffi namespace wrappers `zeroize()` the Rust `Vec<u8>` param. But a user-entered password / recovery phrase still lingers in **two uniffi-generated marshalling copies** that neither side can reach.

## Investigation (grounded in actual generated code)

Confirmed against the regenerated `secretary.swift` (uniffi 0.31) + `uniffi_core` v0.31.0:

1. **Swift `writer: [UInt8]`** in `FfiConverterRustBuffer.lower` — holds the plaintext, freed without zeroize. Distinct from the adapter `Data` #298 scrubs.
2. **Rust `RustBuffer`** — lifted into the `Vec<u8>` param (which we zeroize), then freed via `uniffi_rustbuffer_free → RustBuffer::destroy → drop(Vec<u8>)` (plain drop, no scrub), **before** our wrapper body runs.

**Not closeable in-scope:** uniffi 0.31.2 (current head) has no zeroize/sensitive hook or per-arg allocator; `custom_type!` routes through the same un-scrubbed converter. Upstream [mozilla/uniffi-rs#2080](https://github.com/mozilla/uniffi-rs/issues/2080) is **closed wontfix**. **Android has the identical residue** (`ByteArray → RustBuffer → Vec<u8>`).

Worst case: one secret copy in freed-not-yet-reused heap — not a logic bug; core `Sensitive<T>` discipline unaffected.

## Changes

- **Memo section** in `docs/manual/contributors/ffi-secret-handling-internal.md` ("Accepted limitation: uniffi value-marshalling secret residue (#299)"), the inbound sibling of the existing outbound `expose_*`/`take_*` caveat; cross-linked from the memory-hygiene memo.
- **Investigation/disposition spec** under `docs/superpowers/specs/`.
- **Freshness allowlist** for the 5 uniffi FFI symbols cited in the memo (following the existing FFI-symbol precedent).
- **Upstream:** commented on #2080 from a secrets-manager-consumer angle (no new issue) — https://github.com/mozilla/uniffi-rs/issues/2080#issuecomment-4805641279

## Verification

- `git diff --name-only main...HEAD | grep -v '^docs/'` → docs-only.
- Zero `core/` Rust / FFI-crate source / on-disk-format / `conformance.py` change → cargo / clippy / CodeQL / Swift+Kotlin-conformance gates unaffected.
- `spec_test_name_freshness.py` net-clean: 5 new citations allowlisted; the only remaining 3 hits are the pre-existing #290 `threat-model.md` false-positives (untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)