### PR TITLE
build(ios): enable Swift 6 strict-concurrency on the SwiftPM targets (#231)

### DIFF
--- a/NEXT_SESSION.md
+++ b/NEXT_SESSION.md
@@ -1,1 +1,1 @@
-docs/handoffs/2026-06-26-session-wiped-guard-252-shipped.md
+docs/handoffs/2026-06-26-ios-strict-concurrency-231-shipped.md

--- a/docs/handoffs/2026-06-26-ios-strict-concurrency-231-shipped.md
+++ b/docs/handoffs/2026-06-26-ios-strict-concurrency-231-shipped.md
@@ -1,0 +1,81 @@
+# NEXT_SESSION.md — #231 iOS Swift 6 strict-concurrency on the SwiftPM targets ✅ SHIPPED (PR opening)
+
+**Session date:** 2026-06-26. Started from a clean baton — PR #309 (the #252 cross-platform wipe-guard) had merged to `main` as `28c5b59d`; removed the merged worktree/branch (`.worktrees/session-wiped-guard-252` / `fix/session-wiped-guard-252`). User picked **#231** (enable strict concurrency on the iOS SwiftPM targets). Executed in project-local worktree `.worktrees/ios-strict-concurrency-231`, branch `feature/ios-strict-concurrency-231`.
+
+**Status:** ✅ **SHIPPED — branch `feature/ios-strict-concurrency-231`, PR opening.** Pure build-quality/CI-posture hardening of the three iOS SwiftPM packages. **No public-interface behavior change, no Rust/`core`/FFI/on-disk-format/`conformance.py` change.** `Closes #231` rides in the PR body.
+
+## (1) What we shipped this session
+
+**The gap (#231).** During the C.3 slice-2 review (#230) a real cross-thread race on `PresenterFolderWatch.onPulse` compiled with **zero warnings** — because the iOS SwiftPM targets built under Swift language mode 5 with **minimal** concurrency checking. The "zero strict-concurrency warnings" bar was therefore **vacuous** on the highest-risk surface (the real OS-callback adapters).
+
+**Design (settled with the user via options+recommendation):**
+- **Scope:** all three packages (`SecretaryDeviceUnlock`, `SecretaryVaultAccess`, `SecretaryKit`), every surfaced warning driven to zero — no leftover debt.
+- **Mechanism + teeth (one move):** adopt **Swift 6 language mode** by bumping each `Package.swift` to `swift-tools-version: 6.0`. This makes complete strict-concurrency checking a **hard compile error** (stronger teeth than `-warnings-as-errors`, and the canonical Apple mechanism the warning text itself names — "this is an error in the Swift 6 language mode"). No `unsafeFlags`, no over-broad `treatAllWarnings`.
+- **Empirically surgical:** measured first — under Swift 6 mode **only concurrency diagnostics** surface on these packages (zero unrelated Swift 6 source breaks), so the migration *is* purely the concurrency fixes.
+
+**The uniform fix.** Every surfaced diagnostic was the same class: a non-`Sendable` injected port/coordinator (or a value returned across the boundary) crossing an actor/`@MainActor` line on an `async` call. Fixed by **expressing the contract in the types** — the injected port protocols now require `Sendable` (correct: they are deliberately injected into actors and `@MainActor` view models). Mutable test fakes and lock-guarded real adapters are `@unchecked Sendable` with **stated** justifications (assumption stated, not hidden).
+
+**Highest-value catch:** the very file the issue cited — `PresenterFolderWatch` — surfaced the residual `MainActor.assumeIsolated` self-send hazard.
+
+**Branch commits** (off `main` @ `28c5b59d`):
+| SHA | What |
+|---|---|
+| `e2c79f1f` | **build(ios)**: Swift 6 on SecretaryDeviceUnlock — 4 port protocols + `DeviceUnlockCoordinator` Sendable; 4 fakes `@unchecked` |
+| `9329afc6` | **build(ios)**: Swift 6 on SecretaryVaultAccess — 5 ports (`VaultSyncPort`/`VaultOpenPort`/`VaultCreatePort`/`WriteReauthGate`/`BiometricAuthorizer`) + `VaultSession`/`CreatedVault`/`VaultLocation` Sendable; 4 fakes `@unchecked` |
+| `1232d7bc` | **build(ios)**: Swift 6 on SecretaryKit — `PresenterFolderWatch` + `UniffiVaultSession` `@unchecked`; `SecureEnclaveDeviceSecretStore` lock-guarded then `@unchecked`; one test re-isolated |
+| (+ handoff commit) | this baton + retargeted `NEXT_SESSION.md` symlink |
+
+### Acceptance (verified this session, in the worktree)
+```bash
+cd /Users/hherb/src/secretary/.worktrees/ios-strict-concurrency-231
+IOS_SIM='iPhone 17' bash ios/scripts/run-ios-tests.sh
+#   → DeviceUnlock 35 host tests, VaultAccess 205 host tests (both swift test),
+#     fresh xcframework build, SecretaryKit 37 simulator tests, SwiftUI app
+#     ** BUILD SUCCEEDED ** — all GREEN under Swift 6 mode, zero source warnings.
+```
+- **Genuine red→green:** captured the authoritative RED (build fails on `sending 'self.coordinator' risks causing data races` etc.) before each fix; GREEN after.
+- The only non-source warning left is an environmental `ld` note (the FFI static lib built against simulator SDK 26.5 vs deployment target 17.0) — pre-existing, no concurrency content, not introduced here.
+- **Code-review pass** (pr-review-toolkit code-reviewer) on the full diff: **no material issues**. It traced `start`/`stop` callers (the `@MainActor ChangeDetectionMonitor`) to confirm `PresenterFolderWatch` main-queue confinement is airtight, verified all three `@unchecked Sendable` claims are lock/confinement-enforced with no missed write sites, and confirmed no crypto "both halves" invariant was touched.
+
+## (2) What's next
+**#231 done (PR open). Pick a fresh item.** Carried candidates (collision status as of this session):
+- **#290** — allowlist the 3 D.4 freshness false-positives (`origin_binding`/`registrable_domain`/`exact_origin` in `threat-model.md`). Trivial (3 allowlist entries, precedent exists), but **collision-risky**: `.worktrees/d4-browser-autofill` (`claude/intelligent-davinci-hriple`) is active — coordinate first.
+- **#92** (docs) — clean up the 28 pre-existing `cargo doc` warnings (14 in `secretary-cli`). Self-contained docs slice; `cargo doc -D warnings` is **not** a CI gate today. No collision.
+- **SecretaryApp Swift 6 follow-up** (optional, no issue yet) — the XcodeGen `ios/SecretaryApp/` walking-skeleton app target is NOT a SwiftPM package, so it was out of #231's "SwiftPM targets" scope and still builds in its default (Swift 5) mode. It consumes the now-Swift-6 packages cleanly. Promoting the app target to Swift 6 would extend the bar to the app shell; low risk (thin SwiftUI), file an issue if wanted.
+- **CI note:** confirm `test.yml`'s Swift job picks up the new bar. The job runs `run-ios-tests.sh` / `swift test`, which now compile under Swift 6 mode, so a future concurrency regression fails CI automatically — that is the teeth. (Not re-verified in CI this session; verified locally.)
+
+**Acceptance criteria template:** a failing test/build reproducing the gap on `main`, the typed-error/enforcement surface *proven* not assumed (security paths, [[feedback_verify_deferred_items]]), the platform's full test gate green, spec/`conformance.py` updated in lockstep if observable bytes/semantics change.
+
+**Open follow-up issues (carried):** #290 / #284 / #280 / #277 / #273 / #269 / #255 / #247 / #246 / #234 / #232 / #224 / #218 / #192 / #190 / #189 / #186 / #183 / #92. (#231 closing via this PR.)
+
+## (3) Open decisions and risks
+- **Swift 6 language mode over `-strict-concurrency=complete` + warnings-as-errors (resolved with user).** Empirically Swift 6 mode surfaces *only* concurrency diagnostics here, so it is the surgical, self-documenting, blessed mechanism — and it satisfies both the "enable checking" and "teeth" decisions in one move (concurrency violations are hard errors). Avoids `unsafeFlags` (the registry-consumption caveat) and the over-broad `treatAllWarnings(as:.error)`.
+- **`@unchecked Sendable` is used in 7 places, each justified.** Test fakes (8) earn it via serial XCTest-through-`await` usage. Real adapters: `PresenterFolderWatch` via main-queue confinement (`presentedItemOperationQueue = .main`); `UniffiVaultSession` via its existing FFI-handle `NSLock` (#300/#304). The **only new lock** is in `SecureEnclaveDeviceSecretStore` — the security-critical SE conformer — where I added `diagnosticLock` around the mutable `lastReleaseDiagnostic` rather than *assume* serial usage (enforcement over assumptions, per [[feedback_security_no_assumptions]]).
+- **README / ROADMAP unchanged (deliberate).** No public interface / behavior / on-disk-format / milestone change — matches the #252/#300 pure-hardening precedent. Verified neither doc references `#231` or makes a now-inaccurate Swift-version claim. (The ROADMAP's 2026-06-14 Argon2id-off-main-actor entry mentions an old "non-`Sendable` `VaultSession` … Swift-5.9 Sendable warning" rationale — now historically superseded since `VaultSession` is `Sendable`, but it is a completed-milestone changelog entry describing the state at that time, so it is left as the historical record.)
+- **Risk:** none to product behavior. No protocol method semantics changed; the only runtime change is the new `diagnosticLock` (uncontended in practice) in the SE store. Public interfaces verbatim.
+- **Verification gate scope:** the full `run-ios-tests.sh` (xcframework rebuild + both pure host suites + SecretaryKit sim suite + app build) was exercised here (iOS toolchain available). CI runs the same gates.
+
+## (4) Exact commands to resume
+```bash
+cd /Users/hherb/src/secretary
+git fetch --prune origin && git checkout main && git pull --ff-only origin main
+# If PR merged: branch + worktree can be removed:
+#   git worktree remove .worktrees/ios-strict-concurrency-231 && git branch -D feature/ios-strict-concurrency-231
+git worktree list && git status -s
+
+# Re-verify this session's gate (from the worktree if the PR is still open):
+cd .worktrees/ios-strict-concurrency-231
+IOS_SIM='iPhone 17' bash ios/scripts/run-ios-tests.sh
+#   pure-package only (fast, no simulator/xcframework):
+#   ( cd ios/SecretaryDeviceUnlock && swift test ) && ( cd ios/SecretaryVaultAccess && swift test )
+```
+
+## (5) Handoff file model
+`NEXT_SESSION.md` is a **relative symlink** to this file in `docs/handoffs/`. Authored once here; symlink retargeted in the same commit on the feature branch. New-path handoff → no add/add conflict. Branch cut from `origin/main` (`28c5b59d`); at handoff time `origin/main` == merge-base == `28c5b59d` (verified), so no history-binding merge was needed.
+
+## Closing inventory
+- **State on close:** PR opening on `feature/ios-strict-concurrency-231` (`e2c79f1f` DeviceUnlock + `9329afc6` VaultAccess + `1232d7bc` SecretaryKit + handoff). Worktree `.worktrees/ios-strict-concurrency-231`.
+- **Acceptance:** full `run-ios-tests.sh` green — DeviceUnlock 35 + VaultAccess 205 host tests, SecretaryKit 37 simulator tests, SwiftUI app BUILD SUCCEEDED — all under Swift 6 mode, zero source-code warnings; genuine red→green proven; code-review clean. No `core`/FFI/on-disk-format/`conformance.py` touched → all language gates unaffected. `#231` closes via the PR.
+- **README.md / ROADMAP.md:** unchanged (rationale in §3).
+- **CLAUDE.md:** unchanged.
+- **NEXT_SESSION.md:** symlink → `docs/handoffs/2026-06-26-ios-strict-concurrency-231-shipped.md`.

--- a/ios/SecretaryDeviceUnlock/Package.swift
+++ b/ios/SecretaryDeviceUnlock/Package.swift
@@ -1,6 +1,11 @@
-// swift-tools-version: 5.9
+// swift-tools-version: 6.0
 import PackageDescription
 
+// Swift 6 language mode (the tools-version 6.0 default) makes complete
+// strict-concurrency checking a hard compile error rather than an opt-in
+// warning. This closes the "vacuous concurrency bar" gap from #231: a
+// non-`Sendable` value crossing an actor/`@MainActor` boundary now fails the
+// build instead of slipping past minimal checking to manual review.
 let package = Package(
     name: "SecretaryDeviceUnlock",
     platforms: [.macOS(.v13), .iOS(.v17)],

--- a/ios/SecretaryDeviceUnlock/Sources/SecretaryDeviceUnlock/DeviceEnrollment.swift
+++ b/ios/SecretaryDeviceUnlock/Sources/SecretaryDeviceUnlock/DeviceEnrollment.swift
@@ -9,7 +9,9 @@ public struct DeviceEnrollment: Equatable {
     }
 }
 
-public protocol DeviceEnrollmentMetadataStore {
+/// `Sendable` because conformers are injected into the (sendable)
+/// `DeviceUnlockCoordinator` and reached across the actor boundary (#231).
+public protocol DeviceEnrollmentMetadataStore: Sendable {
     func load() throws -> DeviceEnrollment?
     func save(_ enrollment: DeviceEnrollment) throws
     func clear() throws

--- a/ios/SecretaryDeviceUnlock/Sources/SecretaryDeviceUnlock/DeviceSecretEnclave.swift
+++ b/ios/SecretaryDeviceUnlock/Sources/SecretaryDeviceUnlock/DeviceSecretEnclave.swift
@@ -1,6 +1,10 @@
 /// A biometric-gated store for one 32-byte device secret. Conformers throw
 /// `DeviceUnlockError` for every failure (biometric, corruption, OS errors).
-public protocol DeviceSecretEnclave {
+///
+/// `Sendable` because conformers are injected into `DeviceUnlockCoordinator`,
+/// which a `@MainActor` view model sends across the actor boundary to call the
+/// `async` `release` (Swift 6 strict concurrency, #231).
+public protocol DeviceSecretEnclave: Sendable {
     var isEnrolled: Bool { get }
     /// Raw diagnostic from the most recent `release` failure ("domain=… code=…
     /// mappedTo=…"), for a UI to surface so the real Security-framework taxonomy

--- a/ios/SecretaryDeviceUnlock/Sources/SecretaryDeviceUnlock/DeviceUnlockCoordinator.swift
+++ b/ios/SecretaryDeviceUnlock/Sources/SecretaryDeviceUnlock/DeviceUnlockCoordinator.swift
@@ -1,7 +1,12 @@
 import Foundation
 
 /// Pure orchestration over three injected ports. No I/O of its own.
-public struct DeviceUnlockCoordinator {
+///
+/// Explicitly `Sendable` (its three ports are `Sendable`): a non-frozen public
+/// struct does not export synthesized `Sendable` across the module boundary, and
+/// a `@MainActor` view model sends it off-actor to call the `async` `unlock`
+/// (#231).
+public struct DeviceUnlockCoordinator: Sendable {
     let slotPort: VaultDeviceSlotPort
     let enclave: DeviceSecretEnclave
     let metadata: DeviceEnrollmentMetadataStore

--- a/ios/SecretaryDeviceUnlock/Sources/SecretaryDeviceUnlock/OpenedVault.swift
+++ b/ios/SecretaryDeviceUnlock/Sources/SecretaryDeviceUnlock/OpenedVault.swift
@@ -1,6 +1,9 @@
 /// An opened vault, abstracted so the pure package never names the uniffi
 /// `OpenVaultOutput`. The real adapter conforms `OpenVaultOutput` to this.
-public protocol OpenedVault {
+///
+/// `Sendable` because `DeviceUnlockCoordinator.unlock` returns it from a
+/// nonisolated `async` context back to a `@MainActor` caller (#231).
+public protocol OpenedVault: Sendable {
     var vaultUuid: [UInt8] { get }
     /// Release the manifest/identity secret material held by the opened vault.
     func wipe()

--- a/ios/SecretaryDeviceUnlock/Sources/SecretaryDeviceUnlock/VaultDeviceSlotPort.swift
+++ b/ios/SecretaryDeviceUnlock/Sources/SecretaryDeviceUnlock/VaultDeviceSlotPort.swift
@@ -12,7 +12,10 @@ public struct EnrolledSlot {
 }
 
 /// Thin port over the three B.2 device-slot uniffi functions. Throws `VaultSlotError`.
-public protocol VaultDeviceSlotPort {
+///
+/// `Sendable` because conformers are injected into the (sendable)
+/// `DeviceUnlockCoordinator` and reached across the actor boundary (#231).
+public protocol VaultDeviceSlotPort: Sendable {
     func addDeviceSlot(vaultPath: Data, password: [UInt8]) throws -> EnrolledSlot
     func openWithDeviceSecret(vaultPath: Data, deviceUuid: [UInt8], deviceSecret: [UInt8]) throws -> OpenedVault
     func removeDeviceSlot(vaultPath: Data, deviceUuid: [UInt8]) throws

--- a/ios/SecretaryDeviceUnlock/Sources/SecretaryDeviceUnlockTesting/FakeOpenedVault.swift
+++ b/ios/SecretaryDeviceUnlock/Sources/SecretaryDeviceUnlockTesting/FakeOpenedVault.swift
@@ -1,6 +1,10 @@
 import SecretaryDeviceUnlock
 
-public final class FakeOpenedVault: OpenedVault {
+/// `@unchecked Sendable`: a mutable spy double satisfying the (now `Sendable`)
+/// `OpenedVault` protocol. Safe because XCTest drives it serially through
+/// `await` — there is no real concurrent access — and the compiler cannot prove
+/// that for a mutable class. The assumption is stated, not hidden (#231).
+public final class FakeOpenedVault: OpenedVault, @unchecked Sendable {
     public let vaultUuid: [UInt8]
     public private(set) var wipeCount = 0
     public init(vaultUuid: [UInt8]) { self.vaultUuid = vaultUuid }

--- a/ios/SecretaryDeviceUnlock/Sources/SecretaryDeviceUnlockTesting/FakeVaultDeviceSlotPort.swift
+++ b/ios/SecretaryDeviceUnlock/Sources/SecretaryDeviceUnlockTesting/FakeVaultDeviceSlotPort.swift
@@ -3,7 +3,11 @@ import SecretaryDeviceUnlock
 
 /// In-memory `VaultDeviceSlotPort`. Records calls and supports error injection
 /// so the coordinator's every branch is reachable without the real FFI.
-public final class FakeVaultDeviceSlotPort: VaultDeviceSlotPort {
+///
+/// `@unchecked Sendable`: mutable spy/stub state satisfying the (now `Sendable`)
+/// port protocol. Safe because XCTest drives it serially through `await`; the
+/// assumption is stated, not hidden (#231).
+public final class FakeVaultDeviceSlotPort: VaultDeviceSlotPort, @unchecked Sendable {
     // Canned outputs / injected errors.
     public var addResult: Result<EnrolledSlot, VaultSlotError>
     public var openResult: Result<OpenedVault, VaultSlotError>

--- a/ios/SecretaryDeviceUnlock/Sources/SecretaryDeviceUnlockTesting/InMemoryDeviceSecretEnclave.swift
+++ b/ios/SecretaryDeviceUnlock/Sources/SecretaryDeviceUnlockTesting/InMemoryDeviceSecretEnclave.swift
@@ -3,7 +3,11 @@ import SecretaryDeviceUnlock
 /// In-memory `DeviceSecretEnclave`. Holds the bytes (no real crypto); supports
 /// injecting a `DeviceUnlockError` from `store`/`release` to simulate biometric
 /// failures. Reusable by the SecretaryKit Tier-2 integration test.
-public final class InMemoryDeviceSecretEnclave: DeviceSecretEnclave {
+///
+/// `@unchecked Sendable`: mutable spy/stub state satisfying the (now `Sendable`)
+/// enclave protocol. Safe because XCTest drives it serially through `await`; the
+/// assumption is stated, not hidden (#231).
+public final class InMemoryDeviceSecretEnclave: DeviceSecretEnclave, @unchecked Sendable {
     private var secret: [UInt8]?
     public var storeError: DeviceUnlockError?
     public var releaseError: DeviceUnlockError?

--- a/ios/SecretaryDeviceUnlock/Sources/SecretaryDeviceUnlockTesting/InMemoryEnrollmentMetadataStore.swift
+++ b/ios/SecretaryDeviceUnlock/Sources/SecretaryDeviceUnlockTesting/InMemoryEnrollmentMetadataStore.swift
@@ -1,6 +1,9 @@
 import SecretaryDeviceUnlock
 
-public final class InMemoryEnrollmentMetadataStore: DeviceEnrollmentMetadataStore {
+/// `@unchecked Sendable`: mutable spy/stub state satisfying the (now `Sendable`)
+/// metadata-store protocol. Safe because XCTest drives it serially through
+/// `await`; the assumption is stated, not hidden (#231).
+public final class InMemoryEnrollmentMetadataStore: DeviceEnrollmentMetadataStore, @unchecked Sendable {
     private var enrollment: DeviceEnrollment?
     /// Deliberately the untyped `Error?` (not a specific enum): unlike the
     /// enclave (`DeviceUnlockError`) and the slot port (`VaultSlotError`), the

--- a/ios/SecretaryKit/Package.swift
+++ b/ios/SecretaryKit/Package.swift
@@ -1,6 +1,12 @@
-// swift-tools-version: 5.9
+// swift-tools-version: 6.0
 import PackageDescription
 
+// Swift 6 language mode (the tools-version 6.0 default) makes complete
+// strict-concurrency checking a hard compile error rather than an opt-in
+// warning. This closes the "vacuous concurrency bar" gap from #231 on the
+// highest-risk surface — the real uniffi / NSFilePresenter / dispatch adapters —
+// where a non-`Sendable` value crossing an actor/`@MainActor` boundary now fails
+// the build instead of slipping past minimal checking to manual review.
 let package = Package(
     name: "SecretaryKit",
     platforms: [.iOS(.v17)],

--- a/ios/SecretaryKit/Sources/SecretaryKit/DeviceUnlock/SecureEnclaveDeviceSecretStore.swift
+++ b/ios/SecretaryKit/Sources/SecretaryKit/DeviceUnlock/SecureEnclaveDeviceSecretStore.swift
@@ -7,16 +7,33 @@ import SecretaryDeviceUnlock
 /// biometry-bound access control wraps the 32-byte device secret via ECIES; the
 /// SE private key never leaves the enclave. NOT covered by an automated test —
 /// real Face ID / Touch ID needs a device (the #202 follow-up's manual proof).
-public final class SecureEnclaveDeviceSecretStore: DeviceSecretEnclave {
+///
+/// `@unchecked Sendable`: `DeviceSecretEnclave` is `Sendable` (#231) and every
+/// non-`let` member of this conformer is the diagnostic below, whose access is
+/// serialized under `diagnosticLock` — so the guarantee is enforced by the lock,
+/// not merely assumed, mirroring `UniffiVaultSession`. All other state is
+/// immutable; the Keychain / Secure-Enclave APIs are themselves thread-safe.
+public final class SecureEnclaveDeviceSecretStore: DeviceSecretEnclave, @unchecked Sendable {
     private let keyTag: Data
     private let blobService: String
     private let blobAccount: String
     private let algorithm: SecKeyAlgorithm = .eciesEncryptionCofactorVariableIVX963SHA256AESGCM
 
+    /// Serializes access to `unsafeLastReleaseDiagnostic`. The diagnostic is
+    /// written inside `release` (across its biometric `await`) and read by the UI
+    /// afterward; the lock makes that safe even if a future caller drives two
+    /// releases concurrently, rather than relying on serial-usage convention.
+    private let diagnosticLock = NSLock()
     /// Raw diagnostic from the most recent `release` failure (domain+code +
     /// mapped case). Surfaced via the `DeviceSecretEnclave` protocol so the UI
     /// can display the real Security-framework taxonomy (#202). nil after success.
-    public private(set) var lastReleaseDiagnostic: String?
+    /// Backing storage — always go through `lastReleaseDiagnostic` / `record`,
+    /// never touch this directly, so every access holds `diagnosticLock`.
+    private var unsafeLastReleaseDiagnostic: String?
+
+    public var lastReleaseDiagnostic: String? {
+        diagnosticLock.withLock { unsafeLastReleaseDiagnostic }
+    }
 
     public init(keyTag: String = "com.secretary.deviceSecret.seKey",
                 blobService: String = "com.secretary.deviceSecret",
@@ -50,7 +67,7 @@ public final class SecureEnclaveDeviceSecretStore: DeviceSecretEnclave {
     }
 
     public func release(reason: String) async throws -> [UInt8] {
-        lastReleaseDiagnostic = nil
+        diagnosticLock.withLock { unsafeLastReleaseDiagnostic = nil }
         guard let blob = try loadBlob() else { throw DeviceUnlockError.notEnrolled }
         let context = LAContext()
         context.localizedReason = reason
@@ -233,7 +250,9 @@ public final class SecureEnclaveDeviceSecretStore: DeviceSecretEnclave {
     }
 
     private func record(domain: String, code: Int, mappedTo: String) {
-        lastReleaseDiagnostic = "domain=\(domain) code=\(code) mappedTo=\(mappedTo)"
+        diagnosticLock.withLock {
+            unsafeLastReleaseDiagnostic = "domain=\(domain) code=\(code) mappedTo=\(mappedTo)"
+        }
     }
 
     private func cfErrorString(_ error: Unmanaged<CFError>?) -> String {

--- a/ios/SecretaryKit/Sources/SecretaryKit/VaultAccess/PresenterFolderWatch.swift
+++ b/ios/SecretaryKit/Sources/SecretaryKit/VaultAccess/PresenterFolderWatch.swift
@@ -7,7 +7,13 @@ import SecretaryVaultAccess
 /// most general fit for the security-scoped, possibly-iCloud folders the app
 /// opens via bookmarks. (Future: `NSMetadataQuery` for iCloud-download-specific
 /// detection.)
-public final class PresenterFolderWatch: NSObject, FolderWatchPort, NSFilePresenter {
+/// `@unchecked Sendable`: the OS retains this presenter and the monitor that owns
+/// it may be referenced from any thread, but its only mutable state — `onPulse` —
+/// is confined to the main queue (the presenter's `presentedItemOperationQueue`
+/// is `.main`, and `start`/`stop` are reached from the `@MainActor`; see the
+/// `init` comment). Main-queue confinement is the isolation discipline that earns
+/// `Sendable` here, the way `UniffiVaultSession` earns it via a lock (#231).
+public final class PresenterFolderWatch: NSObject, FolderWatchPort, NSFilePresenter, @unchecked Sendable {
     public let presentedItemURL: URL?
     public let presentedItemOperationQueue: OperationQueue
     private var onPulse: (@MainActor (MonotonicInstant) -> Void)?

--- a/ios/SecretaryKit/Sources/SecretaryKit/VaultAccess/UniffiVaultSession.swift
+++ b/ios/SecretaryKit/Sources/SecretaryKit/VaultAccess/UniffiVaultSession.swift
@@ -22,7 +22,13 @@ import SecretaryVaultAccess
 /// off the main actor inside `UniffiVaultOpenPort`'s `runOffMainActor` so Argon2id
 /// open does not block the UI.) The lock is non-recursive — no method re-enters
 /// another; `currentBlock?.wipe()` is the FFI handle's own wipe, not `self.wipe()`.
-public final class UniffiVaultSession: VaultSession {
+///
+/// `@unchecked Sendable`: `VaultSession` is `Sendable` (a session returns across
+/// the open port's `async` boundary, #231), and this conformer earns it through
+/// the `lock` above rather than immutability — the compiler cannot see that the
+/// mutable `wiped`/`currentBlock`/`cachedDeviceUuid` state and the `deviceUuids`
+/// provider are all lock-serialized, so the guarantee is asserted here.
+public final class UniffiVaultSession: VaultSession, @unchecked Sendable {
     private let identity: UnlockedIdentity
     private let manifest: OpenVaultManifest
     private let deviceUuids: DeviceUuidProviding?

--- a/ios/SecretaryKit/Tests/SecretaryKitTests/BlockCrudRoundTripIntegrationTests.swift
+++ b/ios/SecretaryKit/Tests/SecretaryKitTests/BlockCrudRoundTripIntegrationTests.swift
@@ -12,7 +12,11 @@ import SecretaryDeviceUnlockTesting
 /// Staging pattern mirrors RecordEditIntegrationTests: cp -R the bundled fixture
 /// into a fresh tempdir, open via SecretaryKit.openVaultWithPassword, inject a
 /// FixedDeviceUuid so the test is deterministic.
-@MainActor
+// Only the test method is `@MainActor` (it drives the @MainActor
+// VaultBrowseViewModel); the class is nonisolated so `setUpWithError` /
+// `tearDownWithError` — which override nonisolated XCTestCase requirements — can
+// stage `vaultCopy` without a main-actor isolation clash (#231). Mirrors the
+// nonisolated RecordEditIntegrationTests.
 final class BlockCrudRoundTripIntegrationTests: XCTestCase {
     private let goldenPassword = "correct horse battery staple"
     private var vaultCopy: URL!
@@ -42,6 +46,7 @@ final class BlockCrudRoundTripIntegrationTests: XCTestCase {
         func deviceUuid(forVaultHex vaultHex: String) throws -> [UInt8] { value }
     }
 
+    @MainActor
     func testCreateThenMoveRoundTripThroughViewModel() async throws {
         // 1. Stage a writable temp copy + open via the real adapter.
         //    Block/field/value confirmed from golden_vault_001_inputs.json:

--- a/ios/SecretaryVaultAccess/Package.swift
+++ b/ios/SecretaryVaultAccess/Package.swift
@@ -1,6 +1,11 @@
-// swift-tools-version: 5.9
+// swift-tools-version: 6.0
 import PackageDescription
 
+// Swift 6 language mode (the tools-version 6.0 default) makes complete
+// strict-concurrency checking a hard compile error rather than an opt-in
+// warning. This closes the "vacuous concurrency bar" gap from #231: a
+// non-`Sendable` value crossing an actor/`@MainActor` boundary now fails the
+// build instead of slipping past minimal checking to manual review.
 let package = Package(
     name: "SecretaryVaultAccess",
     platforms: [.macOS(.v13), .iOS(.v17)],

--- a/ios/SecretaryVaultAccess/Sources/SecretaryVaultAccess/Reauth.swift
+++ b/ios/SecretaryVaultAccess/Sources/SecretaryVaultAccess/Reauth.swift
@@ -4,7 +4,10 @@ import Foundation
 /// Secure-Enclave key-release (the released secret is zeroized + discarded — re-auth
 /// only cares that the release succeeded). `isEnrolled` is the prompt-free predicate
 /// that decides whether the gate engages at all.
-public protocol BiometricAuthorizer {
+///
+/// `Sendable` because a `@MainActor` re-auth gate sends its conformer off-actor
+/// to `await authorize` (#231).
+public protocol BiometricAuthorizer: Sendable {
     var isEnrolled: Bool { get }
     /// Prove presence. Throws `DeviceUnlockError`-class failures on cancel / non-match
     /// / lockout. `async` because the real conformer drives an `LAContext` evaluation.
@@ -14,7 +17,10 @@ public protocol BiometricAuthorizer {
 /// A gate the view models `await` before each mutating write. Conformers decide
 /// whether a write needs a fresh biometric prompt (grace window) and engage the
 /// biometric only when required.
-public protocol WriteReauthGate {
+///
+/// `Sendable` because a `@MainActor` view model sends its gate off-actor to
+/// `await authorizeWrite` (#231).
+public protocol WriteReauthGate: Sendable {
     /// Returns normally when the write may proceed (authorized, within the grace
     /// window, or not enrolled); throws when biometry was required and failed.
     func authorizeWrite(reason: String) async throws

--- a/ios/SecretaryVaultAccess/Sources/SecretaryVaultAccess/VaultLocation.swift
+++ b/ios/SecretaryVaultAccess/Sources/SecretaryVaultAccess/VaultLocation.swift
@@ -5,7 +5,7 @@ import Foundation
 /// is NOT secret — it is a path-style token with no key material — so persisting
 /// it (e.g. in `UserDefaults`) carries no secret-residue risk. No vault key or
 /// credential ever flows through this type.
-public struct VaultLocation: Equatable {
+public struct VaultLocation: Equatable, Sendable {
     public let displayName: String
     /// Security-scoped bookmark data as returned by the system file picker.
     public let bookmark: Data

--- a/ios/SecretaryVaultAccess/Sources/SecretaryVaultAccess/VaultOpenPort.swift
+++ b/ios/SecretaryVaultAccess/Sources/SecretaryVaultAccess/VaultOpenPort.swift
@@ -6,7 +6,10 @@ import Foundation
 /// `async` because the real open runs Argon2id (CPU-heavy); implementations
 /// offload it off the calling actor so a `@MainActor` caller's UI stays
 /// responsive (see `SecretaryKit.runOffMainActor`).
-public protocol VaultOpenPort {
+///
+/// `Sendable` because a `@MainActor` view model sends its conformer off-actor to
+/// `await openWith…` (#231).
+public protocol VaultOpenPort: Sendable {
     func openWithPassword(vaultPath: Data, password: [UInt8]) async throws -> VaultSession
     func openWithRecovery(vaultPath: Data, phrase: [UInt8]) async throws -> VaultSession
 }

--- a/ios/SecretaryVaultAccess/Sources/SecretaryVaultAccess/VaultProvisioning.swift
+++ b/ios/SecretaryVaultAccess/Sources/SecretaryVaultAccess/VaultProvisioning.swift
@@ -34,7 +34,10 @@ public enum VaultProvisioningError: Error, Equatable {
 /// The product of a successful create: the persisted, openable location plus the
 /// one-shot recovery-phrase bytes (UTF-8). The caller (view-model) owns zeroizing
 /// `phrase` once the mnemonic step is dismissed.
-public struct CreatedVault {
+///
+/// `Sendable` because `VaultCreatePort.create` returns it from a nonisolated
+/// `async` context back to a `@MainActor` caller (#231).
+public struct CreatedVault: Sendable {
     public let location: VaultLocation
     public var phrase: [UInt8]
 
@@ -52,7 +55,10 @@ public struct CreatedVault {
 ///
 /// `async` because create runs Argon2id (CPU-heavy); implementations offload it
 /// off the calling actor (see `SecretaryKit.runOffMainActor`).
-public protocol VaultCreatePort {
+///
+/// `Sendable` because a `@MainActor` view model sends its conformer off-actor to
+/// `await create` (#231).
+public protocol VaultCreatePort: Sendable {
     func create(parent: URL,
                 vaultName: String,
                 password: [UInt8],

--- a/ios/SecretaryVaultAccess/Sources/SecretaryVaultAccess/VaultSession.swift
+++ b/ios/SecretaryVaultAccess/Sources/SecretaryVaultAccess/VaultSession.swift
@@ -8,7 +8,12 @@ import Foundation
 /// decrypted block handles, so it needs reference identity (callers compare
 /// sessions with `===`) and a single authoritative `wipe` — value-copy
 /// semantics would duplicate the handles and make `wipe` non-authoritative.
-public protocol VaultSession: AnyObject {
+///
+/// `Sendable` because `VaultOpenPort.openWith…` returns a session from a
+/// nonisolated `async` context back to a `@MainActor` caller (#231). The real
+/// conformer (`UniffiVaultSession`) is `@unchecked Sendable`, made safe by the
+/// lock that already serializes its FFI-handle access (#300/#304).
+public protocol VaultSession: AnyObject, Sendable {
     /// Opened vault UUID, lowercase hex, no dashes.
     var vaultUuidHex: String { get }
     /// Block metadata from the manifest (no plaintext).

--- a/ios/SecretaryVaultAccess/Sources/SecretaryVaultAccess/VaultSyncPort.swift
+++ b/ios/SecretaryVaultAccess/Sources/SecretaryVaultAccess/VaultSyncPort.swift
@@ -14,7 +14,10 @@ import Foundation
 /// `async` is also kept for protocol uniformity.
 ///
 /// `password` is passed per call and never retained by callers.
-public protocol VaultSyncPort {
+///
+/// `Sendable` because the `SyncCoordinator` actor holds a conformer and reaches
+/// it across its actor boundary on every `async` call (#231).
+public protocol VaultSyncPort: Sendable {
     func status(stateDir: String, vaultUuid: [UInt8]) async throws -> SyncStatus
     func sync(stateDir: String, vaultFolder: String,
               password: [UInt8], nowMs: UInt64) async throws -> SyncOutcome

--- a/ios/SecretaryVaultAccess/Sources/SecretaryVaultAccessTesting/FakeVaultCreatePort.swift
+++ b/ios/SecretaryVaultAccess/Sources/SecretaryVaultAccessTesting/FakeVaultCreatePort.swift
@@ -3,7 +3,11 @@ import SecretaryVaultAccess
 
 /// In-memory `VaultCreatePort` returning a pre-seeded result and spying on the
 /// inputs the view-model forwarded.
-public final class FakeVaultCreatePort: VaultCreatePort {
+///
+/// `@unchecked Sendable`: mutable spy state satisfying the (now `Sendable`) port
+/// protocol. Safe because XCTest drives it serially through `await`; the
+/// assumption is stated, not hidden (#231).
+public final class FakeVaultCreatePort: VaultCreatePort, @unchecked Sendable {
     private let result: Result<CreatedVault, VaultProvisioningError>
     public private(set) var lastParent: URL?
     public private(set) var lastVaultName: String?

--- a/ios/SecretaryVaultAccess/Sources/SecretaryVaultAccessTesting/FakeVaultOpenPort.swift
+++ b/ios/SecretaryVaultAccess/Sources/SecretaryVaultAccessTesting/FakeVaultOpenPort.swift
@@ -2,7 +2,11 @@ import Foundation
 import SecretaryVaultAccess
 
 /// In-memory `VaultOpenPort` returning pre-seeded results.
-public final class FakeVaultOpenPort: VaultOpenPort {
+///
+/// `@unchecked Sendable`: mutable spy state satisfying the (now `Sendable`) port
+/// protocol. Safe because XCTest drives it serially through `await`; the
+/// assumption is stated, not hidden (#231).
+public final class FakeVaultOpenPort: VaultOpenPort, @unchecked Sendable {
     private let passwordResult: Result<VaultSession, VaultAccessError>
     private let recoveryResult: Result<VaultSession, VaultAccessError>
     /// Spies asserted by the UnlockViewModel tests (which credential bytes the

--- a/ios/SecretaryVaultAccess/Sources/SecretaryVaultAccessTesting/FakeVaultSession.swift
+++ b/ios/SecretaryVaultAccess/Sources/SecretaryVaultAccessTesting/FakeVaultSession.swift
@@ -4,7 +4,12 @@ import SecretaryVaultAccess
 /// In-memory `VaultSession` for host tests. `recordsByBlock` is mutable so the
 /// write methods model real add/edit/delete/restore state transitions. Field
 /// `reveal` closures capture the stored plaintext.
-public final class FakeVaultSession: VaultSession {
+///
+/// `@unchecked Sendable`: mutable in-memory state satisfying the (now `Sendable`)
+/// `VaultSession` protocol. Safe because XCTest drives it serially through
+/// `await`; the assumption is stated, not hidden (#231). The real conformer
+/// (`UniffiVaultSession`) earns its `Sendable` via an FFI-handle lock instead.
+public final class FakeVaultSession: VaultSession, @unchecked Sendable {
     public let vaultUuidHex: String
     private var blocks: [BlockSummary]
     private var recordsByBlock: [[UInt8]: [RecordView]]

--- a/ios/SecretaryVaultAccess/Sources/SecretaryVaultAccessTesting/FakeVaultSyncPort.swift
+++ b/ios/SecretaryVaultAccess/Sources/SecretaryVaultAccessTesting/FakeVaultSyncPort.swift
@@ -3,7 +3,11 @@ import SecretaryVaultAccess
 
 /// In-memory `VaultSyncPort` returning pre-seeded results and spying on inputs.
 /// Mirrors `FakeVaultOpenPort`'s convention.
-public final class FakeVaultSyncPort: VaultSyncPort {
+///
+/// `@unchecked Sendable`: mutable spy state satisfying the (now `Sendable`) port
+/// protocol. Safe because XCTest drives it serially through `await`; the
+/// assumption is stated, not hidden (#231).
+public final class FakeVaultSyncPort: VaultSyncPort, @unchecked Sendable {
     private let statusResult: Result<SyncStatus, VaultSyncError>
     private let syncResult: Result<SyncOutcome, VaultSyncError>
     private let commitResult: Result<SyncOutcome, VaultSyncError>


### PR DESCRIPTION
Closes #231.

## What & why

The iOS SwiftPM packages built under Swift language mode 5 with **minimal** concurrency checking, so the "zero strict-concurrency warnings" bar was **vacuous** on the highest-risk surface — the real OS-callback adapters. (#230 found a genuine `PresenterFolderWatch.onPulse` cross-thread race that compiled with zero warnings.)

This bumps all three packages (`SecretaryDeviceUnlock`, `SecretaryVaultAccess`, `SecretaryKit`) to **`swift-tools-version: 6.0`** → **Swift 6 language mode**, which makes complete strict-concurrency checking a **hard compile error** rather than opt-in warnings. That is the teeth: a non-`Sendable` value crossing an actor/`@MainActor` boundary now fails the build (and CI) instead of slipping to manual review.

Chosen over `-strict-concurrency=complete` + `-warnings-as-errors` because, empirically, Swift 6 mode surfaces **only** concurrency diagnostics on these packages (zero unrelated source breaks) — it is the surgical, blessed mechanism the warning text itself names, with no `unsafeFlags` and no over-broad `treatAllWarnings`.

## The fix

Every surfaced diagnostic was the same class: an injected port/coordinator (or a value returned across the boundary) being sent across an isolation line on an `async` call. Fixed by **expressing the contract in the types**:

- **Injected port protocols now require `Sendable`** — correct, since they are deliberately injected into actors and `@MainActor` view models: `VaultSyncPort`, `VaultOpenPort`, `VaultCreatePort`, `WriteReauthGate`, `BiometricAuthorizer`, `DeviceSecretEnclave`, `VaultDeviceSlotPort`, `DeviceEnrollmentMetadataStore`, `OpenedVault`, plus `VaultSession` and the value types crossing back (`CreatedVault`, `VaultLocation`) and `DeviceUnlockCoordinator`.
- **Lock-guarded / confined real adapters → `@unchecked Sendable`** with stated justifications: `PresenterFolderWatch` (main-queue confinement), `UniffiVaultSession` (existing FFI-handle lock, #300/#304). For the security-critical `SecureEnclaveDeviceSecretStore` I added a `diagnosticLock` around its one mutable field rather than *assume* serial usage — enforcement, not a plausibility argument.
- **Mutable test fakes → `@unchecked Sendable`** (serial XCTest-through-`await`; assumption stated, not hidden).
- One integration test re-isolated (`@MainActor` moved from the class to the single test method so nonisolated `setUp`/`tearDown` can stage the temp vault), mirroring the existing `RecordEditIntegrationTests` pattern.

The highest-value catch is in the very file #231 cited (`PresenterFolderWatch`): the residual `MainActor.assumeIsolated` self-send hazard.

## Verification

Full `ios/scripts/run-ios-tests.sh` gate green under Swift 6 mode:
- `swift test` SecretaryDeviceUnlock — **35** host tests
- `swift test` SecretaryVaultAccess — **205** host tests
- xcframework rebuilt; SecretaryKit simulator suite — **37** tests
- SwiftUI walking-skeleton app — **BUILD SUCCEEDED**
- Zero source-code warnings; genuine red→green captured before each fix.

Independent code-review pass: no material issues (traced `start`/`stop` callers to confirm `PresenterFolderWatch` confinement; verified each `@unchecked Sendable` is lock/confinement-enforced with no missed write sites; confirmed no crypto invariant touched).

## Scope

No public-interface behavior change. **No Rust / `core` / FFI / on-disk-format / `conformance.py` change** → all language conformance gates unaffected. README/ROADMAP unchanged (pure build-quality hardening, matching the #252/#300 precedent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)