### PR TITLE
refactor(#183): UUID role newtypes + BlockRekey param object on the re-key path

### DIFF
--- a/NEXT_SESSION.md
+++ b/NEXT_SESSION.md
@@ -1,1 +1,1 @@
-docs/handoffs/2026-06-27-crdt-collision-test-gaps-190-192-shipped.md
+docs/handoffs/2026-06-27-rekey-newtypes-183-shipped.md

--- a/core/src/vault/ids.rs
+++ b/core/src/vault/ids.rs
@@ -1,0 +1,130 @@
+//! Transposition-safe UUID role newtypes for the block re-key path (#183).
+//!
+//! The shared re-key engine ([`crate::vault::orchestrators::share_block`] /
+//! [`crate::vault::orchestrators::revoke_block_recipient`]) threads several
+//! `[u8; 16]` UUIDs that play *different roles* — which block, which recipient,
+//! which writing device. Because they share the underlying type, a positional
+//! transposition at a call site (e.g. swapping `revoked_recipient_uuid` and
+//! `device_uuid`, which are adjacent in [`revoke_block_recipient`]) compiles
+//! silently. On a security-critical path (block content-key rotation + hybrid
+//! re-sign) that is one easy mistake away from a wrong-block / wrong-recipient
+//! re-key.
+//!
+//! These newtypes make each role a *distinct type*, so a transposition becomes a
+//! compile error rather than a silent logic bug. They are intentionally scoped to
+//! the re-key path: the rest of `core` keeps raw `[u8; 16]`, and the
+//! `Vec<[u8; 16]>` recipient lists / on-disk `BlockEntry.recipients` type are
+//! untouched (the on-disk format is frozen for v1).
+//!
+//! # Enforcement
+//!
+//! The point of these newtypes is that a role transposition is a *compile*
+//! error, not a silent logic bug. This is the load-bearing guarantee, so it is
+//! pinned by a `compile_fail` doctest (run by `cargo test --doc`): a
+//! [`DeviceUuid`] cannot be passed where a [`BlockUuid`] is expected. If the
+//! roles ever collapse back to a shared type, this stops failing and the test
+//! breaks loudly.
+//!
+//! ```compile_fail
+//! use secretary_core::vault::{BlockUuid, DeviceUuid};
+//! fn wants_block(_: BlockUuid) {}
+//! let device = DeviceUuid::new([0u8; 16]);
+//! wants_block(device); // mismatched types: expected `BlockUuid`, found `DeviceUuid`
+//! ```
+//!
+//! [`revoke_block_recipient`]: crate::vault::orchestrators::revoke_block_recipient
+//! [`share_block`]: crate::vault::orchestrators::share_block
+
+/// Length in bytes of every UUID role below (matches the on-disk 16-byte UUIDs).
+const UUID_LEN: usize = 16;
+
+/// Generates a transposition-safe `[u8; UUID_LEN]` newtype with the shared
+/// constructor / accessor / `From` surface. Each role is its own type, so the
+/// compiler rejects passing one role where another is expected.
+macro_rules! uuid_newtype {
+    ($(#[$meta:meta])* $name:ident) => {
+        $(#[$meta])*
+        #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+        pub struct $name([u8; UUID_LEN]);
+
+        impl $name {
+            /// Wrap raw UUID bytes in this role.
+            pub const fn new(bytes: [u8; UUID_LEN]) -> Self {
+                Self(bytes)
+            }
+
+            /// Borrow the underlying UUID bytes (for hashing / formatting).
+            pub const fn as_bytes(&self) -> &[u8; UUID_LEN] {
+                &self.0
+            }
+
+            /// Consume the newtype, returning the raw UUID bytes. Cheap (`Copy`).
+            pub const fn into_inner(self) -> [u8; UUID_LEN] {
+                self.0
+            }
+        }
+
+        impl From<[u8; UUID_LEN]> for $name {
+            fn from(bytes: [u8; UUID_LEN]) -> Self {
+                Self(bytes)
+            }
+        }
+
+        impl From<$name> for [u8; UUID_LEN] {
+            fn from(id: $name) -> Self {
+                id.0
+            }
+        }
+    };
+}
+
+uuid_newtype! {
+    /// The UUID of the block being re-keyed.
+    BlockUuid
+}
+
+uuid_newtype! {
+    /// A recipient-role UUID: the share target, the revoke target, or the owner
+    /// of a contact card being persisted alongside a re-key.
+    RecipientUuid
+}
+
+uuid_newtype! {
+    /// The UUID of the device performing the write. Ticks the manifest-level
+    /// vector clock; never the block being operated on.
+    DeviceUuid
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn new_then_into_inner_round_trips() {
+        let bytes = [0x11; UUID_LEN];
+        assert_eq!(BlockUuid::new(bytes).into_inner(), bytes);
+        assert_eq!(RecipientUuid::new(bytes).into_inner(), bytes);
+        assert_eq!(DeviceUuid::new(bytes).into_inner(), bytes);
+    }
+
+    #[test]
+    fn as_bytes_borrows_the_wrapped_value() {
+        let bytes = [0x22; UUID_LEN];
+        assert_eq!(BlockUuid::new(bytes).as_bytes(), &bytes);
+    }
+
+    #[test]
+    fn from_into_is_symmetric() {
+        let bytes = [0x33; UUID_LEN];
+        let id = BlockUuid::from(bytes);
+        let back: [u8; UUID_LEN] = id.into();
+        assert_eq!(back, bytes);
+    }
+
+    #[test]
+    fn equality_is_value_based() {
+        let bytes = [0x44; UUID_LEN];
+        assert_eq!(DeviceUuid::new(bytes), DeviceUuid::new(bytes));
+        assert_ne!(DeviceUuid::new(bytes), DeviceUuid::new([0x45; UUID_LEN]));
+    }
+}

--- a/core/src/vault/mod.rs
+++ b/core/src/vault/mod.rs
@@ -24,6 +24,7 @@ pub mod block;
 pub(crate) mod canonical;
 pub mod conflict;
 pub mod device_slot;
+pub mod ids;
 pub(crate) mod io;
 pub mod manifest;
 pub(crate) mod orchestrators;
@@ -38,6 +39,7 @@ pub use conflict::{
     clock_relation, merge_block, merge_record, merge_vector_clocks, ClockRelation, ConflictError,
     FieldCollision, MergedBlock, MergedRecord, RecordCollision,
 };
+pub use ids::{BlockUuid, DeviceUuid, RecipientUuid};
 pub use manifest::{
     decode_manifest, decode_manifest_file, decrypt_manifest_body, encode_manifest,
     encode_manifest_file, encrypt_manifest_body, sign_manifest, verify_manifest, BlockEntry,

--- a/core/src/vault/orchestrators.rs
+++ b/core/src/vault/orchestrators.rs
@@ -34,11 +34,12 @@ use crate::crypto::sig::{
     Ed25519Secret, MlDsa65Public, MlDsa65Secret, ED25519_SIG_LEN, ML_DSA_65_SIG_LEN,
 };
 use crate::identity::card::{ContactCard, CARD_VERSION_V1};
-use crate::identity::fingerprint::fingerprint;
+use crate::identity::fingerprint::{fingerprint, Fingerprint};
 use crate::unlock::{
     self, bundle::IdentityBundle, mnemonic::Mnemonic, vault_toml, UnlockedIdentity,
 };
 
+use super::ids::{BlockUuid, DeviceUuid, RecipientUuid};
 use super::{block, io, manifest};
 use super::{
     BlockEntry, BlockHeader, BlockPlaintext, KdfParamsRef, Manifest, ManifestFile, ManifestHeader,
@@ -1104,6 +1105,48 @@ pub fn save_block(
 // rewrite_block_with_recipients — shared re-key engine
 // ---------------------------------------------------------------------------
 
+/// The author's signing identity, threaded into the re-key engine as a cohesive
+/// unit (was four adjacent positional args). For v1 single-owner vaults the
+/// author is the calling owner; `fingerprint` is the BLAKE3 fingerprint of
+/// `card`'s canonical bytes, supplied by the caller (which already derived it for
+/// its own author check) to avoid recomputation.
+struct AuthorSigner<'a> {
+    card: &'a ContactCard,
+    fingerprint: Fingerprint,
+    sk_ed: &'a Ed25519Secret,
+    sk_pq: &'a MlDsa65Secret,
+}
+
+/// Parameter object for [`rewrite_block_with_recipients`]: every per-call input
+/// other than the ambient vault context (`folder`, `open`) and the `rng`.
+///
+/// Constructed by field name at each call site, so a positional transposition of
+/// same-typed values (the original `#[allow(clippy::too_many_arguments)]`
+/// hazard) is no longer expressible. `device_uuid` is a [`DeviceUuid`] newtype
+/// and `card_to_persist`'s owner is a [`RecipientUuid`], so even those scalar
+/// roles are type-distinct.
+struct BlockRekey<'a> {
+    /// The decoded §6.1 envelope of the block being re-keyed (read by the caller).
+    block_file: &'a block::BlockFile,
+    /// Index of this block's `BlockEntry` in `open.manifest.blocks` (located by
+    /// the caller for its own steps; reused here to avoid a second scan).
+    entry_idx: usize,
+    /// The author's signing identity (card + fingerprint + hybrid secret keys).
+    signer: AuthorSigner<'a>,
+    /// The final recipient set in wire order (cards), as resolved by the caller.
+    final_recipient_cards: &'a [&'a ContactCard],
+    /// The final recipient set as manifest UUIDs. Kept as raw `[u8; 16]` (the
+    /// on-disk `BlockEntry.recipients` type); set-semantics, not positional.
+    final_recipient_uuids: Vec<[u8; 16]>,
+    /// Optional contact card to persist to `contacts/<uuid>.card` (share grants a
+    /// new recipient access; revoke passes `None`).
+    card_to_persist: Option<(&'a [u8], RecipientUuid)>,
+    /// The device performing the write; ticks the manifest-level vector clock.
+    device_uuid: DeviceUuid,
+    /// Wall-clock millis stamped onto the block + manifest `last_mod_ms`.
+    now_ms: u64,
+}
+
 /// Re-key a block for a given final recipient set and re-sign the manifest.
 ///
 /// Shared crypto engine behind both `share_block` (final set = existing ++ new)
@@ -1114,24 +1157,30 @@ pub fn save_block(
 /// block-first → manifest-second ordering of §9.
 ///
 /// Callers perform steps 1–6 (locate entry, read+decode block, author check,
-/// single-owner check, wire-table resolution) and pass the results in.
-#[allow(clippy::too_many_arguments)]
+/// single-owner check, wire-table resolution) and pass the results in via
+/// [`BlockRekey`].
 fn rewrite_block_with_recipients(
     folder: &Path,
     open: &mut OpenVault,
-    block_file: &block::BlockFile,
-    entry_idx: usize,
-    author_card: &ContactCard,
-    author_fp: crate::identity::fingerprint::Fingerprint,
-    author_sk_ed: &Ed25519Secret,
-    author_sk_pq: &MlDsa65Secret,
-    final_recipient_cards: &[&ContactCard],
-    final_recipient_uuids: Vec<[u8; 16]>,
-    card_to_persist: Option<(&[u8], [u8; 16])>,
-    device_uuid: [u8; 16],
-    now_ms: u64,
+    req: BlockRekey<'_>,
     rng: &mut (impl RngCore + CryptoRng),
 ) -> Result<(), VaultError> {
+    let BlockRekey {
+        block_file,
+        entry_idx,
+        signer,
+        final_recipient_cards,
+        final_recipient_uuids,
+        card_to_persist,
+        device_uuid,
+        now_ms,
+    } = req;
+    let AuthorSigner {
+        card: author_card,
+        fingerprint: author_fp,
+        sk_ed: author_sk_ed,
+        sk_pq: author_sk_pq,
+    } = signer;
     // Recompute the block path from the block UUID (callers read the block
     // from this same location in step 2).
     let blocks_dir = folder.join(BLOCKS_SUBDIR);
@@ -1272,7 +1321,7 @@ fn rewrite_block_with_recipients(
             context: "failed to ensure contacts/ subdirectory",
             source: e,
         })?;
-        let recipient_uuid_hex = format_uuid_hyphenated(&card_uuid);
+        let recipient_uuid_hex = format_uuid_hyphenated(card_uuid.as_bytes());
         let recipient_card_path = contacts_dir.join(format!("{recipient_uuid_hex}.card"));
         io::write_atomic(&recipient_card_path, card_bytes).map_err(|e| VaultError::Io {
             context: "failed to write new recipient contact card",
@@ -1304,7 +1353,7 @@ fn rewrite_block_with_recipients(
     // Step 14: tick the manifest-level vector clock for this device.
     // Sharing changes the manifest's content (recipient list +
     // block-fingerprint), so the vault-level clock advances.
-    tick_clock(&mut open.manifest.vector_clock, &device_uuid)?;
+    tick_clock(&mut open.manifest.vector_clock, device_uuid.as_bytes())?;
 
     // Step 15: refresh manifest header. vault_uuid + created_at_ms
     // are preserved; only last_mod_ms advances.
@@ -1460,16 +1509,21 @@ fn rewrite_block_with_recipients(
 pub fn share_block(
     folder: &Path,
     open: &mut OpenVault,
-    block_uuid: [u8; 16],
+    block_uuid: BlockUuid,
     author_card: &ContactCard,
     author_sk_ed: &Ed25519Secret,
     author_sk_pq: &MlDsa65Secret,
     existing_recipient_cards: &[ContactCard],
     new_recipient: &ContactCard,
-    device_uuid: [u8; 16],
+    device_uuid: DeviceUuid,
     now_ms: u64,
     rng: &mut (impl RngCore + CryptoRng),
 ) -> Result<(), VaultError> {
+    // Unwrap the block-id newtype once; the body addresses the block by raw
+    // bytes (manifest scan, on-disk path). `device_uuid` stays a `DeviceUuid`
+    // and flows typed into the re-key engine.
+    let block_uuid = block_uuid.into_inner();
+
     // Step 1: locate the manifest BlockEntry. Bail before any I/O if
     // the caller is asking about an unknown block.
     let entry_idx = open
@@ -1597,17 +1651,24 @@ pub fn share_block(
     rewrite_block_with_recipients(
         folder,
         open,
-        &block_file,
-        entry_idx,
-        author_card,
-        author_fp,
-        author_sk_ed,
-        author_sk_pq,
-        &final_cards,
-        final_uuids,
-        Some((&new_recipient_card_bytes, new_recipient.contact_uuid)),
-        device_uuid,
-        now_ms,
+        BlockRekey {
+            block_file: &block_file,
+            entry_idx,
+            signer: AuthorSigner {
+                card: author_card,
+                fingerprint: author_fp,
+                sk_ed: author_sk_ed,
+                sk_pq: author_sk_pq,
+            },
+            final_recipient_cards: &final_cards,
+            final_recipient_uuids: final_uuids,
+            card_to_persist: Some((
+                &new_recipient_card_bytes,
+                RecipientUuid::new(new_recipient.contact_uuid),
+            )),
+            device_uuid,
+            now_ms,
+        },
         rng,
     )
 }
@@ -1662,16 +1723,24 @@ pub fn share_block(
 pub fn revoke_block_recipient(
     folder: &Path,
     open: &mut OpenVault,
-    block_uuid: [u8; 16],
+    block_uuid: BlockUuid,
     author_card: &ContactCard,
     author_sk_ed: &Ed25519Secret,
     author_sk_pq: &MlDsa65Secret,
     existing_recipient_cards: &[ContactCard],
-    revoked_recipient_uuid: [u8; 16],
-    device_uuid: [u8; 16],
+    revoked_recipient_uuid: RecipientUuid,
+    device_uuid: DeviceUuid,
     now_ms: u64,
     rng: &mut (impl RngCore + CryptoRng),
 ) -> Result<(), VaultError> {
+    // Unwrap the id newtypes once; the body addresses the block / revoke target
+    // by raw bytes (manifest scan, set filter, owner check). The three roles
+    // (`block_uuid`, `revoked_recipient_uuid`, `device_uuid`) are distinct types
+    // at the call boundary, so a transposition is a compile error (#183);
+    // `device_uuid` stays a `DeviceUuid` and flows typed into the re-key engine.
+    let block_uuid = block_uuid.into_inner();
+    let revoked_recipient_uuid = revoked_recipient_uuid.into_inner();
+
     // Step 1: locate the manifest BlockEntry (mirror share_block step 1).
     let entry_idx = open
         .manifest
@@ -1778,17 +1847,21 @@ pub fn revoke_block_recipient(
     rewrite_block_with_recipients(
         folder,
         open,
-        &block_file,
-        entry_idx,
-        author_card,
-        author_fp,
-        author_sk_ed,
-        author_sk_pq,
-        &final_cards,
-        final_uuids,
-        None,
-        device_uuid,
-        now_ms,
+        BlockRekey {
+            block_file: &block_file,
+            entry_idx,
+            signer: AuthorSigner {
+                card: author_card,
+                fingerprint: author_fp,
+                sk_ed: author_sk_ed,
+                sk_pq: author_sk_pq,
+            },
+            final_recipient_cards: &final_cards,
+            final_recipient_uuids: final_uuids,
+            card_to_persist: None,
+            device_uuid,
+            now_ms,
+        },
         rng,
     )
 }

--- a/core/tests/revoke_block.rs
+++ b/core/tests/revoke_block.rs
@@ -39,8 +39,8 @@ use secretary_core::unlock::{
 };
 use secretary_core::vault::{
     decode_block_file, decrypt_block, encode_manifest_file, manifest, open_vault,
-    revoke_block_recipient, save_block, sign_manifest, BlockPlaintext, KdfParamsRef, Manifest,
-    ManifestHeader, Unlocker,
+    revoke_block_recipient, save_block, sign_manifest, BlockPlaintext, BlockUuid, DeviceUuid,
+    KdfParamsRef, Manifest, ManifestHeader, RecipientUuid, Unlocker,
 };
 use secretary_core::version::{FORMAT_VERSION, SUITE_ID};
 
@@ -341,13 +341,13 @@ fn revoke_block_round_trip() {
     revoke_block_recipient(
         dir.path(),
         &mut open,
-        block_uuid,
+        BlockUuid::new(block_uuid),
         &owner_card,
         &owner_sk_ed,
         &owner_sk_pq,
         &[owner_card.clone(), alice_card.clone(), bob_card.clone()],
-        bob_card.contact_uuid,
-        device_uuid,
+        RecipientUuid::new(bob_card.contact_uuid),
+        DeviceUuid::new(device_uuid),
         1_714_060_910_000,
         &mut rng,
     )
@@ -450,13 +450,13 @@ fn revoke_block_last_recipient_returns_owner_only() {
     revoke_block_recipient(
         dir.path(),
         &mut open,
-        block_uuid,
+        BlockUuid::new(block_uuid),
         &owner_card,
         &owner_sk_ed,
         &owner_sk_pq,
         &[owner_card.clone(), alice_card.clone()],
-        alice_card.contact_uuid,
-        device_uuid,
+        RecipientUuid::new(alice_card.contact_uuid),
+        DeviceUuid::new(device_uuid),
         1_714_060_910_000,
         &mut rng,
     )
@@ -522,13 +522,13 @@ fn revoke_block_re_sign_verifies() {
     revoke_block_recipient(
         dir.path(),
         &mut open,
-        block_uuid,
+        BlockUuid::new(block_uuid),
         &owner_card,
         &owner_sk_ed,
         &owner_sk_pq,
         &[owner_card.clone(), alice_card.clone(), bob_card.clone()],
-        bob_card.contact_uuid,
-        [0xd1u8; 16],
+        RecipientUuid::new(bob_card.contact_uuid),
+        DeviceUuid::new([0xd1u8; 16]),
         1_714_060_910_000,
         &mut rng,
     )
@@ -599,13 +599,13 @@ fn revoke_block_manifest_recipients_shrink() {
     revoke_block_recipient(
         dir.path(),
         &mut open,
-        block_uuid,
+        BlockUuid::new(block_uuid),
         &owner_card,
         &owner_sk_ed,
         &owner_sk_pq,
         &[owner_card.clone(), alice_card.clone(), bob_card.clone()],
-        bob_card.contact_uuid,
-        [0xd1u8; 16],
+        RecipientUuid::new(bob_card.contact_uuid),
+        DeviceUuid::new([0xd1u8; 16]),
         1_714_060_910_000,
         &mut rng,
     )
@@ -685,13 +685,13 @@ fn revoke_block_owner_rejected() {
     let err = revoke_block_recipient(
         dir.path(),
         &mut open,
-        block_uuid,
+        BlockUuid::new(block_uuid),
         &owner_card,
         &owner_sk_ed,
         &owner_sk_pq,
         &[owner_card.clone(), alice_card.clone()],
-        owner_uuid,
-        device_uuid,
+        RecipientUuid::new(owner_uuid),
+        DeviceUuid::new(device_uuid),
         1_714_060_910_000,
         &mut rng,
     )
@@ -762,13 +762,13 @@ fn revoke_block_not_found_rejected() {
     let err = revoke_block_recipient(
         dir.path(),
         &mut open,
-        bogus_uuid,
+        BlockUuid::new(bogus_uuid),
         &owner_card,
         &owner_sk_ed,
         &owner_sk_pq,
         &[owner_card.clone(), alice_card.clone()],
-        alice_card.contact_uuid,
-        [0xd1u8; 16],
+        RecipientUuid::new(alice_card.contact_uuid),
+        DeviceUuid::new([0xd1u8; 16]),
         1_714_060_910_000,
         &mut rng,
     )
@@ -838,13 +838,13 @@ fn revoke_block_non_author_rejected() {
     let err = revoke_block_recipient(
         dir.path(),
         &mut open,
-        block_uuid,
+        BlockUuid::new(block_uuid),
         &alice_card, // wrong author card!
         &owner_sk_ed,
         &owner_sk_pq,
         &[owner_card.clone(), alice_card.clone()],
-        alice_card.contact_uuid,
-        device_uuid,
+        RecipientUuid::new(alice_card.contact_uuid),
+        DeviceUuid::new(device_uuid),
         1_714_060_910_000,
         &mut rng,
     )
@@ -927,13 +927,13 @@ fn revoke_block_non_recipient_rejected() {
     let err = revoke_block_recipient(
         dir.path(),
         &mut open,
-        block_uuid,
+        BlockUuid::new(block_uuid),
         &owner_card,
         &owner_sk_ed,
         &owner_sk_pq,
         &[owner_card.clone(), alice_card.clone(), bob_card.clone()],
-        bob_card.contact_uuid,
-        device_uuid,
+        RecipientUuid::new(bob_card.contact_uuid),
+        DeviceUuid::new(device_uuid),
         1_714_060_910_000,
         &mut rng,
     )
@@ -1007,13 +1007,13 @@ fn revoke_block_missing_remaining_card_rejected() {
     let err = revoke_block_recipient(
         dir.path(),
         &mut open,
-        block_uuid,
+        BlockUuid::new(block_uuid),
         &owner_card,
         &owner_sk_ed,
         &owner_sk_pq,
         std::slice::from_ref(&bob_card),
-        bob_card.contact_uuid,
-        device_uuid,
+        RecipientUuid::new(bob_card.contact_uuid),
+        DeviceUuid::new(device_uuid),
         1_714_060_910_000,
         &mut rng,
     )

--- a/core/tests/revoke_kat.rs
+++ b/core/tests/revoke_kat.rs
@@ -52,8 +52,8 @@ use secretary_core::unlock::{self, bundle::IdentityBundle, create_vault_unchecke
 use secretary_core::vault::block::encode_plaintext;
 use secretary_core::vault::{
     decode_block_file, decrypt_block, encode_manifest_file, open_vault, revoke_block_recipient,
-    save_block, sign_manifest, BlockFile, BlockPlaintext, KdfParamsRef, Manifest, ManifestHeader,
-    Unlocker,
+    save_block, sign_manifest, BlockFile, BlockPlaintext, BlockUuid, DeviceUuid, KdfParamsRef,
+    Manifest, ManifestHeader, RecipientUuid, Unlocker,
 };
 use secretary_core::version::{FORMAT_VERSION, SUITE_ID};
 
@@ -342,13 +342,13 @@ fn generate_revoke_kat() {
     revoke_block_recipient(
         vault_dir.path(),
         &mut open,
-        block_uuid,
+        BlockUuid::new(block_uuid),
         &owner_card,
         &owner_sk_ed,
         &owner_sk_pq,
         &[owner_card.clone(), alice_card.clone(), bob_card.clone()],
-        bob_card.contact_uuid,
-        device_uuid,
+        RecipientUuid::new(bob_card.contact_uuid),
+        DeviceUuid::new(device_uuid),
         1_714_060_910_000,
         &mut rng,
     )

--- a/core/tests/share_block.rs
+++ b/core/tests/share_block.rs
@@ -35,8 +35,8 @@ use secretary_core::unlock::{
 };
 use secretary_core::vault::{
     decode_block_file, decrypt_block, encode_manifest_file, manifest, open_vault, save_block,
-    share_block, sign_manifest, BlockPlaintext, KdfParamsRef, Manifest, ManifestHeader, Unlocker,
-    VaultError,
+    share_block, sign_manifest, BlockPlaintext, BlockUuid, DeviceUuid, KdfParamsRef, Manifest,
+    ManifestHeader, Unlocker, VaultError,
 };
 use secretary_core::version::{FORMAT_VERSION, SUITE_ID};
 
@@ -293,13 +293,13 @@ fn share_block_round_trip() {
     share_block(
         dir.path(),
         &mut open,
-        block_uuid,
+        BlockUuid::new(block_uuid),
         &owner_card,
         &owner_sk_ed,
         &owner_sk_pq,
         std::slice::from_ref(&owner_card),
         &alice_card,
-        device_uuid,
+        DeviceUuid::new(device_uuid),
         1_714_060_910_000,
         &mut rng,
     )
@@ -387,13 +387,13 @@ fn share_block_with_pre_existing_recipients_preserved() {
     share_block(
         dir.path(),
         &mut open,
-        block_uuid,
+        BlockUuid::new(block_uuid),
         &owner_card,
         &owner_sk_ed,
         &owner_sk_pq,
         &[owner_card.clone(), alice_card.clone()],
         &bob_card,
-        device_uuid,
+        DeviceUuid::new(device_uuid),
         1_714_060_910_000,
         &mut rng,
     )
@@ -470,13 +470,13 @@ fn share_block_non_author_rejected() {
     let err = share_block(
         dir.path(),
         &mut open,
-        block_uuid,
+        BlockUuid::new(block_uuid),
         &alice_card, // wrong author card!
         &owner_sk_ed,
         &owner_sk_pq,
         std::slice::from_ref(&owner_card),
         &carol_card,
-        [0xd1u8; 16],
+        DeviceUuid::new([0xd1u8; 16]),
         1_714_060_910_000,
         &mut rng,
     )
@@ -511,13 +511,13 @@ fn share_block_block_not_found_rejected() {
     let err = share_block(
         dir.path(),
         &mut open,
-        bogus_uuid,
+        BlockUuid::new(bogus_uuid),
         &owner_card,
         &owner_sk_ed,
         &owner_sk_pq,
         std::slice::from_ref(&owner_card),
         &alice_card,
-        [0xd1u8; 16],
+        DeviceUuid::new([0xd1u8; 16]),
         1_714_060_910_000,
         &mut rng,
     )
@@ -565,13 +565,13 @@ fn share_block_duplicate_recipient_rejected() {
     let err = share_block(
         dir.path(),
         &mut open,
-        block_uuid,
+        BlockUuid::new(block_uuid),
         &owner_card,
         &owner_sk_ed,
         &owner_sk_pq,
         &[owner_card.clone(), alice_card.clone()],
         &alice_card, // duplicate!
-        [0xd1u8; 16],
+        DeviceUuid::new([0xd1u8; 16]),
         1_714_060_910_000,
         &mut rng,
     )
@@ -619,13 +619,13 @@ fn share_block_re_sign_verifies() {
     share_block(
         dir.path(),
         &mut open,
-        block_uuid,
+        BlockUuid::new(block_uuid),
         &owner_card,
         &owner_sk_ed,
         &owner_sk_pq,
         std::slice::from_ref(&owner_card),
         &alice_card,
-        [0xd1u8; 16],
+        DeviceUuid::new([0xd1u8; 16]),
         1_714_060_910_000,
         &mut rng,
     )
@@ -734,13 +734,13 @@ fn share_block_send_only_mode() {
     let err = share_block(
         dir.path(),
         &mut open,
-        block_uuid,
+        BlockUuid::new(block_uuid),
         &owner_card,
         &owner_sk_ed,
         &owner_sk_pq,
         &[alice_card.clone(), bob_card.clone()],
         &carol_card,
-        [0xd1u8; 16],
+        DeviceUuid::new([0xd1u8; 16]),
         1_714_060_910_000,
         &mut rng,
     )
@@ -789,13 +789,13 @@ fn share_block_atomic_no_torn() {
     share_block(
         dir.path(),
         &mut open,
-        block_uuid,
+        BlockUuid::new(block_uuid),
         &owner_card,
         &owner_sk_ed,
         &owner_sk_pq,
         std::slice::from_ref(&owner_card),
         &alice_card,
-        [0xd1u8; 16],
+        DeviceUuid::new([0xd1u8; 16]),
         1_714_060_910_000,
         &mut rng,
     )
@@ -876,13 +876,13 @@ fn share_block_missing_recipient_card_rejected() {
     let err = share_block(
         dir.path(),
         &mut open,
-        block_uuid,
+        BlockUuid::new(block_uuid),
         &owner_card,
         &owner_sk_ed,
         &owner_sk_pq,
         std::slice::from_ref(&owner_card), // alice intentionally omitted
         &bob_card,
-        [0xd1u8; 16],
+        DeviceUuid::new([0xd1u8; 16]),
         1_714_060_910_000,
         &mut rng,
     )

--- a/docs/handoffs/2026-06-27-rekey-newtypes-183-shipped.md
+++ b/docs/handoffs/2026-06-27-rekey-newtypes-183-shipped.md
@@ -1,0 +1,80 @@
+# NEXT_SESSION.md — #183 re-key signature hardening ✅ SHIPPED (PR opening)
+
+**Session date:** 2026-06-27. Started from a clean baton — PR #312 (the #190+#192 CRDT collision test gaps) had merged to `main` as `836f8be1`; removed the merged worktree/branch (`.worktrees/crdt-test-gaps-190-192` / `feature/crdt-test-gaps-190-192`). User picked **#183** (reduce positional-arg count + transposition-safety on the `rewrite_block_with_recipients` re-key engine). Executed in project-local worktree `.worktrees/rekey-newtypes-183`, branch `feature/rekey-newtypes-183`.
+
+**Status:** ✅ **SHIPPED — branch `feature/rekey-newtypes-183`, PR opening.** Pure internal-API-shape refactor. **No on-disk format / spec / `conformance.py` / KAT-JSON / FFI-surface / Cargo-manifest change; no behavior change** (verified field-by-field in review). `Closes #183` rides in the commit + PR body.
+
+## (1) What we shipped this session
+
+**The hazard (from #183).** The shared re-key engine `rewrite_block_with_recipients` took **14 positional args** behind `#[allow(clippy::too_many_arguments)]`, and its public callers threaded several adjacent same-typed `[u8; 16]` UUIDs — `revoke_block_recipient` carries **three** (`block_uuid`, `revoked_recipient_uuid`, `device_uuid`), the last two **adjacent**. A transposition compiled silently on a security-critical path (BCK rotation + Ed25519∧ML-DSA hybrid re-sign). The existing `Fingerprint = [u8;16]` is only a *type alias* → no transposition safety, no usable precedent.
+
+**Design (settled with the user via the options format).** Chose **true UUID newtypes through the public API + a parameter object for the engine** over (B) named param-structs without newtypes (still type-check on a wrong-value-in-right-field) and (C) engine-only struct (leaves the public-API transposition risk). Only true newtypes make a transposition *fail to compile* — the issue's literal goal. Spec: [docs/superpowers/specs/2026-06-27-rekey-newtypes-183-design.md](docs/superpowers/specs/2026-06-27-rekey-newtypes-183-design.md).
+
+**Mechanics:**
+- **New `core/src/vault/ids.rs`** — `BlockUuid` / `RecipientUuid` / `DeviceUuid` true newtypes (one `uuid_newtype!` macro; `new`/`as_bytes`/`into_inner`/bidirectional `From`; `Copy` + value equality). 4 unit tests + a **`compile_fail` doctest** on the module doc (NOT inside `#[cfg(test)]` — rustdoc skips those) that pins "passing a `DeviceUuid` where a `BlockUuid` is expected does not compile." Re-exported from `core/src/vault/mod.rs`.
+- **Engine** collapses its 14 args into a `BlockRekey<'_>` parameter object (nested `AuthorSigner<'_>` for the author card+fp+sk_ed+sk_pq cluster) → **4 args; `#[allow(clippy::too_many_arguments)]` removed**. Field-name construction is inherently transposition-proof. `entry_idx` stays caller-supplied (no behavior change).
+- **Public `share_block` / `revoke_block_recipient`** keep flat arg lists (user-facing API) but their UUID params are newtypes — swapping the adjacent `revoked_recipient_uuid`/`device_uuid` now fails to compile. They `.into_inner()` the scalar ids at the top (body unchanged) and build a `BlockRekey`. They keep their own `#[allow]` (inherent API arg count; the issue's complaint *there* was transposition, now fixed).
+- **Scalar-role only:** `Vec<[u8;16]>` recipient lists and the on-disk `BlockEntry.recipients` type stay raw → frozen v1 format untouched.
+- **Call sites:** 2 bridge sites (`ffi/secretary-ffi-bridge/src/{share,revoke}/orchestration.rs`) wrap raw bytes via `::new` — bridge/FFI public signatures stay `[u8;16]`, so **no `.udl` / conformance change**. ~21 core test sites (share_block.rs, revoke_block.rs, revoke_kat.rs) wrapped via a validated line-number-driven script (`::new`, not `.into()`, to keep tests transposition-honest).
+
+**Branch commits** (off `main` @ `836f8be1`):
+| SHA | What |
+|---|---|
+| `6af85e32` | **docs(#183)**: design spec |
+| `79a70a37` | **refactor(#183)**: UUID role newtypes + `BlockRekey` param object + bridge/test call-site updates |
+| (+ handoff commit) | this baton + retargeted `NEXT_SESSION.md` symlink |
+
+### Acceptance (verified this session, in the worktree)
+```bash
+cd /Users/hherb/src/secretary/.worktrees/rekey-newtypes-183
+cargo test --release --workspace                          # 1456 passed, 0 failed
+cargo test --release -p secretary-core --doc             # compile_fail doctest passes (transposition rejected)
+cargo clippy --release --workspace --tests -- -D warnings # clean (exit 0)
+cargo fmt --all -- --check                               # clean (exit 0)
+bash ffi/scripts/check-lean-binding.sh --self-test && bash ffi/scripts/check-lean-binding.sh  # #189 guard green
+```
+- **Non-vacuousness proven:** the reviewer compiled the doctest body standalone against the built rlib → fails with `E0308: mismatched types, expected BlockUuid, found DeviceUuid` (the exact guarantee, not an unresolved-import/private-item artifact).
+- **Code review** (pr-review-toolkit code-reviewer) on the full diff: **no issues ≥80 confidence**. It independently verified the engine destructuring maps every field to the same value the old positional arg carried (no swaps), the same bytes reach crypto/manifest/disk (`device_uuid.as_bytes()`→`tick_clock`, `card_uuid.as_bytes()`→`format_uuid_hyphenated`, raw `Vec` → `BlockEntry.recipients`), and every bridge/test wrap uses the correct role newtype.
+
+## (2) What's next
+**#183 done (PR open). Pick a fresh item.** Active parallel worktrees this session (avoid collisions): `.worktrees/d4-browser-autofill` (D.4), `.worktrees/desktop-block-crud-ui`, `.claude/worktrees/hardcore-robinson-373901`. Collision-free candidates:
+- **#92** (docs) — clean up the 28 pre-existing `cargo doc` warnings (14 in `secretary-cli`); `cargo doc -D warnings` is **not** a CI gate today (could add it as teeth). No collision.
+- **SecretaryApp Swift 6 follow-up** (optional, no issue) — the XcodeGen `ios/SecretaryApp/` app target was out of #231's "SwiftPM targets" scope and still builds in Swift 5 mode; promoting it extends the strict-concurrency bar to the app shell.
+- **#290** — allowlist the 3 D.4 freshness false-positives in `threat-model.md`. **Still collision-risky** while `.worktrees/d4-browser-autofill` is active — coordinate before touching D.4 docs.
+
+**Possible follow-up from this work (optional, no issue yet):** the UUID newtypes live only on the re-key path; the rest of `core` (save_block, trash/restore, sync, device_slot) still threads raw `[u8;16]`. Codebase-wide adoption was explicitly out of #183's scope, but if the transposition pattern is judged worth generalizing, that's a natural follow-up (would also let `Fingerprint` graduate from alias to newtype).
+
+**Acceptance criteria template:** a failing test/build reproducing the gap on `main`, the typed-error/enforcement surface *proven* not assumed (security paths, [[feedback_verify_deferred_items]]), the platform's full test gate green, spec/`conformance.py` updated in lockstep if observable bytes/semantics change.
+
+**Open follow-up issues (carried):** #290 / #284 / #280 / #277 / #273 / #269 / #255 / #247 / #246 / #234 / #232 / #224 / #218 / #186 / #92. (#183 closing via this PR.)
+
+## (3) Open decisions and risks
+- **Newtypes scoped to the re-key path (resolved with user).** `BlockUuid`/`RecipientUuid`/`DeviceUuid` exist only on `share_block`/`revoke_block_recipient`/engine; the rest of `core` keeps raw `[u8;16]`. Accepted local inconsistency — expanding the convention codebase-wide is a separate, larger change.
+- **Public fns keep `#[allow(clippy::too_many_arguments)]` (deliberate).** Their arg count is inherent user-facing API surface; the issue's complaint *there* was transposition (now a compile error), not arg count. Only the internal engine's allow was removed.
+- **`compile_fail` doctest must live on a public item, NOT in `#[cfg(test)]`.** rustdoc doesn't enable `cfg(test)`, so a doctest inside the tests module would be silently skipped (a green-but-vacuous trap). It's on the module-level `//!` doc; `cargo test --doc` runs it.
+- **README / ROADMAP / CLAUDE.md unchanged (deliberate).** No public-interface / behavior / on-disk-format / milestone change — matches the #190/#192/#189/#252/#231 pure-refactor/test precedent. README's sync-surface row is about the bridge DTOs (unchanged: bridge still takes `[u8;16]`).
+- **Risk:** none to product behavior — compile-time-only wrappers; serialized bytes, manifest types, and the FFI surface are untouched. Worst case would be a behavior-changing field swap in the refactor; ruled out by the field-by-field review + the unchanged 1456-test suite (incl. share/revoke/revoke-KAT/conformance-KAT).
+
+## (4) Exact commands to resume
+```bash
+cd /Users/hherb/src/secretary
+git fetch --prune origin && git checkout main && git pull --ff-only origin main
+# If PR merged: branch + worktree can be removed:
+#   git worktree remove .worktrees/rekey-newtypes-183 && git branch -D feature/rekey-newtypes-183
+git worktree list && git status -s
+
+# Re-verify this session's work (from the worktree if the PR is still open):
+cd .worktrees/rekey-newtypes-183
+cargo test --release --workspace
+cargo test --release -p secretary-core --doc          # the transposition compile_fail doctest
+cargo clippy --release --workspace --tests -- -D warnings
+```
+
+## (5) Handoff file model
+`NEXT_SESSION.md` is a **relative symlink** to this file in `docs/handoffs/`. Authored once here; symlink retargeted in the same commit on the feature branch. New-path handoff → no add/add conflict. Branch cut from `origin/main` (`836f8be1`); at handoff time `origin/main` is an ancestor of `HEAD` (verified), so no history-binding merge was needed.
+
+## Closing inventory
+- **State on close:** PR opening on `feature/rekey-newtypes-183` (`6af85e32` spec + `79a70a37` refactor + handoff). Worktree `.worktrees/rekey-newtypes-183`.
+- **Acceptance:** full workspace green (1456 passed, 0 failed); `compile_fail` doctest proves transposition is a type error (verified non-vacuous); clippy `-D warnings` clean; fmt clean; #189 lean-binding guard green; code review clean (no issues ≥80). No `core` on-disk-format/FFI-surface/`conformance.py`/manifest touched → all language gates unaffected. `#183` closes via the PR.
+- **README.md / ROADMAP.md / CLAUDE.md:** unchanged (rationale in §3).
+- **NEXT_SESSION.md:** symlink → `docs/handoffs/2026-06-27-rekey-newtypes-183-shipped.md`.

--- a/docs/superpowers/specs/2026-06-27-rekey-newtypes-183-design.md
+++ b/docs/superpowers/specs/2026-06-27-rekey-newtypes-183-design.md
@@ -1,0 +1,123 @@
+# #183 — Re-key signature hardening (UUID newtypes + parameter object)
+
+**Date:** 2026-06-27
+**Issue:** [#183](https://github.com/hherb/secretary/issues/183) — Reduce positional-arg count on the `rewrite_block_with_recipients` re-key engine.
+**Scope:** `core/src/vault/orchestrators.rs` (engine + `share_block` + `revoke_block_recipient`), a new `core/src/vault/ids.rs`, the 2 bridge call sites that invoke core directly, and the ~21 core test call sites. **No on-disk format / spec / `conformance.py` / KAT-JSON / FFI-surface change.**
+
+## Problem
+
+The shared re-key engine `rewrite_block_with_recipients` takes 14 positional arguments behind `#[allow(clippy::too_many_arguments)]`. Its public callers thread several adjacent same-typed `[u8; 16]` values:
+
+- `revoke_block_recipient` carries **three** `[u8; 16]`s — `block_uuid`, `revoked_recipient_uuid`, `device_uuid` — with the last two **adjacent**.
+- `share_block` carries `block_uuid` and `device_uuid`, both `[u8; 16]`.
+
+Because they share a type, a transposition at a call site **compiles silently**. The current sites are guarded by the integration + KAT suites, so this is not a correctness bug today — but a future caller is one easy mistake away from a wrong-block / wrong-recipient re-key that type-checks. This is a security-critical path (BCK rotation + hybrid re-sign), so the project's "enforcement over assumptions" practice warrants a focused, reviewed change.
+
+The existing `Fingerprint = [u8; 16]` is a *type alias*, so it provides no transposition safety and is not a usable precedent.
+
+## Approach (chosen)
+
+**True UUID newtypes through the public API + a parameter object for the engine.** Selected over (a) named param-structs without newtypes — which still type-check when the wrong `[u8;16]` goes into a correctly-named field — and (b) an engine-only struct that leaves the headline public-API transposition risk in `revoke` unaddressed. Only true newtypes make a transposition *fail to compile*, which is the issue's literal goal.
+
+## Design
+
+### 1. `core/src/vault/ids.rs` — scalar-role UUID newtypes
+
+```rust
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct BlockUuid([u8; 16]);      // which block is being re-keyed
+pub struct RecipientUuid([u8; 16]);  // a recipient role: share target / revoke target / card-to-persist owner
+pub struct DeviceUuid([u8; 16]);     // which device performed the write (ticks the manifest clock)
+```
+
+Each newtype provides:
+- `pub const fn new(bytes: [u8; 16]) -> Self`
+- `pub const fn as_bytes(&self) -> &[u8; 16]` and `pub const fn into_inner(self) -> [u8; 16]` (cheap; `Copy`)
+- `impl From<[u8; 16]>` and `impl From<X> for [u8; 16]`
+- role doc comments explaining *why* the type is distinct (anti-transposition)
+- unit tests: byte round-trip, `From`/`Into` symmetry, equality.
+
+**Scalar-only:** the `Vec<[u8; 16]>` recipient lists (`final_recipient_uuids`) and the on-disk `BlockEntry.recipients` type stay raw `[u8; 16]`. Newtyping only the transposition-prone scalar params keeps the change out of the frozen on-disk format and the manifest types.
+
+**Accepted local inconsistency:** these newtypes exist only on the re-key functions; the rest of `core` keeps raw `[u8; 16]`. Expanding the convention codebase-wide is explicitly out of scope for #183.
+
+### 2. Engine parameter object — drop the clippy allow
+
+Collapse the engine's 14 positional args into a parameter object built from cohesive groups:
+
+```rust
+struct AuthorSigner<'a> {
+    card: &'a ContactCard,
+    fingerprint: Fingerprint,
+    sk_ed: &'a Ed25519Secret,
+    sk_pq: &'a MlDsa65Secret,
+}
+
+struct BlockRekey<'a> {
+    block_file: &'a block::BlockFile,
+    entry_idx: usize,
+    signer: AuthorSigner<'a>,
+    final_recipient_cards: &'a [&'a ContactCard],
+    final_recipient_uuids: Vec<[u8; 16]>,
+    card_to_persist: Option<(&'a [u8], RecipientUuid)>,
+    device_uuid: DeviceUuid,
+    now_ms: u64,
+}
+
+fn rewrite_block_with_recipients(
+    folder: &Path,
+    open: &mut OpenVault,
+    req: BlockRekey<'_>,
+    rng: &mut (impl RngCore + CryptoRng),
+) -> Result<(), VaultError>
+```
+
+→ 4 positional args; `#[allow(clippy::too_many_arguments)]` **removed** from the engine. Field-name construction is inherently transposition-proof. `AuthorSigner` and `BlockRekey` are private to the module (the engine is private). **No behavior change** — `entry_idx` is still caller-supplied (callers already compute it for their own steps), the engine body is unchanged apart from reading fields off `req`.
+
+### 3. Public-API transposition fix
+
+`share_block` and `revoke_block_recipient` keep their flat parameter lists (user-facing API) but their `[u8; 16]` UUID params become newtypes:
+
+```rust
+pub fn share_block(folder, open, block_uuid: BlockUuid, author_card, author_sk_ed,
+                   author_sk_pq, existing_recipient_cards, new_recipient,
+                   device_uuid: DeviceUuid, now_ms, rng) -> Result<(), VaultError>
+
+pub fn revoke_block_recipient(folder, open, block_uuid: BlockUuid, author_card, author_sk_ed,
+                              author_sk_pq, existing_recipient_cards,
+                              revoked_recipient_uuid: RecipientUuid, device_uuid: DeviceUuid,
+                              now_ms, rng) -> Result<(), VaultError>
+```
+
+A swap of the adjacent `revoked_recipient_uuid`/`device_uuid` (or any UUID role) now **fails to compile**. These two functions keep their own `#[allow(clippy::too_many_arguments)]`: their arg count is inherent public-API surface, and the issue's complaint about *them* is transposition, which is now fixed. They unwrap the newtypes (`.into_inner()` / `.as_bytes()`) where they pass values into block lookups and the manifest, and build a `BlockRekey` to call the engine.
+
+### 4. Enforcement artifact — `compile_fail` doctest
+
+A `compile_fail` doctest (built-in; zero new deps) on the newtype module proves a transposition is rejected by the compiler — e.g. constructing a call that passes a `DeviceUuid` where a `BlockUuid` is expected does not compile. This is the "enforcement, proven, not assumed" artifact for the security path.
+
+### 5. Call-site updates
+
+- **2 bridge sites** that call core directly wrap raw `[u8; 16]` at the boundary:
+  - `ffi/secretary-ffi-bridge/src/share/orchestration.rs` (`core::share_block`)
+  - `ffi/secretary-ffi-bridge/src/revoke/orchestration.rs` (`core::revoke_block_recipient`)
+  The bridge's own public signatures (what uniffi/pyo3 see) stay `[u8; 16]`/`Vec<u8>` — no `.udl`/FFI-surface change.
+- **~21 core test sites** (`share_block.rs`, `revoke_block.rs`, `revoke_kat.rs`, conformance-KAT dispatch helpers, fixture builders) wrap UUIDs at the call boundary.
+
+## Testing strategy
+
+- The compiler is the primary new test: transposition = type error (proven by the `compile_fail` doctest).
+- Newtype unit tests in `ids.rs` (round-trip, `From`/`Into`, equality).
+- **Behavior-unchanged regression net:** the existing `share_block`, `revoke_block`, `revoke_kat`, and conformance-KAT suites must stay green unchanged — this refactor is byte-for-byte behavior-preserving.
+- Full gate: `cargo test --release --workspace`, `cargo clippy --release --workspace --tests -- -D warnings`, `cargo fmt --all -- --check`, and the #189 lean-binding guard.
+
+## Out of scope
+
+- Codebase-wide adoption of the UUID newtypes (only the re-key path here).
+- Newtyping the `Vec<[u8;16]>` recipient lists / `BlockEntry.recipients` (would touch on-disk types).
+- Any change to `share_block_to` / desktop / uniffi / pyo3 public signatures (they route through the bridge, which keeps `[u8;16]`).
+- Removing the `#[allow]` from the public `share_block`/`revoke_block_recipient` (inherent API arg count; not the issue's complaint there).
+
+## Risks
+
+- **None to product behavior** — compile-time-only wrappers; serialized bytes, manifest types, and the FFI surface are untouched.
+- Mechanical churn at ~23 call sites; mitigated by the green regression suite proving behavior is preserved.

--- a/ffi/secretary-ffi-bridge/src/revoke/orchestration.rs
+++ b/ffi/secretary-ffi-bridge/src/revoke/orchestration.rs
@@ -26,7 +26,7 @@ use rand_core::OsRng;
 use secretary_core::crypto::secret::Sensitive;
 use secretary_core::crypto::sig::{Ed25519Secret, MlDsa65Secret};
 use secretary_core::identity::card::ContactCard;
-use secretary_core::vault::{OpenVault, VaultError};
+use secretary_core::vault::{BlockUuid, DeviceUuid, OpenVault, RecipientUuid, VaultError};
 use zeroize::Zeroize as _;
 
 use crate::error::FfiVaultError;
@@ -141,13 +141,13 @@ pub fn revoke_block(
     let result = secretary_core::vault::revoke_block_recipient(
         &vault_folder,
         &mut open_vault,
-        block_uuid,
+        BlockUuid::new(block_uuid),
         &author_card,
         &sk_ed,
         &sk_pq,
         &existing_decoded,
-        revoked_recipient_uuid,
-        device_uuid,
+        RecipientUuid::new(revoked_recipient_uuid),
+        DeviceUuid::new(device_uuid),
         now_ms,
         &mut OsRng,
     );

--- a/ffi/secretary-ffi-bridge/src/share/orchestration.rs
+++ b/ffi/secretary-ffi-bridge/src/share/orchestration.rs
@@ -14,7 +14,7 @@ use rand_core::OsRng;
 use secretary_core::crypto::secret::Sensitive;
 use secretary_core::crypto::sig::{Ed25519Secret, MlDsa65Secret};
 use secretary_core::identity::card::ContactCard;
-use secretary_core::vault::{format_uuid_hyphenated, OpenVault, VaultError};
+use secretary_core::vault::{format_uuid_hyphenated, BlockUuid, DeviceUuid, OpenVault, VaultError};
 use zeroize::Zeroize as _;
 
 use crate::error::FfiVaultError;
@@ -154,13 +154,13 @@ pub fn share_block(
     let result = secretary_core::vault::share_block(
         &vault_folder,
         &mut open_vault,
-        block_uuid,
+        BlockUuid::new(block_uuid),
         &author_card,
         &sk_ed,
         &sk_pq,
         &existing_decoded,
         &new_decoded,
-        device_uuid,
+        DeviceUuid::new(device_uuid),
         now_ms,
         &mut OsRng,
     );


### PR DESCRIPTION
Closes #183.

## What & why

The shared re-key engine `rewrite_block_with_recipients` took **14 positional args** behind `#[allow(clippy::too_many_arguments)]`, and its public callers threaded several adjacent same-typed `[u8; 16]` UUIDs — `revoke_block_recipient` carries **three** (`block_uuid`, `revoked_recipient_uuid`, `device_uuid`), the last two **adjacent**. A transposition compiled silently on a security-critical path (BCK rotation + Ed25519∧ML-DSA hybrid re-sign). The existing `Fingerprint = [u8;16]` is only a *type alias*, so it offered no transposition safety and no usable precedent.

## Changes

- **New `core/src/vault/ids.rs`** — true newtypes `BlockUuid` / `RecipientUuid` / `DeviceUuid` (one `uuid_newtype!` macro; `new`/`as_bytes`/`into_inner`/bidirectional `From`; `Copy` + value equality). 4 unit tests + a **`compile_fail` doctest** (on the module doc, where rustdoc actually runs it) pinning that a transposition is now a type error.
- **Engine** collapses its 14 args into a `BlockRekey<'_>` parameter object (nested `AuthorSigner<'_>` for the author card+fp+sk_ed+sk_pq cluster) → **4 args; the `#[allow(clippy::too_many_arguments)]` is removed**. Field-name construction is inherently transposition-proof. No behavior change.
- **Public `share_block` / `revoke_block_recipient`** keep flat arg lists but their UUID params are now newtypes — swapping the adjacent `revoked_recipient_uuid`/`device_uuid` fails to compile. They keep their own `#[allow]` (inherent API arg count; the issue's complaint there was transposition, now fixed).
- **Bridge** wraps raw bytes at its 2 call sites; bridge/FFI public signatures stay `[u8;16]` → **no `.udl` / conformance-KAT / on-disk-format change**.
- ~21 core test call sites updated to wrap UUIDs in the correct-role newtype.

**Scalar-role only:** `Vec<[u8;16]>` recipient lists and the on-disk `BlockEntry.recipients` type stay raw — the frozen v1 format is untouched. Newtypes are scoped to the re-key path (codebase-wide adoption is out of scope for #183).

## Verification
- `cargo test --release --workspace` → **1456 passed, 0 failed**
- `cargo test --release -p secretary-core --doc` → the `compile_fail` transposition doctest passes (proven non-vacuous: standalone it fails with `E0308 expected BlockUuid, found DeviceUuid`)
- `cargo clippy --release --workspace --tests -- -D warnings` → clean
- `cargo fmt --all -- --check` → clean
- `#189` lean-binding guard → green
- Code review (pr-review-toolkit) on the full diff → **no issues ≥80 confidence**; behavior-preservation verified field-by-field (engine destructuring maps every field to the same value the old positional arg carried; same bytes reach crypto/manifest/disk).

No README/ROADMAP/CLAUDE.md change — pure internal-API refactor, no public-interface/behavior/format/milestone change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)