### PR TITLE
ci(#189): assert lean mobile-binding boundary (no notify/clap)

### DIFF
--- a/.github/workflows/rust-lint.yml
+++ b/.github/workflows/rust-lint.yml
@@ -61,3 +61,19 @@ jobs:
         uses: Swatinem/rust-cache@v2
       - name: Clippy (lib + tests, deny warnings)
         run: cargo clippy --release --workspace --tests -- -D warnings
+
+  lean-binding:
+    name: lean mobile-binding boundary
+    # Regression tripwire for #189: the daemon deps (notify/clap) must not leak
+    # into the FFI bridge or the mobile bindings beneath it. `cargo tree` only
+    # resolves the dependency graph — it never compiles the crates — so this job
+    # needs no GTK/WebKit/Tauri system libs and runs ubuntu-only and fast.
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      # Prove the matcher actually fires (positive control) before trusting a
+      # green guard — a vacuous check is the failure mode #231 surfaced.
+      - name: Self-test the guard matcher
+        run: bash ffi/scripts/check-lean-binding.sh --self-test
+      - name: Assert binding crates stay lean (no notify/clap)
+        run: bash ffi/scripts/check-lean-binding.sh

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,6 +55,12 @@ cargo clippy --release --workspace --tests -- -D warnings
 
 # Format
 cargo fmt --all
+
+# Assert the lean mobile-binding boundary (#189): notify/clap must NOT leak into
+# secretary-ffi-{uniffi,py,bridge}. `--self-test` first proves the matcher fires
+# on a known-positive control (secretary-cli) so a green guard is never vacuous.
+bash ffi/scripts/check-lean-binding.sh --self-test
+bash ffi/scripts/check-lean-binding.sh
 ```
 
 ### Python paths

--- a/NEXT_SESSION.md
+++ b/NEXT_SESSION.md
@@ -1,1 +1,1 @@
-docs/handoffs/2026-06-26-ios-strict-concurrency-231-shipped.md
+docs/handoffs/2026-06-26-lean-binding-ci-guard-189-shipped.md

--- a/docs/handoffs/2026-06-26-lean-binding-ci-guard-189-shipped.md
+++ b/docs/handoffs/2026-06-26-lean-binding-ci-guard-189-shipped.md
@@ -1,0 +1,74 @@
+# NEXT_SESSION.md — #189 lean mobile-binding CI guard ✅ SHIPPED (PR opening)
+
+**Session date:** 2026-06-26. Started from a clean baton — PR #310 (the #231 iOS Swift 6 strict-concurrency work) had merged to `main` as `99e3fcd9`; removed the merged worktree/branch (`.worktrees/ios-strict-concurrency-231` / `feature/ios-strict-concurrency-231`). User picked **#189** (CI guard asserting the lean mobile-binding feature boundary). Executed in project-local worktree `.worktrees/lean-binding-guard-189`, branch `feature/lean-binding-guard-189`.
+
+**Status:** ✅ **SHIPPED — branch `feature/lean-binding-guard-189`, PR opening.** Pure CI-posture / regression-insurance change. **No `core`/FFI/on-disk-format/`conformance.py`/crypto change; no Cargo manifest change.** `Closes #189` rides in the PR body.
+
+## (1) What we shipped this session
+
+**The gap (#189).** `secretary-cli`'s `daemon` feature gates `notify`/`clap`; `secretary-ffi-bridge` depends on `secretary-cli` with `default-features = false` to keep them out of the bridge and the mobile bindings (`secretary-ffi-uniffi`, `secretary-ffi-py`). This "lean binding" property is **build-context-dependent** — under `cargo test --workspace` Cargo unifies `daemon` ON (the `secretary-sync` bin requires it); the guarantee only holds for the `-p`-scoped `--no-default-features` resolution that is the real shipping context. Nothing in-repo prevented a future dependency edit from silently re-pulling `notify`/`clap` into the binding tree. The issue was filed before any CI workflows existed; they exist now (`rust-lint.yml`, `test.yml`, `ios-tsan.yml`), so it became actionable.
+
+**Design (settled with the user via brainstorming + options):** *Script + CI step*.
+- `ffi/scripts/check-lean-binding.sh` (new `ffi/scripts/` dir; mirrors the `run_conformance.sh` pattern — locally runnable, CI-invoked, self-documenting). One forbidden-deps matcher `FORBIDDEN_RE='^(clap|notify) '`, one guarded-crate list. For each crate: `cargo tree -p <crate> --no-default-features -e normal --prefix none` → grep the anchor → fail with the offending lines. `--prefix none` strips box-drawing chars so the line-anchor is robust (the issue's proposed `^\S*…` anchor was buggy). **Fail-closed**: a `cargo tree` error aborts via `set -euo pipefail` rather than passing as "lean" (the `{ grep || true; }` only neutralizes grep's exit-1-on-no-match).
+- **`--self-test` mode (positive control):** asserts the matcher *does* flag `clap`+`notify` in `secretary-cli` built with default features (daemon ON). If the control fails to trip, the script exits non-zero — proving the guard is never vacuous (**the #231 lesson:** a "zero warnings" bar that checked nothing).
+- CI: new ubuntu-only `lean-binding` job in `rust-lint.yml` (it's a static dependency-boundary lint; `cargo tree` only *resolves* — never compiles — so no GTK/WebKit/Tauri apt deps, fast). Runs `--self-test` first, then the guard.
+- CLAUDE.md Commands section documents both local invocations.
+
+**Branch commits** (off `main` @ `99e3fcd9`):
+| SHA | What |
+|---|---|
+| `55bb1281` | **docs(#189)**: design spec (`docs/superpowers/specs/2026-06-26-lean-binding-ci-guard-189-design.md`) |
+| `8417de4c` | **ci(#189)**: the guard script + `rust-lint.yml` `lean-binding` job + CLAUDE.md command |
+| (+ handoff commit) | this baton + retargeted `NEXT_SESSION.md` symlink |
+
+### Acceptance (verified this session, in the worktree)
+```bash
+cd /Users/hherb/src/secretary/.worktrees/lean-binding-guard-189
+bash ffi/scripts/check-lean-binding.sh --self-test   # → matcher fires on secretary-cli (control)
+bash ffi/scripts/check-lean-binding.sh               # → all 3 binding crates lean, exit 0
+shellcheck ffi/scripts/check-lean-binding.sh         # → clean
+```
+- **Genuine red→green:** temporarily flipped the bridge's `secretary-cli` dep back to default-features (daemon on) — the exact regression class the guard targets — and the guard correctly **FAILED** (exit 1) flagging `clap v4.6.1` + `notify v6.1.1` on **all three** binding crates; reverted clean (no residual diff), guard green again. Self-test fires independently.
+- **Code-review pass** (pr-review-toolkit code-reviewer) on the full staged diff: **no material issues**. Independently verified the fail-closed direction (pipefail aborts before the "lean" branch on a `cargo tree` error), the matcher anchoring (`clap_builder`/`clap_lex`/`clap_derive` do NOT false-positive; `clap `/`notify ` do), that the bridge genuinely reaches `secretary-cli` daemon-off on the guarded path (green ≠ no-op), and CI-toolchain consistency with the existing clippy job (no missing setup; `Cargo.lock` is committed so `cargo tree` resolves without mutation).
+
+## (2) What's next
+**#189 done (PR open). Pick a fresh item.** Carried collision-free candidates (from this session's backlog sweep):
+- **#190 / #192** — bridge/CRDT test gaps: assert `sync_vault`'s `MergedClean` arm under the held lockfile (#190) and that `prepare_merge` populates `DraftMerge.collisions` on a non-tombstone concurrent-edit fixture (#192). Pure Rust TDD; strengthens the merge-correctness net. No collision.
+- **#92** (docs) — clean up the 28 pre-existing `cargo doc` warnings (14 in `secretary-cli`); `cargo doc -D warnings` is **not** a CI gate today (could add it as teeth). No collision.
+- **#183** — reduce positional-arg count on the `rewrite_block_with_recipients` re-key engine. Rust refactor on a crypto-adjacent path — needs care.
+- **#290** — allowlist the 3 D.4 freshness false-positives in `threat-model.md`. **Still collision-risky:** `.worktrees/d4-browser-autofill` (`claude/intelligent-davinci-hriple`) was active this session — coordinate before touching D.4 docs.
+- **SecretaryApp Swift 6 follow-up** (optional, no issue) — the XcodeGen `ios/SecretaryApp/` app target was out of #231's "SwiftPM targets" scope and still builds in Swift 5 mode; promoting it would extend the strict-concurrency bar to the app shell.
+
+**Acceptance criteria template:** a failing test/build reproducing the gap on `main`, the typed-error/enforcement surface *proven* not assumed (security paths, [[feedback_verify_deferred_items]]), the platform's full test gate green, spec/`conformance.py` updated in lockstep if observable bytes/semantics change.
+
+**Open follow-up issues (carried):** #290 / #284 / #280 / #277 / #273 / #269 / #255 / #247 / #246 / #234 / #232 / #224 / #218 / #192 / #190 / #186 / #183 / #92. (#189 closing via this PR.)
+
+## (3) Open decisions and risks
+- **Script + CI step over a Rust test or inline CI YAML (resolved with user via brainstorming).** A runnable script keeps the logic locally reproducible + documented (matches `run_conformance.sh`), avoids the awkwardness of spawning `cargo tree` from inside `cargo test`, and keeps the matcher robust (`--prefix none` + line anchor) rather than the issue's buggy `^\S*` proposal.
+- **Self-test positive control is load-bearing, not decoration.** It uses `secretary-cli` (daemon on by default) as a known-positive tree; if the matcher ever stops detecting `clap`/`notify` the CI job fails on the self-test step *before* it can vouch for a vacuous green. This is the direct application of [[feedback_security_no_assumptions]] / the #231 vacuous-bar lesson.
+- **Guard scope = normal edges, `--no-default-features`.** `-e normal` is the deps that actually land in the shipped artifact (excludes build/dev deps); `--no-default-features` matches the real cdylib/.so build context *and* guards against a future move of the opt-in `cli` feature into `default`. Build-dep clap (e.g. via uniffi-bindgen's `cli` feature) is intentionally **not** flagged — it never links into the artifact.
+- **README / ROADMAP unchanged (deliberate).** No public interface / behavior / on-disk-format / milestone change — matches the #231/#252 pure-hardening precedent. Verified neither doc references `#189` or the notify/clap boundary or makes a now-inaccurate claim.
+- **Risk:** none to product behavior — no code/manifest touched, only a new CI tripwire + a script + a doc line. Worst case is a *false CI failure* on an air-gapped runner with no cached registry index (`cargo tree` could try an index update and fail) — fail-closed, never a silent pass; not a practical concern on GitHub-hosted ubuntu.
+
+## (4) Exact commands to resume
+```bash
+cd /Users/hherb/src/secretary
+git fetch --prune origin && git checkout main && git pull --ff-only origin main
+# If PR merged: branch + worktree can be removed:
+#   git worktree remove .worktrees/lean-binding-guard-189 && git branch -D feature/lean-binding-guard-189
+git worktree list && git status -s
+
+# Re-verify this session's guard (from the worktree if the PR is still open):
+cd .worktrees/lean-binding-guard-189
+bash ffi/scripts/check-lean-binding.sh --self-test && bash ffi/scripts/check-lean-binding.sh
+```
+
+## (5) Handoff file model
+`NEXT_SESSION.md` is a **relative symlink** to this file in `docs/handoffs/`. Authored once here; symlink retargeted in the same commit on the feature branch. New-path handoff → no add/add conflict. Branch cut from `origin/main` (`99e3fcd9`); at handoff time `origin/main` == merge-base == `99e3fcd9` (verified), so no history-binding merge was needed.
+
+## Closing inventory
+- **State on close:** PR opening on `feature/lean-binding-guard-189` (`55bb1281` spec + `8417de4c` guard/CI/docs + handoff). Worktree `.worktrees/lean-binding-guard-189`.
+- **Acceptance:** `--self-test` fires; guard green over all 3 binding crates; shellcheck clean; genuine red→green proven via an injected default-features regression (exit 1 on all 3 crates, clean after revert); code-review clean. No `core`/FFI/on-disk-format/`conformance.py`/manifest touched → all language gates unaffected. `#189` closes via the PR.
+- **README.md / ROADMAP.md:** unchanged (rationale in §3).
+- **CLAUDE.md:** updated — documents the new local guard command in the Commands section.
+- **NEXT_SESSION.md:** symlink → `docs/handoffs/2026-06-26-lean-binding-ci-guard-189-shipped.md`.

--- a/docs/superpowers/specs/2026-06-26-lean-binding-ci-guard-189-design.md
+++ b/docs/superpowers/specs/2026-06-26-lean-binding-ci-guard-189-design.md
@@ -1,0 +1,89 @@
+# Lean mobile-binding CI guard (#189)
+
+**Date:** 2026-06-26
+**Issue:** #189 — CI: assert lean mobile-binding feature boundary (no `notify`/`clap` in `secretary-ffi-uniffi`)
+**Status:** approved, ready for implementation
+
+## Problem
+
+`secretary-cli`'s `daemon` feature gates the headless-sync deps (`notify`, `clap`,
+`tracing-subscriber`, `rpassword`, `serde_json`). `secretary-ffi-bridge` depends on
+`secretary-cli` with `default-features = false`, so the daemon deps are kept out of the
+bridge and the two mobile bindings beneath it (`secretary-ffi-uniffi`, `secretary-ffi-py`).
+
+This "lean binding" property is **build-context-dependent**. Under `cargo test --workspace`,
+Cargo unifies `daemon` ON for the bridge too (the `secretary-sync` bin in the same package
+requires it). The guarantee only holds for a `-p`-scoped resolution that excludes the bin
+target — which is exactly the context in which the shipping cdylib/`.so` is built. Nothing
+in-repo currently prevents a future dependency edit from silently re-enabling `daemon` (or
+otherwise pulling `notify`/`clap`) into the binding tree.
+
+When the issue was filed there were no CI workflows. There now are
+(`.github/workflows/rust-lint.yml`, `test.yml`, `ios-tsan.yml`), so the guard is actionable.
+
+The property holds today — verified for all three crates with
+`cargo tree -p <crate> --no-default-features -e normal` (no `notify`/`clap`). This change is
+**regression insurance**, not a fix.
+
+## Design
+
+### Component 1 — `ffi/scripts/check-lean-binding.sh`
+
+A runnable shell script (mirrors the existing `ffi/secretary-ffi-uniffi/tests/*/run_conformance.sh`
+pattern: locally runnable, CI-invoked, self-documenting).
+
+- `set -euo pipefail`.
+- **One forbidden-deps matcher**, not scattered literals: `FORBIDDEN_RE='^(clap|notify) '`.
+- **One guarded-crate list**: `secretary-ffi-uniffi secretary-ffi-py secretary-ffi-bridge`.
+- For each crate:
+  `cargo tree -p <crate> --no-default-features -e normal --prefix none`
+  → grep for `FORBIDDEN_RE` → if it matches, print the offending lines and record a failure.
+  - `--prefix none` strips cargo-tree's box-drawing characters so the line-anchored regex is
+    robust (the issue's proposed `^\S*(notify|clap) ` anchor does not survive the `├──` prefix).
+  - `-e normal` scopes to normal (linked/runtime) edges — the deps that actually land in the
+    shipped artifact — excluding build- and dev-dependencies.
+  - `--no-default-features` matches the real shipping context (the cdylib is built with
+    `secretary-ffi-uniffi`'s empty default feature set) and additionally guards against a
+    future move of the opt-in `cli` feature into `default`.
+- Exit non-zero if **any** guarded crate trips; exit 0 when all are clean.
+- **`--self-test` mode** (positive control): assert the matcher *does* flag `clap` and `notify`
+  in `secretary-cli` built with default features (daemon ON). If the positive control fails to
+  trip, the script exits non-zero. This proves the guard is not vacuous — the exact failure
+  mode #231 surfaced (a "zero warnings" bar that checked nothing). The self-test is a
+  pure matcher check; it does not assert anything about the bindings.
+- Header comment states **why** `notify`/`clap` are forbidden (the `daemon` feature boundary)
+  and points at this spec + `cli/Cargo.toml`'s `daemon` feature.
+
+### Component 2 — CI wiring
+
+A new lightweight `lean-binding` job in `.github/workflows/rust-lint.yml` (the guard is a
+static dependency-boundary lint, thematically a lint alongside fmt/clippy). `cargo tree` only
+resolves the graph — it never compiles the crates — so the job needs no GTK/WebKit/Tauri
+system deps and runs ubuntu-only and fast.
+
+Steps:
+1. `actions/checkout@v4`
+2. `bash ffi/scripts/check-lean-binding.sh --self-test` (prove the matcher fires)
+3. `bash ffi/scripts/check-lean-binding.sh` (the real guard)
+
+The toolchain comes from `rust-toolchain.toml` (same as the other jobs).
+
+### Component 3 — docs
+
+Add the local command to CLAUDE.md's "Commands" section so the documented-commands surface
+stays in sync (the same discipline rust-lint.yml's header cites).
+
+## Out of scope / non-goals
+
+- No `core` / FFI / on-disk-format / `conformance.py` change. No observable bytes or merge
+  semantics touched, so no spec/`conformance.py` lockstep update is required.
+- No change to the `daemon` feature or any Cargo manifest. The boundary already exists; this
+  only adds a regression tripwire.
+
+## Verification (red→green)
+
+- **Green:** `check-lean-binding.sh` exits 0 against the three crates today.
+- **Red (built-in):** `--self-test` proves the matcher flags `clap`+`notify` in the
+  `secretary-cli` positive control.
+- **Red (manual, during dev):** point the matcher at `secretary-cli` (daemon on) and confirm
+  it reports a violation, demonstrating the guard would catch a real regression.

--- a/ffi/scripts/check-lean-binding.sh
+++ b/ffi/scripts/check-lean-binding.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+#
+# check-lean-binding.sh — assert the lean mobile-binding feature boundary (#189).
+#
+# WHY THIS EXISTS
+# ---------------
+# `secretary-cli`'s `daemon` feature gates the headless-sync deps — `notify`
+# (inotify/FSEvents/kqueue file watching) and `clap` (CLI arg parsing), among
+# others. `secretary-ffi-bridge` depends on `secretary-cli` with
+# `default-features = false`, deliberately keeping those deps out of the bridge
+# and the two mobile bindings beneath it (`secretary-ffi-uniffi`,
+# `secretary-ffi-py`). See `cli/Cargo.toml`'s `[features] daemon` and
+# `docs/superpowers/specs/2026-06-26-lean-binding-ci-guard-189-design.md`.
+#
+# This "lean binding" property is build-context-dependent: under
+# `cargo test --workspace`, Cargo unifies `daemon` ON for the bridge (the
+# `secretary-sync` bin in the same package requires it). The guarantee only
+# holds for the `-p`-scoped, `--no-default-features` resolution that excludes
+# the bin target — which is exactly the context in which the shipped cdylib/.so
+# is built. Nothing else in-repo prevents a future dependency edit from silently
+# re-pulling `notify`/`clap` into the binding tree. This script is that tripwire.
+#
+# USAGE
+# -----
+#   bash ffi/scripts/check-lean-binding.sh              # guard the 3 binding crates
+#   bash ffi/scripts/check-lean-binding.sh --self-test  # prove the matcher fires
+#
+# Exit 0 when every guarded crate's normal-edge dependency tree is free of the
+# forbidden deps; exit non-zero (with the offending lines printed) otherwise.
+
+set -euo pipefail
+
+# Forbidden runtime deps, as a single line-anchored regex over `--prefix none`
+# output (each line is `<pkg> v<x.y.z>`). One source of truth — do not scatter
+# these literals. Anchored at line start so a crate merely *named* like these
+# inside a path/description cannot trip it.
+readonly FORBIDDEN_RE='^(clap|notify) '
+
+# The binding crates that must stay lean. Order: outermost (mobile) first.
+readonly GUARDED_CRATES=(
+  secretary-ffi-uniffi
+  secretary-ffi-py
+  secretary-ffi-bridge
+)
+
+# A crate whose default features DO pull the forbidden deps — used by
+# --self-test as a positive control so the matcher can never silently become
+# vacuous (the #231 lesson: a "zero warnings" bar that checked nothing).
+readonly POSITIVE_CONTROL_CRATE=secretary-cli
+
+# Print the forbidden deps present on a crate's normal-edge tree, one per line
+# (empty output ⇒ clean). `--no-default-features` matches the shipping context;
+# `-e normal` scopes to linked/runtime edges (the deps that land in the
+# artifact); `--prefix none` strips box-drawing chars so the anchor is robust.
+forbidden_deps_in() {
+  local crate=$1
+  shift
+  # grep returns 1 on no-match; that is the clean (success) case here, so
+  # tolerate it without tripping `set -e` / `pipefail`.
+  cargo tree -p "$crate" -e normal --prefix none "$@" 2>/dev/null \
+    | { grep -E "$FORBIDDEN_RE" || true; }
+}
+
+run_guard() {
+  local crate matches failed=0
+  for crate in "${GUARDED_CRATES[@]}"; do
+    matches=$(forbidden_deps_in "$crate" --no-default-features)
+    if [[ -n "$matches" ]]; then
+      echo "FAIL: forbidden daemon dep(s) reached $crate:" >&2
+      while IFS= read -r line; do echo "    $line" >&2; done <<<"$matches"
+      failed=1
+    else
+      echo "ok: $crate is lean (no clap/notify on normal edges)"
+    fi
+  done
+  if (( failed )); then
+    echo "" >&2
+    echo "The lean mobile-binding boundary regressed. A dependency edit pulled" >&2
+    echo "clap/notify into a binding tree. See cli/Cargo.toml [features] daemon." >&2
+    return 1
+  fi
+  echo "All ${#GUARDED_CRATES[@]} binding crates are lean."
+}
+
+# Positive control: the matcher MUST flag both forbidden deps in the control
+# crate built with default features. If it does not, the matcher is broken or
+# the control crate changed — fail loudly rather than ship a vacuous guard.
+run_self_test() {
+  local matches
+  # Default features (daemon ON) — note: no --no-default-features here.
+  matches=$(forbidden_deps_in "$POSITIVE_CONTROL_CRATE")
+  local missing=0 dep
+  for dep in clap notify; do
+    if ! grep -qE "^${dep} " <<<"$matches"; then
+      echo "SELF-TEST FAIL: matcher did not flag '$dep' in $POSITIVE_CONTROL_CRATE" >&2
+      missing=1
+    fi
+  done
+  if (( missing )); then
+    echo "The guard's matcher is not detecting known-present deps; it would be" >&2
+    echo "vacuous. Refusing to vouch for the lean-binding check." >&2
+    return 1
+  fi
+  echo "self-test ok: matcher flags clap+notify in $POSITIVE_CONTROL_CRATE (positive control)"
+}
+
+main() {
+  case "${1:-}" in
+    --self-test) run_self_test ;;
+    "") run_guard ;;
+    *)
+      echo "usage: $0 [--self-test]" >&2
+      return 2
+      ;;
+  esac
+}
+
+main "$@"

--- a/ffi/scripts/check-lean-binding.sh
+++ b/ffi/scripts/check-lean-binding.sh
@@ -55,9 +55,15 @@ readonly POSITIVE_CONTROL_CRATE=secretary-cli
 forbidden_deps_in() {
   local crate=$1
   shift
-  # grep returns 1 on no-match; that is the clean (success) case here, so
-  # tolerate it without tripping `set -e` / `pipefail`.
-  cargo tree -p "$crate" -e normal --prefix none "$@" 2>/dev/null \
+  # `cargo tree`'s stderr is deliberately NOT redirected to /dev/null: a
+  # resolution error (bad crate name, registry-index update failure on an
+  # air-gapped runner) makes the pipeline exit non-zero, `pipefail` propagates
+  # it, and the `matches=$(...)` assignment in the callers aborts under `set -e`
+  # — fail-closed. Swallowing stderr would keep the fail-closed abort but leave
+  # the operator with no diagnostic for *why* the guard died. grep returns 1 on
+  # no-match (the clean case here), so tolerate only grep's exit without masking
+  # cargo's.
+  cargo tree -p "$crate" -e normal --prefix none "$@" \
     | { grep -E "$FORBIDDEN_RE" || true; }
 }
 


### PR DESCRIPTION
## What & why

Closes #189. Adds a CI regression tripwire that fails if the `daemon` deps (`notify`/`clap`) leak into the FFI binding crates (`secretary-ffi-uniffi`, `secretary-ffi-py`, `secretary-ffi-bridge`).

`secretary-cli`'s `daemon` feature gates `notify`/`clap`; the bridge depends on `secretary-cli` with `default-features = false` to keep them out. That "lean binding" property is **build-context-dependent** — under `cargo test --workspace` Cargo unifies `daemon` ON (the `secretary-sync` bin requires it); the guarantee only holds for the `-p`-scoped `--no-default-features` resolution that is the real shipping context. Nothing in-repo previously prevented a future dependency edit from silently re-pulling them in. The issue predates this repo having any CI workflows; they exist now, so it's actionable.

The property holds today — this is regression insurance, not a fix.

## Changes
- **`ffi/scripts/check-lean-binding.sh`** — runs `cargo tree -p <crate> --no-default-features -e normal --prefix none` over the three binding crates and fails on `^(clap|notify) `. `--prefix none` strips box-drawing chars so the line-anchor is robust. **Fail-closed:** a `cargo tree` error aborts via `set -euo pipefail` rather than passing as "lean". A **`--self-test`** mode asserts the matcher *does* fire on the `secretary-cli` positive control (daemon on) so a green guard is never vacuous (the #231 lesson).
- **`.github/workflows/rust-lint.yml`** — new ubuntu-only `lean-binding` job (`cargo tree` only resolves, never compiles → no GTK/Tauri deps). Runs `--self-test` then the guard.
- **`CLAUDE.md`** — documents the local command.

## Verification
- `--self-test` fires; guard green over all 3 crates; `shellcheck` clean.
- **Genuine red→green:** temporarily flipped the bridge's `secretary-cli` dep back to default-features (daemon on) — the guard correctly **failed** (exit 1) flagging `clap`+`notify` on all three crates; clean after revert.
- Code-review pass (pr-review-toolkit): no material issues; fail-closed direction, matcher anchoring, and CI-toolchain consistency independently verified.

No `core`/FFI/on-disk-format/`conformance.py`/crypto/manifest change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)