### PR TITLE
refactor(cli): dedup gather_copy_clocks + real-race EvidenceStale test + split pipeline into submodule (#193)

### DIFF
--- a/NEXT_SESSION.md
+++ b/NEXT_SESSION.md
@@ -1,1 +1,1 @@
-docs/handoffs/2026-06-26-uniffi-secret-residue-299-shipped.md
+docs/handoffs/2026-06-26-pipeline-refactor-193-shipped.md

--- a/cli/src/pipeline.rs
+++ b/cli/src/pipeline.rs
@@ -26,7 +26,7 @@ use secretary_core::crypto::secret::SecretBytes;
 use secretary_core::sync::draft::RecordCollisionSummary;
 use secretary_core::sync::{
     commit_with_decisions, prepare_merge, sync_once, ManifestHash, RecordTombstoneVeto,
-    RollbackEvidence, SyncError, SyncOutcome, SyncState, VetoDecision,
+    RollbackEvidence, SyncError, SyncOutcome, SyncState, VaultBundle, VetoDecision,
 };
 use secretary_core::unlock::UnlockedIdentity;
 use secretary_core::vault::block::VectorClockEntry;
@@ -256,11 +256,7 @@ pub fn run_one(
             // this moment — not just the canonical disk clock. See
             // `silent_merge_clock` for the full rationale.
             if plan.diverging_blocks.is_empty() {
-                let copy_clocks: Vec<&[VectorClockEntry]> = bundle
-                    .copies
-                    .iter()
-                    .map(|c| c.manifest.vector_clock.as_slice())
-                    .collect();
+                let copy_clocks = gather_copy_clocks(&bundle);
                 state.highest_vector_clock_seen = silent_merge_clock(
                     &disk_vector_clock,
                     &copy_clocks,
@@ -317,11 +313,7 @@ pub fn sync_pass_pause_on_conflict(
             local_highest_seen: _,
         } => {
             if plan.diverging_blocks.is_empty() {
-                let copy_clocks: Vec<&[VectorClockEntry]> = bundle
-                    .copies
-                    .iter()
-                    .map(|c| c.manifest.vector_clock.as_slice())
-                    .collect();
+                let copy_clocks = gather_copy_clocks(&bundle);
                 state.highest_vector_clock_seen = silent_merge_clock(
                     &disk_vector_clock,
                     &copy_clocks,
@@ -385,11 +377,7 @@ pub fn sync_pass_inspect(
             local_highest_seen: _,
         } => {
             if plan.diverging_blocks.is_empty() {
-                let copy_clocks: Vec<&[VectorClockEntry]> = bundle
-                    .copies
-                    .iter()
-                    .map(|c| c.manifest.vector_clock.as_slice())
-                    .collect();
+                let copy_clocks = gather_copy_clocks(&bundle);
                 state.highest_vector_clock_seen = silent_merge_clock(
                     &disk_vector_clock,
                     &copy_clocks,
@@ -499,11 +487,7 @@ pub fn sync_pass_commit_decisions(
             local_highest_seen: _,
         } => {
             if plan.diverging_blocks.is_empty() {
-                let copy_clocks: Vec<&[VectorClockEntry]> = bundle
-                    .copies
-                    .iter()
-                    .map(|c| c.manifest.vector_clock.as_slice())
-                    .collect();
+                let copy_clocks = gather_copy_clocks(&bundle);
                 state.highest_vector_clock_seen = silent_merge_clock(
                     &disk_vector_clock,
                     &copy_clocks,
@@ -524,6 +508,22 @@ pub fn sync_pass_commit_decisions(
             Ok(SyncPassOutcome::MergedClean)
         }
     }
+}
+
+/// Borrow every conflict-copy manifest's `vector_clock` out of `bundle`
+/// as a slice-of-slices, ready to feed [`silent_merge_clock`] as its
+/// `copy_clocks` argument.
+///
+/// Each of the four sync passes reaches the silent-merge fast path with
+/// the same need — fold every conflict copy's clock into the LUB — so the
+/// gather lives here once rather than copy-pasted per pass. Pure: borrows
+/// from `bundle` without allocating beyond the outer `Vec` of references.
+fn gather_copy_clocks(bundle: &VaultBundle) -> Vec<&[VectorClockEntry]> {
+    bundle
+        .copies
+        .iter()
+        .map(|c| c.manifest.vector_clock.as_slice())
+        .collect()
 }
 
 /// Compute the post-silent-merge `highest_vector_clock_seen` as the

--- a/cli/src/pipeline/mod.rs
+++ b/cli/src/pipeline/mod.rs
@@ -1,0 +1,39 @@
+//! One sync attempt — composes
+//! `sync_once → prepare_merge → veto UX → commit_with_decisions` and
+//! updates the caller-held [`secretary_core::sync::SyncState`] in place.
+//!
+//! Spec: [`docs/superpowers/specs/2026-05-23-c2-headless-sync-cli-design.md`](../../docs/superpowers/specs/2026-05-23-c2-headless-sync-cli-design.md)
+//! §"Module layout" + §"Daemon loop sketch".
+//!
+//! The [`run_one`] entry point is the single seam consumed by both
+//! `once` (one attempt then exit) and `run` (daemon loop) subcommands.
+//! It is intentionally pure-orchestration: every disk read/write and
+//! every cryptographic step happens inside the `core::sync` primitives
+//! it dispatches to. The local side effects are limited to:
+//!
+//! - Mutating `state` in place when the disk-side clock moves forward
+//!   (`AppliedAutomatically`, `SilentMerge`, `MergedAndCommitted`).
+//! - Driving the caller-supplied [`crate::veto::VetoUx`] on the
+//!   `ConcurrentDetected` arm.
+//!
+//! `RollbackRejected` deliberately does NOT advance state — `state`
+//! survives byte-for-byte so the caller can persist the same value
+//! after dispatching the [`RunOutcome::RollbackRejected`] exit code.
+//!
+//! ## Module layout
+//!
+//! - `outcomes` — the three outcome enums ([`RunOutcome`],
+//!   [`SyncPassOutcome`], [`InspectOutcome`]) plus their pure
+//!   variant-level tests.
+//! - `passes` — the four sync passes ([`run_one`],
+//!   [`sync_pass_pause_on_conflict`], [`sync_pass_inspect`],
+//!   [`sync_pass_commit_decisions`]) plus the shared clock-folding
+//!   helpers and their LUB-contract tests.
+
+mod outcomes;
+mod passes;
+
+pub use outcomes::{InspectOutcome, RunOutcome, SyncPassOutcome};
+pub use passes::{
+    run_one, sync_pass_commit_decisions, sync_pass_inspect, sync_pass_pause_on_conflict,
+};

--- a/cli/src/pipeline/outcomes.rs
+++ b/cli/src/pipeline/outcomes.rs
@@ -1,0 +1,345 @@
+//! Outcome enums returned by the four sync passes in [`super::passes`].
+//!
+//! These are pure data types — no I/O, no crypto. [`RunOutcome`] is the
+//! daemon/`once` entry-point result; [`SyncPassOutcome`] and
+//! [`InspectOutcome`] are the auto-pause / interactive-resolution pass
+//! results. They live apart from the pass functions so the orchestration
+//! logic in [`super::passes`] reads as control flow, not type definitions.
+
+use secretary_core::sync::draft::RecordCollisionSummary;
+use secretary_core::sync::{ManifestHash, RecordTombstoneVeto, RollbackEvidence};
+
+/// Outcome of one sync attempt. The caller logs the variant and maps
+/// it to an [`crate::exit::ExitCode`] (in `once` mode) or continues the
+/// daemon loop (in `run` mode).
+///
+/// `vetoes_resolved` on the merged-and-committed variant doubles as a
+/// metric (how many record-level vetoes the operator's chosen
+/// [`crate::veto::VetoUx`] adjudicated this pass). Zero means a concurrent
+/// state was detected but every divergence merged cleanly without any veto
+/// candidates — distinct from [`Self::SilentMerge`], where the diff
+/// plan itself was empty.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RunOutcome {
+    /// Disk vector clock equals the local `highest_vector_clock_seen`.
+    /// No state mutation.
+    NothingToDo,
+    /// Disk strictly dominates the local `highest_vector_clock_seen`.
+    /// `state` advanced to match.
+    AppliedAutomatically,
+    /// Concurrent state was detected and the diff plan was non-empty:
+    /// `prepare_merge` produced a draft, the veto UX adjudicated any
+    /// tombstone disputes, and `commit_with_decisions` wrote the
+    /// merged result. `state` advanced to the post-merge clock.
+    /// `vetoes_resolved` reports the number of record-level vetoes the
+    /// UX handled (zero is valid — happens when the concurrent
+    /// divergence was all field-level merges with no tombstone fights).
+    MergedAndCommitted {
+        /// Number of [`secretary_core::sync::RecordTombstoneVeto`]
+        /// entries the veto UX adjudicated. Zero ⇒ silent record merge
+        /// (still a real commit, just no operator decisions surfaced).
+        vetoes_resolved: usize,
+    },
+    /// Concurrent state was detected but the diff plan was empty
+    /// (no diverging blocks after authentication; this is the
+    /// "concurrent at the manifest level, identical at the block
+    /// level" fast path). `state.highest_vector_clock_seen` advanced
+    /// to the LUB of the canonical disk clock, every conflict-copy
+    /// clock in the bundle, and the prior local-seen — mirroring
+    /// what `commit_with_decisions` returns on the
+    /// [`Self::MergedAndCommitted`] arm via
+    /// [`secretary_core::sync::DraftMerge::post_merge_clock`]. No
+    /// commit was issued.
+    SilentMerge,
+    /// Disk vector clock is strictly dominated by the local
+    /// `highest_vector_clock_seen` (rollback per
+    /// `docs/crypto-design.md` §10). `state` is NOT advanced — caller
+    /// surfaces [`crate::exit::ExitCode::RollbackRejected`] and the
+    /// next attempt sees the same disk state. Carries the
+    /// [`RollbackEvidence`] (disk clock + local clock) so the daemon
+    /// loop can log the attack indicator with forensic detail (#207).
+    RollbackRejected(RollbackEvidence),
+}
+
+impl RunOutcome {
+    /// `true` iff this outcome advanced `state.highest_vector_clock_seen`
+    /// and therefore must be persisted before the next daemon iteration.
+    /// Matches the C.2 spec §"State persistence" persist-list (extended
+    /// to include `SilentMerge`, which post-dates the spec text but does
+    /// advance the clock — see [`super::passes::run_one`]'s
+    /// `# State mutation contract` doc section for the per-variant details).
+    #[must_use]
+    pub fn advanced_state(&self) -> bool {
+        matches!(
+            self,
+            Self::AppliedAutomatically | Self::SilentMerge | Self::MergedAndCommitted { .. }
+        )
+    }
+}
+
+/// Outcome of one [`super::passes::sync_pass_pause_on_conflict`] pass. Mirrors
+/// [`RunOutcome`] for the safe arms, but replaces the always-commit
+/// `MergedAndCommitted` with two outcomes: [`Self::MergedClean`] (a
+/// concurrent state that merged with zero tombstone vetoes, committed) and
+/// [`Self::ConflictsPending`] (a concurrent state whose merge raised
+/// tombstone vetoes — **not** committed; the caller surfaces the count and
+/// defers to interactive resolution).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SyncPassOutcome {
+    /// Disk clock == local highest-seen. No state mutation, no write.
+    NothingToDo,
+    /// Disk strictly dominates local. `state` advanced; no vault write.
+    AppliedAutomatically,
+    /// Concurrent, `diverging_blocks` empty → silent-merge clock advance.
+    /// `state` advanced; no vault write.
+    SilentMerge,
+    /// Concurrent, `diverging_blocks` non-empty, **zero** vetoes →
+    /// `commit_with_decisions(.., [])` wrote the merged result. `state` advanced.
+    MergedClean,
+    /// Concurrent, `diverging_blocks` non-empty, **non-empty** vetoes →
+    /// nothing committed, `state` NOT advanced. `veto_count` is the number of
+    /// tombstone disputes awaiting a human decision.
+    ConflictsPending { veto_count: usize },
+    /// Disk clock strictly dominated by local (rollback). `state` unchanged.
+    RollbackRejected,
+}
+
+/// Outcome of one [`super::passes::sync_pass_inspect`] pass — the stateless
+/// call-1 of the interactive resolution flow. Identical to [`SyncPassOutcome`]
+/// on every arm except `ConflictsPending`, which carries the full draft detail
+/// (vetoes + collision summaries + the manifest-hash freshness token) the UI
+/// needs to render the resolution modal. Nothing is committed on this arm and
+/// `state` is not advanced — the commit happens in
+/// [`super::passes::sync_pass_commit_decisions`].
+#[derive(Debug, Clone, PartialEq)]
+pub enum InspectOutcome {
+    /// Disk clock == local highest-seen. No state mutation, no write.
+    NothingToDo,
+    /// Disk strictly dominates local. `state` advanced; no vault write.
+    AppliedAutomatically,
+    /// Concurrent, `diverging_blocks` empty -> silent-merge clock advance.
+    /// `state` advanced; no vault write.
+    SilentMerge,
+    /// Concurrent, `diverging_blocks` non-empty, **zero** vetoes ->
+    /// `commit_with_decisions(.., [])` wrote the merged result. `state` advanced.
+    MergedClean,
+    /// Concurrent, `diverging_blocks` non-empty, **non-empty** vetoes ->
+    /// nothing committed, `state` NOT advanced. Carries the full draft
+    /// detail the UI needs to render the resolution modal.
+    ConflictsPending {
+        /// Tombstone disputes awaiting a human decision.
+        ///
+        /// **Secret hygiene.** Each [`RecordTombstoneVeto`] carries
+        /// `local_state: Record` — the AEAD-decrypted canonical record,
+        /// i.e. plaintext secret material. It is wiped on drop by
+        /// `RecordTombstoneVeto`'s own `ZeroizeOnDrop` (firing whenever this
+        /// `Vec` drops), and the secret field *values* redact under `Debug`
+        /// (`SecretString`/`SecretBytes` print `<redacted>`), so only
+        /// metadata is loggable. `InspectOutcome` is deliberately NOT
+        /// `ZeroizeOnDrop` itself — that would forbid the bridge from moving
+        /// these fields out when projecting to its DTO. Consumers MUST NOT
+        /// cache, stash, or widen the lifetime of this `Vec` beyond the
+        /// resolution flow.
+        vetoes: Vec<RecordTombstoneVeto>,
+        /// Metadata-only field-level LWW collisions surfaced for display.
+        collisions: Vec<RecordCollisionSummary>,
+        /// Freshness token (TOCTOU anchor) the commit step re-checks.
+        manifest_hash: ManifestHash,
+    },
+    /// Disk clock strictly dominated by local (rollback). `state` unchanged.
+    RollbackRejected,
+}
+
+#[cfg(test)]
+mod tests {
+    //! Pure variant-level tests for the outcome enums (equality, `Debug`,
+    //! `Clone`, `advanced_state`). End-to-end orchestration tests for the
+    //! pass functions live in `cli/tests/pipeline_integration.rs` /
+    //! `cli/tests/sync_pass_integration.rs` because they need a real
+    //! `golden_vault_001`-backed on-disk vault that the unit-test harness
+    //! can't easily fake (every `sync_once` call authenticates a signed
+    //! manifest and AEAD-decrypts a body).
+
+    use super::*;
+
+    fn sample_evidence() -> RollbackEvidence {
+        RollbackEvidence {
+            disk_vector_clock: Vec::new(),
+            local_highest_seen: Vec::new(),
+        }
+    }
+
+    /// Identical variants compare equal via the derived [`Eq`] impl.
+    #[test]
+    fn nothing_to_do_is_self_equal() {
+        assert_eq!(RunOutcome::NothingToDo, RunOutcome::NothingToDo);
+    }
+
+    /// Identical `AppliedAutomatically` values compare equal.
+    #[test]
+    fn applied_automatically_is_self_equal() {
+        assert_eq!(
+            RunOutcome::AppliedAutomatically,
+            RunOutcome::AppliedAutomatically
+        );
+    }
+
+    /// Identical `SilentMerge` values compare equal.
+    #[test]
+    fn silent_merge_is_self_equal() {
+        assert_eq!(RunOutcome::SilentMerge, RunOutcome::SilentMerge);
+    }
+
+    /// Identical `RollbackRejected` values compare equal.
+    #[test]
+    fn rollback_rejected_is_self_equal() {
+        assert_eq!(
+            RunOutcome::RollbackRejected(sample_evidence()),
+            RunOutcome::RollbackRejected(sample_evidence())
+        );
+    }
+
+    /// Two `MergedAndCommitted` with the same `vetoes_resolved` count
+    /// compare equal — the variant's discriminant + payload is the
+    /// equality contract callers see.
+    #[test]
+    fn merged_and_committed_eq_when_counts_match() {
+        assert_eq!(
+            RunOutcome::MergedAndCommitted { vetoes_resolved: 0 },
+            RunOutcome::MergedAndCommitted { vetoes_resolved: 0 }
+        );
+        assert_eq!(
+            RunOutcome::MergedAndCommitted { vetoes_resolved: 7 },
+            RunOutcome::MergedAndCommitted { vetoes_resolved: 7 }
+        );
+    }
+
+    /// Two `MergedAndCommitted` with DIFFERENT veto counts must NOT
+    /// compare equal. Pins the discriminant payload as part of the
+    /// equality contract — a future refactor that boxed the count into
+    /// a struct would break this test rather than silently collapsing
+    /// distinct outcomes.
+    #[test]
+    fn merged_and_committed_ne_when_counts_differ() {
+        assert_ne!(
+            RunOutcome::MergedAndCommitted { vetoes_resolved: 0 },
+            RunOutcome::MergedAndCommitted { vetoes_resolved: 1 }
+        );
+        assert_ne!(
+            RunOutcome::MergedAndCommitted { vetoes_resolved: 1 },
+            RunOutcome::MergedAndCommitted { vetoes_resolved: 2 }
+        );
+    }
+
+    /// Distinct variants compare not-equal. Sanity check that the
+    /// derived `PartialEq` discriminates on variant, not just payload.
+    #[test]
+    fn distinct_variants_are_not_equal() {
+        assert_ne!(RunOutcome::NothingToDo, RunOutcome::AppliedAutomatically);
+        assert_ne!(RunOutcome::AppliedAutomatically, RunOutcome::SilentMerge);
+        assert_ne!(
+            RunOutcome::SilentMerge,
+            RunOutcome::RollbackRejected(sample_evidence())
+        );
+        assert_ne!(
+            RunOutcome::NothingToDo,
+            RunOutcome::RollbackRejected(sample_evidence())
+        );
+        assert_ne!(
+            RunOutcome::AppliedAutomatically,
+            RunOutcome::MergedAndCommitted { vetoes_resolved: 0 }
+        );
+        assert_ne!(
+            RunOutcome::SilentMerge,
+            RunOutcome::MergedAndCommitted { vetoes_resolved: 0 }
+        );
+    }
+
+    /// `Debug` is available on every variant (rules out a future
+    /// refactor that removed the derive). The exact format isn't part
+    /// of the contract, but we sanity-check that the variant name is
+    /// present in the rendered output — that's what an operator-facing
+    /// log line would surface.
+    #[test]
+    fn debug_format_includes_variant_name() {
+        assert!(format!("{:?}", RunOutcome::NothingToDo).contains("NothingToDo"));
+        assert!(format!("{:?}", RunOutcome::AppliedAutomatically).contains("AppliedAutomatically"));
+        assert!(format!("{:?}", RunOutcome::SilentMerge).contains("SilentMerge"));
+        assert!(
+            format!("{:?}", RunOutcome::RollbackRejected(sample_evidence()))
+                .contains("RollbackRejected")
+        );
+        let merged = RunOutcome::MergedAndCommitted { vetoes_resolved: 3 };
+        let dbg = format!("{merged:?}");
+        assert!(dbg.contains("MergedAndCommitted"));
+        assert!(dbg.contains('3'));
+    }
+
+    #[test]
+    fn sync_pass_outcome_variants_are_self_equal() {
+        assert_eq!(SyncPassOutcome::NothingToDo, SyncPassOutcome::NothingToDo);
+        assert_eq!(
+            SyncPassOutcome::AppliedAutomatically,
+            SyncPassOutcome::AppliedAutomatically
+        );
+        assert_eq!(SyncPassOutcome::SilentMerge, SyncPassOutcome::SilentMerge);
+        assert_eq!(SyncPassOutcome::MergedClean, SyncPassOutcome::MergedClean);
+        assert_eq!(
+            SyncPassOutcome::RollbackRejected,
+            SyncPassOutcome::RollbackRejected
+        );
+        assert_eq!(
+            SyncPassOutcome::ConflictsPending { veto_count: 3 },
+            SyncPassOutcome::ConflictsPending { veto_count: 3 }
+        );
+    }
+    #[test]
+    fn sync_pass_outcome_conflicts_pending_discriminates_on_count() {
+        assert_ne!(
+            SyncPassOutcome::ConflictsPending { veto_count: 1 },
+            SyncPassOutcome::ConflictsPending { veto_count: 2 }
+        );
+    }
+    #[test]
+    fn sync_pass_outcome_debug_includes_variant_name() {
+        assert!(format!("{:?}", SyncPassOutcome::SilentMerge).contains("SilentMerge"));
+        let c = SyncPassOutcome::ConflictsPending { veto_count: 7 };
+        let dbg = format!("{c:?}");
+        assert!(dbg.contains("ConflictsPending"));
+        assert!(dbg.contains('7'));
+    }
+
+    #[test]
+    fn advanced_state_true_for_advancing_arms() {
+        assert!(RunOutcome::AppliedAutomatically.advanced_state());
+        assert!(RunOutcome::SilentMerge.advanced_state());
+        assert!(RunOutcome::MergedAndCommitted { vetoes_resolved: 0 }.advanced_state());
+        assert!(RunOutcome::MergedAndCommitted { vetoes_resolved: 5 }.advanced_state());
+    }
+
+    #[test]
+    fn advanced_state_false_for_non_advancing_arms() {
+        assert!(!RunOutcome::NothingToDo.advanced_state());
+        assert!(!RunOutcome::RollbackRejected(sample_evidence()).advanced_state());
+    }
+
+    /// `Clone` round-trip preserves variant + payload. Pins the
+    /// derived impl in place — callers in the daemon loop will clone
+    /// outcomes for logging while continuing to dispatch on the
+    /// original.
+    #[test]
+    fn clone_preserves_variant_and_payload() {
+        let outcomes = [
+            RunOutcome::NothingToDo,
+            RunOutcome::AppliedAutomatically,
+            RunOutcome::SilentMerge,
+            RunOutcome::RollbackRejected(sample_evidence()),
+            RunOutcome::MergedAndCommitted {
+                vetoes_resolved: 42,
+            },
+        ];
+        for outcome in &outcomes {
+            assert_eq!(outcome, &outcome.clone());
+        }
+    }
+}

--- a/cli/src/pipeline/passes.rs
+++ b/cli/src/pipeline/passes.rs
@@ -1,178 +1,23 @@
-//! One sync attempt — composes
-//! `sync_once → prepare_merge → veto UX → commit_with_decisions` and
-//! updates the caller-held [`SyncState`] in place.
+//! The four sync passes plus their shared clock-folding helpers.
 //!
-//! Spec: [`docs/superpowers/specs/2026-05-23-c2-headless-sync-cli-design.md`](../../docs/superpowers/specs/2026-05-23-c2-headless-sync-cli-design.md)
-//! §"Module layout" + §"Daemon loop sketch".
-//!
-//! The [`run_one`] entry point is the single seam consumed by both
-//! `once` (one attempt then exit) and `run` (daemon loop) subcommands.
-//! It is intentionally pure-orchestration: every disk read/write and
-//! every cryptographic step happens inside the `core::sync` primitives
-//! it dispatches to. The local side effects are limited to:
-//!
-//! - Mutating `state` in place when the disk-side clock moves forward
-//!   (`AppliedAutomatically`, `SilentMerge`, `MergedAndCommitted`).
-//! - Driving the caller-supplied [`VetoUx`] on the
-//!   `ConcurrentDetected` arm.
-//!
-//! `RollbackRejected` deliberately does NOT advance state — `state`
-//! survives byte-for-byte so the caller can persist the same value
-//! after dispatching the [`RunOutcome::RollbackRejected`] exit code.
+//! Each pass composes `sync_once → prepare_merge → commit_with_decisions`
+//! and updates the caller-held [`SyncState`] in place; they differ only in
+//! how they handle the `ConcurrentDetected` arm (auto-veto, pause, inspect,
+//! commit). The outcome enums they return live in [`super::outcomes`].
 
 use std::path::Path;
 
 use secretary_core::crypto::secret::SecretBytes;
-use secretary_core::sync::draft::RecordCollisionSummary;
 use secretary_core::sync::{
-    commit_with_decisions, prepare_merge, sync_once, ManifestHash, RecordTombstoneVeto,
-    RollbackEvidence, SyncError, SyncOutcome, SyncState, VaultBundle, VetoDecision,
+    commit_with_decisions, prepare_merge, sync_once, ManifestHash, SyncError, SyncOutcome,
+    SyncState, VaultBundle, VetoDecision,
 };
 use secretary_core::unlock::UnlockedIdentity;
 use secretary_core::vault::block::VectorClockEntry;
 use secretary_core::vault::merge_vector_clocks;
 
+use super::outcomes::{InspectOutcome, RunOutcome, SyncPassOutcome};
 use crate::veto::VetoUx;
-
-/// Outcome of one sync attempt. The caller logs the variant and maps
-/// it to an [`crate::exit::ExitCode`] (in `once` mode) or continues the
-/// daemon loop (in `run` mode).
-///
-/// `vetoes_resolved` on the merged-and-committed variant doubles as a
-/// metric (how many record-level vetoes the operator's chosen
-/// [`VetoUx`] adjudicated this pass). Zero means a concurrent state
-/// was detected but every divergence merged cleanly without any veto
-/// candidates — distinct from [`Self::SilentMerge`], where the diff
-/// plan itself was empty.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum RunOutcome {
-    /// Disk vector clock equals the local `highest_vector_clock_seen`.
-    /// No state mutation.
-    NothingToDo,
-    /// Disk strictly dominates the local `highest_vector_clock_seen`.
-    /// `state` advanced to match.
-    AppliedAutomatically,
-    /// Concurrent state was detected and the diff plan was non-empty:
-    /// `prepare_merge` produced a draft, the veto UX adjudicated any
-    /// tombstone disputes, and `commit_with_decisions` wrote the
-    /// merged result. `state` advanced to the post-merge clock.
-    /// `vetoes_resolved` reports the number of record-level vetoes the
-    /// UX handled (zero is valid — happens when the concurrent
-    /// divergence was all field-level merges with no tombstone fights).
-    MergedAndCommitted {
-        /// Number of [`secretary_core::sync::RecordTombstoneVeto`]
-        /// entries the veto UX adjudicated. Zero ⇒ silent record merge
-        /// (still a real commit, just no operator decisions surfaced).
-        vetoes_resolved: usize,
-    },
-    /// Concurrent state was detected but the diff plan was empty
-    /// (no diverging blocks after authentication; this is the
-    /// "concurrent at the manifest level, identical at the block
-    /// level" fast path). `state.highest_vector_clock_seen` advanced
-    /// to the LUB of the canonical disk clock, every conflict-copy
-    /// clock in the bundle, and the prior local-seen — mirroring
-    /// what `commit_with_decisions` returns on the
-    /// [`Self::MergedAndCommitted`] arm via
-    /// [`secretary_core::sync::DraftMerge::post_merge_clock`]. No
-    /// commit was issued.
-    SilentMerge,
-    /// Disk vector clock is strictly dominated by the local
-    /// `highest_vector_clock_seen` (rollback per
-    /// `docs/crypto-design.md` §10). `state` is NOT advanced — caller
-    /// surfaces [`crate::exit::ExitCode::RollbackRejected`] and the
-    /// next attempt sees the same disk state. Carries the
-    /// [`RollbackEvidence`] (disk clock + local clock) so the daemon
-    /// loop can log the attack indicator with forensic detail (#207).
-    RollbackRejected(RollbackEvidence),
-}
-
-impl RunOutcome {
-    /// `true` iff this outcome advanced `state.highest_vector_clock_seen`
-    /// and therefore must be persisted before the next daemon iteration.
-    /// Matches the C.2 spec §"State persistence" persist-list (extended
-    /// to include `SilentMerge`, which post-dates the spec text but does
-    /// advance the clock — see `run_one`'s `# State mutation contract`
-    /// doc section for the per-variant details).
-    #[must_use]
-    pub fn advanced_state(&self) -> bool {
-        matches!(
-            self,
-            Self::AppliedAutomatically | Self::SilentMerge | Self::MergedAndCommitted { .. }
-        )
-    }
-}
-
-/// Outcome of one [`sync_pass_pause_on_conflict`] pass. Mirrors
-/// [`RunOutcome`] for the safe arms, but replaces the always-commit
-/// `MergedAndCommitted` with two outcomes: [`Self::MergedClean`] (a
-/// concurrent state that merged with zero tombstone vetoes, committed) and
-/// [`Self::ConflictsPending`] (a concurrent state whose merge raised
-/// tombstone vetoes — **not** committed; the caller surfaces the count and
-/// defers to interactive resolution).
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum SyncPassOutcome {
-    /// Disk clock == local highest-seen. No state mutation, no write.
-    NothingToDo,
-    /// Disk strictly dominates local. `state` advanced; no vault write.
-    AppliedAutomatically,
-    /// Concurrent, `diverging_blocks` empty → silent-merge clock advance.
-    /// `state` advanced; no vault write.
-    SilentMerge,
-    /// Concurrent, `diverging_blocks` non-empty, **zero** vetoes →
-    /// `commit_with_decisions(.., [])` wrote the merged result. `state` advanced.
-    MergedClean,
-    /// Concurrent, `diverging_blocks` non-empty, **non-empty** vetoes →
-    /// nothing committed, `state` NOT advanced. `veto_count` is the number of
-    /// tombstone disputes awaiting a human decision.
-    ConflictsPending { veto_count: usize },
-    /// Disk clock strictly dominated by local (rollback). `state` unchanged.
-    RollbackRejected,
-}
-
-/// Outcome of one [`sync_pass_inspect`] pass — the stateless call-1 of the
-/// interactive resolution flow. Identical to [`SyncPassOutcome`] on every arm
-/// except `ConflictsPending`, which carries the full draft detail (vetoes +
-/// collision summaries + the manifest-hash freshness token) the UI needs to
-/// render the resolution modal. Nothing is committed on this arm and `state`
-/// is not advanced — the commit happens in `sync_pass_commit_decisions` (Task 3).
-#[derive(Debug, Clone, PartialEq)]
-pub enum InspectOutcome {
-    /// Disk clock == local highest-seen. No state mutation, no write.
-    NothingToDo,
-    /// Disk strictly dominates local. `state` advanced; no vault write.
-    AppliedAutomatically,
-    /// Concurrent, `diverging_blocks` empty -> silent-merge clock advance.
-    /// `state` advanced; no vault write.
-    SilentMerge,
-    /// Concurrent, `diverging_blocks` non-empty, **zero** vetoes ->
-    /// `commit_with_decisions(.., [])` wrote the merged result. `state` advanced.
-    MergedClean,
-    /// Concurrent, `diverging_blocks` non-empty, **non-empty** vetoes ->
-    /// nothing committed, `state` NOT advanced. Carries the full draft
-    /// detail the UI needs to render the resolution modal.
-    ConflictsPending {
-        /// Tombstone disputes awaiting a human decision.
-        ///
-        /// **Secret hygiene.** Each [`RecordTombstoneVeto`] carries
-        /// `local_state: Record` — the AEAD-decrypted canonical record,
-        /// i.e. plaintext secret material. It is wiped on drop by
-        /// `RecordTombstoneVeto`'s own `ZeroizeOnDrop` (firing whenever this
-        /// `Vec` drops), and the secret field *values* redact under `Debug`
-        /// (`SecretString`/`SecretBytes` print `<redacted>`), so only
-        /// metadata is loggable. `InspectOutcome` is deliberately NOT
-        /// `ZeroizeOnDrop` itself — that would forbid the bridge from moving
-        /// these fields out when projecting to its DTO. Consumers MUST NOT
-        /// cache, stash, or widen the lifetime of this `Vec` beyond the
-        /// resolution flow.
-        vetoes: Vec<RecordTombstoneVeto>,
-        /// Metadata-only field-level LWW collisions surfaced for display.
-        collisions: Vec<RecordCollisionSummary>,
-        /// Freshness token (TOCTOU anchor) the commit step re-checks.
-        manifest_hash: ManifestHash,
-    },
-    /// Disk clock strictly dominated by local (rollback). `state` unchanged.
-    RollbackRejected,
-}
 
 /// Run one sync attempt against `vault_folder` using `identity` for
 /// reads, `password` for the commit-side re-open, and `state` as both
@@ -348,8 +193,8 @@ pub fn sync_pass_pause_on_conflict(
 /// shared arms (`AppliedAutomatically` / `SilentMerge` advance `state`,
 /// `MergedClean` advances after a zero-veto commit); on the
 /// `ConflictsPending` arm `state` is byte-identical and the vault
-/// unwritten — the commit happens later in `sync_pass_commit_decisions`
-/// (Task 3) re-checking `manifest_hash` for freshness.
+/// unwritten — the commit happens later in [`sync_pass_commit_decisions`]
+/// re-checking `manifest_hash` for freshness.
 ///
 /// # Errors
 /// Any [`SyncError`] from the underlying `sync_once` / `prepare_merge` /
@@ -563,127 +408,13 @@ fn silent_merge_clock(
 
 #[cfg(test)]
 mod tests {
-    //! Pure variant-level tests for [`RunOutcome`]. End-to-end
-    //! orchestration tests for [`run_one`] live in
-    //! [`cli/tests/pipeline_integration.rs`] because they need a real
-    //! `golden_vault_001`-backed on-disk vault that the unit test
-    //! harness can't easily fake (every `sync_once` call authenticates
-    //! a signed manifest and AEAD-decrypts a body).
+    //! Pure LUB-contract tests for [`silent_merge_clock`]. End-to-end
+    //! orchestration tests for the pass functions live in
+    //! `cli/tests/pipeline_integration.rs` /
+    //! `cli/tests/sync_pass_integration.rs` (they need a real
+    //! `golden_vault_001`-backed on-disk vault the unit harness can't fake).
 
     use super::*;
-
-    fn sample_evidence() -> RollbackEvidence {
-        RollbackEvidence {
-            disk_vector_clock: Vec::new(),
-            local_highest_seen: Vec::new(),
-        }
-    }
-
-    /// Identical variants compare equal via the derived [`Eq`] impl.
-    #[test]
-    fn nothing_to_do_is_self_equal() {
-        assert_eq!(RunOutcome::NothingToDo, RunOutcome::NothingToDo);
-    }
-
-    /// Identical `AppliedAutomatically` values compare equal.
-    #[test]
-    fn applied_automatically_is_self_equal() {
-        assert_eq!(
-            RunOutcome::AppliedAutomatically,
-            RunOutcome::AppliedAutomatically
-        );
-    }
-
-    /// Identical `SilentMerge` values compare equal.
-    #[test]
-    fn silent_merge_is_self_equal() {
-        assert_eq!(RunOutcome::SilentMerge, RunOutcome::SilentMerge);
-    }
-
-    /// Identical `RollbackRejected` values compare equal.
-    #[test]
-    fn rollback_rejected_is_self_equal() {
-        assert_eq!(
-            RunOutcome::RollbackRejected(sample_evidence()),
-            RunOutcome::RollbackRejected(sample_evidence())
-        );
-    }
-
-    /// Two `MergedAndCommitted` with the same `vetoes_resolved` count
-    /// compare equal — the variant's discriminant + payload is the
-    /// equality contract callers see.
-    #[test]
-    fn merged_and_committed_eq_when_counts_match() {
-        assert_eq!(
-            RunOutcome::MergedAndCommitted { vetoes_resolved: 0 },
-            RunOutcome::MergedAndCommitted { vetoes_resolved: 0 }
-        );
-        assert_eq!(
-            RunOutcome::MergedAndCommitted { vetoes_resolved: 7 },
-            RunOutcome::MergedAndCommitted { vetoes_resolved: 7 }
-        );
-    }
-
-    /// Two `MergedAndCommitted` with DIFFERENT veto counts must NOT
-    /// compare equal. Pins the discriminant payload as part of the
-    /// equality contract — a future refactor that boxed the count into
-    /// a struct would break this test rather than silently collapsing
-    /// distinct outcomes.
-    #[test]
-    fn merged_and_committed_ne_when_counts_differ() {
-        assert_ne!(
-            RunOutcome::MergedAndCommitted { vetoes_resolved: 0 },
-            RunOutcome::MergedAndCommitted { vetoes_resolved: 1 }
-        );
-        assert_ne!(
-            RunOutcome::MergedAndCommitted { vetoes_resolved: 1 },
-            RunOutcome::MergedAndCommitted { vetoes_resolved: 2 }
-        );
-    }
-
-    /// Distinct variants compare not-equal. Sanity check that the
-    /// derived `PartialEq` discriminates on variant, not just payload.
-    #[test]
-    fn distinct_variants_are_not_equal() {
-        assert_ne!(RunOutcome::NothingToDo, RunOutcome::AppliedAutomatically);
-        assert_ne!(RunOutcome::AppliedAutomatically, RunOutcome::SilentMerge);
-        assert_ne!(
-            RunOutcome::SilentMerge,
-            RunOutcome::RollbackRejected(sample_evidence())
-        );
-        assert_ne!(
-            RunOutcome::NothingToDo,
-            RunOutcome::RollbackRejected(sample_evidence())
-        );
-        assert_ne!(
-            RunOutcome::AppliedAutomatically,
-            RunOutcome::MergedAndCommitted { vetoes_resolved: 0 }
-        );
-        assert_ne!(
-            RunOutcome::SilentMerge,
-            RunOutcome::MergedAndCommitted { vetoes_resolved: 0 }
-        );
-    }
-
-    /// `Debug` is available on every variant (rules out a future
-    /// refactor that removed the derive). The exact format isn't part
-    /// of the contract, but we sanity-check that the variant name is
-    /// present in the rendered output — that's what an operator-facing
-    /// log line would surface.
-    #[test]
-    fn debug_format_includes_variant_name() {
-        assert!(format!("{:?}", RunOutcome::NothingToDo).contains("NothingToDo"));
-        assert!(format!("{:?}", RunOutcome::AppliedAutomatically).contains("AppliedAutomatically"));
-        assert!(format!("{:?}", RunOutcome::SilentMerge).contains("SilentMerge"));
-        assert!(
-            format!("{:?}", RunOutcome::RollbackRejected(sample_evidence()))
-                .contains("RollbackRejected")
-        );
-        let merged = RunOutcome::MergedAndCommitted { vetoes_resolved: 3 };
-        let dbg = format!("{merged:?}");
-        assert!(dbg.contains("MergedAndCommitted"));
-        assert!(dbg.contains('3'));
-    }
 
     /// Build a `VectorClockEntry` from a fill byte + counter — keeps
     /// the LUB-helper tests' fixture lines compact and self-evident.
@@ -771,73 +502,5 @@ mod tests {
         let result = silent_merge_clock(&disk, &copies, &prior);
         // 0xAA: max(1, 5, 3) = 5. 0xBB: max(9, 2, 4) = 9.
         assert_eq!(result, vec![vc(0xAA, 5), vc(0xBB, 9)]);
-    }
-
-    #[test]
-    fn sync_pass_outcome_variants_are_self_equal() {
-        assert_eq!(SyncPassOutcome::NothingToDo, SyncPassOutcome::NothingToDo);
-        assert_eq!(
-            SyncPassOutcome::AppliedAutomatically,
-            SyncPassOutcome::AppliedAutomatically
-        );
-        assert_eq!(SyncPassOutcome::SilentMerge, SyncPassOutcome::SilentMerge);
-        assert_eq!(SyncPassOutcome::MergedClean, SyncPassOutcome::MergedClean);
-        assert_eq!(
-            SyncPassOutcome::RollbackRejected,
-            SyncPassOutcome::RollbackRejected
-        );
-        assert_eq!(
-            SyncPassOutcome::ConflictsPending { veto_count: 3 },
-            SyncPassOutcome::ConflictsPending { veto_count: 3 }
-        );
-    }
-    #[test]
-    fn sync_pass_outcome_conflicts_pending_discriminates_on_count() {
-        assert_ne!(
-            SyncPassOutcome::ConflictsPending { veto_count: 1 },
-            SyncPassOutcome::ConflictsPending { veto_count: 2 }
-        );
-    }
-    #[test]
-    fn sync_pass_outcome_debug_includes_variant_name() {
-        assert!(format!("{:?}", SyncPassOutcome::SilentMerge).contains("SilentMerge"));
-        let c = SyncPassOutcome::ConflictsPending { veto_count: 7 };
-        let dbg = format!("{c:?}");
-        assert!(dbg.contains("ConflictsPending"));
-        assert!(dbg.contains('7'));
-    }
-
-    #[test]
-    fn advanced_state_true_for_advancing_arms() {
-        assert!(RunOutcome::AppliedAutomatically.advanced_state());
-        assert!(RunOutcome::SilentMerge.advanced_state());
-        assert!(RunOutcome::MergedAndCommitted { vetoes_resolved: 0 }.advanced_state());
-        assert!(RunOutcome::MergedAndCommitted { vetoes_resolved: 5 }.advanced_state());
-    }
-
-    #[test]
-    fn advanced_state_false_for_non_advancing_arms() {
-        assert!(!RunOutcome::NothingToDo.advanced_state());
-        assert!(!RunOutcome::RollbackRejected(sample_evidence()).advanced_state());
-    }
-
-    /// `Clone` round-trip preserves variant + payload. Pins the
-    /// derived impl in place — callers in the daemon loop will clone
-    /// outcomes for logging while continuing to dispatch on the
-    /// original.
-    #[test]
-    fn clone_preserves_variant_and_payload() {
-        let outcomes = [
-            RunOutcome::NothingToDo,
-            RunOutcome::AppliedAutomatically,
-            RunOutcome::SilentMerge,
-            RunOutcome::RollbackRejected(sample_evidence()),
-            RunOutcome::MergedAndCommitted {
-                vetoes_resolved: 42,
-            },
-        ];
-        for outcome in &outcomes {
-            assert_eq!(outcome, &outcome.clone());
-        }
     }
 }

--- a/cli/tests/sync_pass_integration.rs
+++ b/cli/tests/sync_pass_integration.rs
@@ -761,6 +761,120 @@ fn commit_decisions_stale_token_is_rejected() {
     assert_eq!(hash_dir(&vault_folder), before, "no write on stale token");
 }
 
+/// Simulate a **real** concurrent writer advancing the canonical manifest
+/// on disk between call-1 (inspect) and call-2 (commit): re-sign the same
+/// logical manifest — same diverging block entry, same clocks — under a
+/// fresh AEAD nonce. The envelope ciphertext (and therefore the recomputed
+/// `manifest_hash` freshness token) changes, while the merge shape
+/// `sync_once` reclassifies stays identical, so call-2 still reaches the
+/// `ConcurrentDetected` freshness gate.
+///
+/// Reads the current block entry straight out of the on-disk canonical
+/// manifest (rather than reconstructing the staging constants) so the
+/// rewrite is a faithful no-op on merge semantics — only the bytes move.
+/// The nonce is runtime-generated, not a literal, to avoid CodeQL's
+/// `rust/hard-coded-cryptographic-value` sink rule (see CLAUDE.md
+/// `feedback_test_crypto_random_not_hardcoded`).
+fn rewrite_canonical_manifest_fresh_nonce(
+    vault_folder: &Path,
+    password: &SecretBytes,
+    block_uuid: [u8; 16],
+) {
+    use rand::RngCore as _;
+
+    let open = open_vault(vault_folder, Unlocker::Password(password), None)
+        .expect("re-open vault for concurrent manifest rewrite");
+    let entry = open
+        .manifest
+        .blocks
+        .iter()
+        .find(|b| b.block_uuid == block_uuid)
+        .cloned()
+        .expect("divergent block present in canonical manifest");
+
+    let mut fresh_nonce = [0u8; 24];
+    rand::rng().fill_bytes(&mut fresh_nonce);
+
+    write_manifest_with_block_entry(
+        vault_folder,
+        &open,
+        MANIFEST_FILENAME,
+        block_uuid,
+        entry.fingerprint,
+        entry.vector_clock_summary.clone(),
+        open.manifest.vector_clock.clone(),
+        entry.last_mod_ms,
+        &fresh_nonce,
+    );
+}
+
+/// Real-race counterpart to `commit_decisions_stale_token_is_rejected`.
+/// That test flips a byte of the token to *simulate* staleness; this one
+/// induces genuine staleness — a concurrent writer re-writes the canonical
+/// manifest on disk between call-1 and call-2 — while the operator still
+/// holds the **genuine, unmodified** call-1 token. The recomputed manifest
+/// hash no longer matches it, so the freshness gate trips with
+/// [`SyncError::EvidenceStale`] and writes nothing.
+///
+/// This is the wiring proof the byte-flip test cannot give: it shows the
+/// gate compares the token against the *live recompute source*, not against
+/// itself. An `expected != expected` bug (or one recomputing from a stale
+/// cached value) would pass `commit_decisions_stale_token_is_rejected` yet
+/// fail here.
+#[test]
+fn commit_decisions_real_concurrent_manifest_rewrite_is_rejected() {
+    let (_tmp, vault_folder, identity, password, vault_uuid, block_uuid) =
+        stage_concurrent_veto_vault();
+    let mut state = concurrent_state(vault_uuid);
+    let state_before = state.clone();
+
+    // Call-1: obtain the GENUINE freshness token + veto set.
+    let mut probe_state = state.clone();
+    let (vetoes, genuine_token) =
+        match sync_pass_inspect(&vault_folder, &identity, &password, &mut probe_state, 0).unwrap() {
+            InspectOutcome::ConflictsPending {
+                vetoes,
+                manifest_hash,
+                ..
+            } => (vetoes, manifest_hash),
+            other => panic!("expected ConflictsPending, got {other:?}"),
+        };
+    let decisions: Vec<VetoDecision> = vetoes
+        .iter()
+        .map(|v| VetoDecision::AcceptTombstone {
+            record_id: v.record_id,
+        })
+        .collect();
+
+    // A concurrent writer races the disk forward between call-1 and
+    // call-2: same merge shape, fresh manifest bytes.
+    rewrite_canonical_manifest_fresh_nonce(&vault_folder, &password, block_uuid);
+    let before = hash_dir(&vault_folder);
+
+    // Call-2 with the GENUINE (not flipped) token now trips the gate.
+    let err = sync_pass_commit_decisions(
+        &vault_folder,
+        &identity,
+        &password,
+        &mut state,
+        genuine_token,
+        decisions,
+        1,
+    )
+    .unwrap_err();
+
+    assert!(matches!(err, SyncError::EvidenceStale), "got {err:?}");
+    assert_eq!(
+        hash_dir(&vault_folder),
+        before,
+        "no write on a genuinely stale token (real concurrent rewrite)"
+    );
+    assert_eq!(
+        state, state_before,
+        "state must not advance when the freshness gate rejects"
+    );
+}
+
 // --- Manual-smoke staging helper (#161) --------------------------------
 
 /// Materialize the two-device tombstone-veto divergence into a *persistent*

--- a/cli/tests/sync_pass_integration.rs
+++ b/cli/tests/sync_pass_integration.rs
@@ -830,15 +830,22 @@ fn commit_decisions_real_concurrent_manifest_rewrite_is_rejected() {
 
     // Call-1: obtain the GENUINE freshness token + veto set.
     let mut probe_state = state.clone();
-    let (vetoes, genuine_token) =
-        match sync_pass_inspect(&vault_folder, &identity, &password, &mut probe_state, 0).unwrap() {
-            InspectOutcome::ConflictsPending {
-                vetoes,
-                manifest_hash,
-                ..
-            } => (vetoes, manifest_hash),
-            other => panic!("expected ConflictsPending, got {other:?}"),
-        };
+    let (vetoes, genuine_token) = match sync_pass_inspect(
+        &vault_folder,
+        &identity,
+        &password,
+        &mut probe_state,
+        0,
+    )
+    .unwrap()
+    {
+        InspectOutcome::ConflictsPending {
+            vetoes,
+            manifest_hash,
+            ..
+        } => (vetoes, manifest_hash),
+        other => panic!("expected ConflictsPending, got {other:?}"),
+    };
     let decisions: Vec<VetoDecision> = vetoes
         .iter()
         .map(|v| VetoDecision::AcceptTombstone {

--- a/docs/handoffs/2026-06-26-pipeline-refactor-193-shipped.md
+++ b/docs/handoffs/2026-06-26-pipeline-refactor-193-shipped.md
@@ -1,0 +1,84 @@
+# NEXT_SESSION.md — #193 pipeline.rs refactor (dedup + real-race test + submodule split) ✅ SHIPPED (PR opening)
+
+**Session date:** 2026-06-26. Started from a clean baton — PR #299 (uniffi value-marshalling secret residue) had merged to `main` as `debdb5a9` (#306); removed the merged worktree/branch (`.worktrees/uniffi-secret-residue` / `docs/uniffi-secret-residue-299`). User picked **#193** (CLI pipeline refactor — a Rust-learning task, zero platform-worktree collision). Also closed **#272** as verified-stale (see §1). Executed in project-local worktree `.worktrees/pipeline-refactor-193`, branch `refactor/pipeline-submodule-193`.
+
+**Status:** ✅ **SHIPPED — branch `refactor/pipeline-submodule-193`, PR opening.** Pure internal refactor + one regression test of the already-✅ C.2 CLI sync pipeline. **No behavior change, no public-API change, no `core`/FFI/on-disk-format/`conformance.py` change.** `Closes #193` rides in the PR body.
+
+## (1) What we shipped this session
+
+**Housekeeping first — closed #272 (stale).** `cargo fmt --all --check` passes clean on `main` (exit 0); the rustfmt drift #272 reported was fixed by `f498206c` (#288), which also added the fmt/clippy CI gate. Closed with that evidence.
+
+**#193 — three subtasks** (follow-ups deferred from the D.1.15 interactive-conflict-resolution Task-3 review), each its own commit:
+
+1. **Extract `gather_copy_clocks` helper** — the 5-line conflict-copy clock gather feeding `silent_merge_clock` was copy-pasted into all four sync passes (`run_one`, `sync_pass_pause_on_conflict`, `sync_pass_inspect`, `sync_pass_commit_decisions`). Now one pure `gather_copy_clocks(&VaultBundle) -> Vec<&[VectorClockEntry]>` beside `silent_merge_clock`. No behavior change; existing integration tests are the guard.
+
+2. **Pipeline-level real-race `EvidenceStale` test** — `commit_decisions_stale_token_is_rejected` *fakes* staleness by XOR-flipping a token byte (disk stays fresh). Added `commit_decisions_real_concurrent_manifest_rewrite_is_rejected`: a concurrent writer genuinely re-signs the canonical manifest under a **fresh runtime-generated nonce** (`rand`, not a literal — per [[feedback_test_crypto_random_not_hardcoded]]) between call-1 (inspect) and call-2 (commit), same merge shape, different bytes, while the operator holds the **genuine** call-1 token. The recomputed hash no longer matches → early freshness gate trips with `EvidenceStale`, no write. This pins the gate's *other* operand to the live `sync_once` recompute (the byte-flip test only pins that the token is consulted). **Proven a real guard:** mutating the gate to `manifest_hash != manifest_hash` turns *both* staleness tests red; the correct gate keeps them green (verified, then reverted).
+
+3. **Split `pipeline.rs` (~840 lines) into a `pipeline/` submodule** — over the project's ~500-line heuristic ([[feedback_split_files_proactively]]). Natural cut, no behavior change:
+   - `pipeline/outcomes.rs` — the 3 outcome enums (`RunOutcome`/`SyncPassOutcome`/`InspectOutcome`) + `RunOutcome::advanced_state` + their pure variant-level tests.
+   - `pipeline/passes.rs` — the 4 sync passes + `gather_copy_clocks` + `silent_merge_clock` + the LUB-contract tests.
+   - `pipeline/mod.rs` — the seam: module docs + `pub use` re-exports, so `pipeline::{run_one, RunOutcome, sync_pass_*, InspectOutcome, SyncPassOutcome}` is byte-for-byte unchanged for `daemon.rs` / `main.rs` / the integration tests.
+
+**Branch commits** (off `main` @ `debdb5a9`):
+| SHA | What |
+|---|---|
+| `8cacd6e4` | **refactor(cli)**: extract `gather_copy_clocks`, dedup 4 sync passes |
+| `94b6fbeb` | **test(cli)**: pipeline-level real-race `EvidenceStale` guard |
+| `ae9eab1c` | **refactor(cli)**: split `pipeline.rs` into a `pipeline/` submodule |
+| `2ac50b55` | **style(cli)**: rustfmt the new real-race test (clippy-clean but un-fmt'd in `94b6fbeb`) |
+| (+ handoff commit) | this baton + retargeted `NEXT_SESSION.md` symlink |
+
+### Acceptance (verified this session, in the worktree)
+```bash
+cd /Users/hherb/src/secretary/.worktrees/pipeline-refactor-193
+cargo clippy --release --workspace --tests -- -D warnings   # clean
+cargo fmt --all --check                                      # clean (exit 0)
+cargo test --release --workspace                             # all green, 0 failed
+# the real-race guard specifically:
+cargo test --release -p secretary-cli --test sync_pass_integration \
+  commit_decisions_real_concurrent_manifest_rewrite_is_rejected   # ok
+```
+- cli lib **154** + all integration suites green; full workspace test suite green.
+- `cargo doc`: **no new** broken intra-doc links (14 pre-existing on `main`, 14 after — the `outcomes`/`passes` private-module links I briefly introduced were caught and fixed to plain code spans before commit).
+
+## (2) What's next
+**#193 done (PR open). Pick a fresh item.** Carried candidates (collision status as of this session):
+- **#290** — allowlist the 3 D.4 freshness false-positives (`origin_binding`/`registrable_domain`/`exact_origin` in `threat-model.md`). Trivial (3 allowlist entries, precedent exists), but **still collision-risky**: `.worktrees/d4-browser-autofill` (`claude/intelligent-davinci-hriple`) is active — coordinate first.
+- **#252** (Android) — `UniffiVaultSession` read-only path (`blockSummaries`/`vaultUuidHex`) lacks the wiped guard; mirrors the iOS #304 hardening for Kotlin. No pipeline collision.
+- **#231** (iOS) — enable `-strict-concurrency=complete` on the SwiftPM targets; natural follow-on to the #300 TSan work.
+- **#92** (docs) — clean up the **28 pre-existing `cargo doc` warnings** (14 are in `secretary-cli`: `watcher::*` unresolved links, `pipeline::run_one` from `daemon`/`main`/`unlock`, `log_outcome`/`start`/`run_against_vault` linking private items). Surfaced again this session; **already filed as #92** — a good self-contained docs slice. NB: `cargo doc -D warnings` is **not** a CI gate today.
+
+**Acceptance criteria template:** a failing test reproducing the gap on `main`, the typed-error/enforcement surface *proven* not assumed (security paths, [[feedback_verify_deferred_items]]), the platform's full test gate green, spec/`conformance.py` updated in lockstep if observable bytes/semantics change.
+
+**Open follow-up issues (carried):** #290 / #284 / #280 / #277 / #273 / #269 / #255 / #252 / #247 / #246 / #234 / #232 / #231 / #224 / #218 / #192 / #190 / #189 / #186 / #183 / #92. (#272 closed this session; #193 closing via this PR.)
+
+## (3) Open decisions and risks
+- **#272 closed this session** (verified-stale, evidence above). Was carried as "closeable" in the prior baton — done.
+- **README / ROADMAP unchanged (deliberate).** A pure internal refactor + regression test of the already-✅ C.2 CLI pipeline is no capability/milestone — matches the #210/#251/#229/#300 pure-hardening precedent (contrast #261/D.1.10, actual features that *did* get doc lines). No public API, behavior, or on-disk-format change.
+- **The real-race test is complementary, not a replacement.** It keeps the byte-flip `commit_decisions_stale_token_is_rejected` test — together they pin both operands of the freshness gate (token consulted *and* recompute is live). The `commit_with_decisions` *internal* second gate only catches a disk change *during* commit (between `prepare_merge` and write); the early gate is the only thing covering "disk moved between call-1 and call-2", which is exactly what the new test exercises.
+- **Risk:** none to product behavior (refactor preserves the public API verbatim; the split is a git rename + two new files; the only logic touched is the helper extraction, guarded by the unchanged integration suite).
+- **Process note (parallel-session hazard hit & recovered, twice):** the Edit/Write tools resolve `file_path` literally — a bare `/Users/hherb/src/secretary/cli/...` path edits the **main repo**, not the worktree, even with Bash cwd in the worktree. Symptom: a rebuild "passes" without recompiling + worktree `git status` clean after an edit. Recovered both times (`cp` modified main file → worktree, `git checkout --` in main; trees were identical from the same base). **Lesson saved as [[feedback_edit_tool_targets_main_not_worktree]]: always spell out `.worktrees/<name>/...` in file-tool paths.**
+
+## (4) Exact commands to resume
+```bash
+cd /Users/hherb/src/secretary
+git fetch --prune origin && git checkout main && git pull --ff-only origin main
+# If PR merged: branch + worktree can be removed:
+#   git worktree remove .worktrees/pipeline-refactor-193 && git branch -D refactor/pipeline-submodule-193
+git worktree list && git status -s
+
+# Re-verify this session's gate (from the worktree if the PR is still open):
+cd .worktrees/pipeline-refactor-193
+cargo clippy --release --workspace --tests -- -D warnings
+cargo test --release -p secretary-cli
+```
+
+## (5) Handoff file model
+`NEXT_SESSION.md` is a **relative symlink** to this file in `docs/handoffs/`. Authored once here; symlink retargeted in the same commit on the feature branch. New-path handoff → no add/add conflict. Branch cut from `origin/main` (`debdb5a9`); `origin/main` had **not** advanced at handoff time (verified `origin/main` == merge-base == `debdb5a9`), so no history-binding merge was needed.
+
+## Closing inventory
+- **State on close:** PR opening on `refactor/pipeline-submodule-193` (`8cacd6e4` dedup + `94b6fbeb` test + `ae9eab1c` split + `2ac50b55` fmt + handoff). Worktree `.worktrees/pipeline-refactor-193`.
+- **Acceptance:** clippy + fmt + full workspace test all green; no new broken doc links; zero `core`/FFI/on-disk-format/`conformance.py` touched → all language gates unaffected. `#193` closes via the PR; `#272` closed directly.
+- **README.md / ROADMAP.md:** unchanged (rationale in §3).
+- **CLAUDE.md:** unchanged.
+- **NEXT_SESSION.md:** symlink → `docs/handoffs/2026-06-26-pipeline-refactor-193-shipped.md`.


### PR DESCRIPTION
Closes #193.

Three deferred follow-ups from the D.1.15 interactive-conflict-resolution Task-3 review, each its own commit. Pure internal refactor + one regression test of the already-✅ C.2 CLI sync pipeline — **no behavior change, no public-API change, no `core`/FFI/on-disk-format/`conformance.py` change.**

## What changed

1. **Extract `gather_copy_clocks` helper** (`8cacd6e4`) — the 5-line conflict-copy clock gather feeding `silent_merge_clock` was copy-pasted into all four sync passes. Now one pure `gather_copy_clocks(&VaultBundle) -> Vec<&[VectorClockEntry]>`.

2. **Pipeline-level real-race `EvidenceStale` test** (`94b6fbeb`, fmt in `2ac50b55`) — the existing `commit_decisions_stale_token_is_rejected` *fakes* staleness by XOR-flipping a token byte (disk stays fresh). The new `commit_decisions_real_concurrent_manifest_rewrite_is_rejected` induces **genuine** staleness: a concurrent writer re-signs the canonical manifest under a fresh runtime-generated nonce between call-1 (inspect) and call-2 (commit) — same merge shape, different bytes — while the operator holds the genuine call-1 token. The recomputed hash no longer matches → the early freshness gate trips with `EvidenceStale`, no write. This pins the gate's *other* operand to the live `sync_once` recompute (the byte-flip test only pins that the token is consulted).

   Proven a real guard: mutating the gate to `manifest_hash != manifest_hash` turns both staleness tests red; the correct gate keeps them green.

3. **Split `pipeline.rs` (~840 lines) into a `pipeline/` submodule** (`ae9eab1c`) — over the project's ~500-line heuristic. `outcomes.rs` (the 3 outcome enums + variant tests), `passes.rs` (the 4 passes + clock helpers + LUB tests), `mod.rs` (docs + `pub use` re-exports). The public API `pipeline::{run_one, RunOutcome, sync_pass_*, InspectOutcome, SyncPassOutcome}` is byte-for-byte unchanged for `daemon.rs` / `main.rs` / the integration tests.

## Verification
- `cargo clippy --release --workspace --tests -- -D warnings` — clean
- `cargo fmt --all --check` — clean
- `cargo test --release --workspace` — all green, 0 failed (cli lib 154 + all integration suites)
- `cargo doc` — no new broken intra-doc links (14 pre-existing on `main`, tracked by #92; 14 after)

🤖 Generated with [Claude Code](https://claude.com/claude-code)