### PR TITLE
docs(#92): clear all cargo doc warnings + add workspace -D warnings gate

### DIFF
--- a/.github/workflows/rust-lint.yml
+++ b/.github/workflows/rust-lint.yml
@@ -1,8 +1,8 @@
 name: Rust lint
 
-# Format + clippy gate. Mirrors the documented local commands in CLAUDE.md
-# so drift (e.g. #279) cannot reach `main` unnoticed. CodeQL's default setup
-# covers security analysis only; it does not run fmt/clippy.
+# Format + clippy + doc gate. Mirrors the documented local commands in
+# CLAUDE.md so drift (e.g. #279) cannot reach `main` unnoticed. CodeQL's
+# default setup covers security analysis only; it does not run fmt/clippy/doc.
 #
 # Scope: the cargo workspace. `core/fuzz/` is excluded from the workspace
 # (and uses a separate nightly toolchain), so it is intentionally not linted
@@ -61,6 +61,40 @@ jobs:
         uses: Swatinem/rust-cache@v2
       - name: Clippy (lib + tests, deny warnings)
         run: cargo clippy --release --workspace --tests -- -D warnings
+
+  doc:
+    name: cargo doc (deny warnings)
+    # Gate intra-doc links so broken / private-item references (#92) cannot
+    # silently re-accumulate. Mirrors clippy's matrix + Tauri Linux deps
+    # because rustdoc only documents the `#[cfg]`-active code per platform,
+    # so a macOS-only doc-link bug would slip past a Linux-only run.
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+    env:
+      # Turn every rustdoc warning (unresolved link, private-item link, …)
+      # into a hard error. --no-deps keeps the scope to this workspace's own
+      # crates; dependency docs are not our gate.
+      RUSTDOCFLAGS: -D warnings
+    steps:
+      - uses: actions/checkout@v4
+      # The Tauri desktop crate (`secretary-desktop`) needs GTK3/WebKitGTK to
+      # build before rustdoc can document it; ubuntu-latest lacks them.
+      - name: Install Tauri Linux system dependencies
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            libwebkit2gtk-4.1-dev \
+            libgtk-3-dev \
+            libayatana-appindicator3-dev \
+            librsvg2-dev
+      - name: Cache cargo build
+        uses: Swatinem/rust-cache@v2
+      - name: cargo doc --no-deps --workspace
+        run: cargo doc --no-deps --workspace
 
   lean-binding:
     name: lean mobile-binding boundary

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,6 +53,10 @@ cargo test --release --workspace --features differential-replay
 # Lint — must stay clean with -D warnings (covers both lib + test targets)
 cargo clippy --release --workspace --tests -- -D warnings
 
+# Doc links — must stay warning-clean (#92 CI gate; rustdoc only documents the
+# cfg-active code, so run on both Linux and macOS to catch platform-gated links)
+RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --workspace
+
 # Format
 cargo fmt --all
 

--- a/NEXT_SESSION.md
+++ b/NEXT_SESSION.md
@@ -1,1 +1,1 @@
-docs/handoffs/2026-06-27-rekey-newtypes-183-shipped.md
+docs/handoffs/2026-06-27-docs-cargo-doc-warnings-92-shipped.md

--- a/browser/secretary-browser-host/src/enroll.rs
+++ b/browser/secretary-browser-host/src/enroll.rs
@@ -7,9 +7,11 @@
 //! the per-fill open path can be exercised end to end; the Tauri UI is a later
 //! slice.
 //!
-//! **Development-only.** It calls the genuine ADR 0009 [`add_device_slot`] (so
+//! **Development-only.** It calls the genuine ADR 0009
+//! [`add_device_slot`](secretary_core::vault::device_slot::add_device_slot) (so
 //! the enrolled slot is real), but it then writes the 32-byte device secret to
-//! a **cleartext file** for the [`DevFileSecretSource`]. That is not a
+//! a **cleartext file** for the
+//! [`DevFileSecretSource`](crate::secret_source::DevFileSecretSource). That is not a
 //! production key-storage path — see the loud warning on
 //! [`crate::secret_source::DevFileSecretSource`].
 
@@ -35,7 +37,8 @@ pub enum EnrollError {
 /// Mint a device slot on `vault_path` using `password`, write the dev secret to
 /// `secret_path` and the helper config to `config_path`, and return the config.
 ///
-/// On a wrong password, [`add_device_slot`] fails **before** any file is
+/// On a wrong password,
+/// [`add_device_slot`](secretary_core::vault::device_slot::add_device_slot) fails **before** any file is
 /// written (and before any config/secret file is touched here).
 pub fn enroll(
     vault_path: &Path,

--- a/browser/secretary-browser-host/src/protocol.rs
+++ b/browser/secretary-browser-host/src/protocol.rs
@@ -4,7 +4,7 @@
 //! extension sends a [`Inbound::Query`] and the host replies with an
 //! [`Outbound::Available`] count (or an [`Outbound::Error`] for an unrecognized
 //! message type, never a panic). The dispatch itself lives in
-//! [`crate::Context::answer`] — the host opens the casual vault per fill and
+//! `crate::Context::answer` — the host opens the casual vault per fill and
 //! reports a real count (D.4.2), gated by the page-level origin rules.
 //!
 //! Every reply carries a freshly minted `request_id` so D.4.4's `request_fill`

--- a/browser/secretary-browser-host/src/vault.rs
+++ b/browser/secretary-browser-host/src/vault.rs
@@ -8,7 +8,8 @@
 //!
 //! **No key material is held between fills.** The device secret is fetched from
 //! the [`DeviceSecretSource`] port, lives only for the duration of one open as
-//! a zeroize-on-drop [`SecretBytes`], and the opened [`OpenVault`] (which
+//! a zeroize-on-drop [`SecretBytes`](secretary_core::crypto::secret::SecretBytes),
+//! and the opened [`OpenVault`](secretary_core::vault::OpenVault) (which
 //! carries the IBK + identity) is dropped — zeroizing — before the count
 //! returns (design §12 invariant 1).
 //!

--- a/cli/src/daemon.rs
+++ b/cli/src/daemon.rs
@@ -1,6 +1,6 @@
 //! `run` subcommand event loop. Composes the watcher submodule's pure
-//! pieces ([`watcher::debounce::step`], [`watcher::notify_driver`]) +
-//! the existing [`pipeline::run_one`] into a single-threaded blocking
+//! pieces ([`crate::watcher::debounce::step`], [`crate::watcher::notify_driver`]) +
+//! the existing [`crate::pipeline::run_one`] into a single-threaded blocking
 //! daemon.
 //!
 //! Spec: [`docs/superpowers/specs/2026-05-23-c2-headless-sync-cli-design.md`](../../docs/superpowers/specs/2026-05-23-c2-headless-sync-cli-design.md)
@@ -10,14 +10,14 @@
 //! the event source and an `on_sync` closure as the sync action. This
 //! lets the unit tests drive the loop with a scripted event source +
 //! a counter, while the production wire-up (see
-//! [`run_against_vault`]) plugs in [`watcher::notify_driver::NotifyWatcher`]
-//! and a [`pipeline::run_one`] call.
+//! [`run_against_vault`]) plugs in [`crate::watcher::notify_driver::NotifyWatcher`]
+//! and a [`crate::pipeline::run_one`] call.
 //!
 //! ## Trailing-edge debounce
 //!
 //! The loop honours the trailing-edge debounce semantic that
-//! [`watcher::debounce`] documents: every fresh
-//! [`watcher::WatcherEvent::SyncCandidate`] *resets* the deadline. The
+//! [`crate::watcher::debounce`] documents: every fresh
+//! [`crate::watcher::WatcherEvent::SyncCandidate`] *resets* the deadline. The
 //! sync only fires once an entire debounce window has elapsed without
 //! a new event. The previous design (see C.2 Task 7 plan §"Plan
 //! deviation" in the handoff) used a blocking `std::thread::sleep` in
@@ -240,9 +240,9 @@ fn outcome_log(outcome: &RunOutcome) -> Option<OutcomeLog> {
 }
 
 /// Emit the operator-visible log line (if any) for a successful sync
-/// outcome. The side-effecting edge over the pure [`outcome_log`].
+/// outcome. The side-effecting edge over the pure `outcome_log`.
 ///
-/// `pub` because both the daemon loop ([`after_sync`]) and the single-shot
+/// `pub` because both the daemon loop (`after_sync`) and the single-shot
 /// `once` dispatch (`main::once_ok_exit_code`, #295) route their `Ok`
 /// outcomes through it, so a `once` rollback/veto gets the same forensic
 /// log line — disk-vs-local vector clocks, auto-resolved veto counts — the
@@ -295,7 +295,7 @@ fn after_sync(
 /// should know — debug-level "skipping sync" lines would otherwise
 /// stay invisible at default verbosity.
 ///
-/// Pinned by the [`note_not_ready_and_should_warn`] unit test so the
+/// Pinned by the `note_not_ready_and_should_warn` unit test so the
 /// fire-exactly-once-at-threshold semantic is durable.
 pub const READY_NOT_READY_WARN_THRESHOLD: u32 = 5;
 
@@ -315,7 +315,7 @@ pub const READY_NOT_READY_WARN_THRESHOLD: u32 = 5;
 ///    something external is continuously modifying the folder and
 ///    starving the sync; the counter resets on the next `Ok(true)`.
 /// 2. Calls [`run_one`] for one sync attempt, then calls
-///    [`after_sync`] to log the outcome and persist state if it
+///    `after_sync` to log the outcome and persist state if it
 ///    advanced (#208). A save failure is logged and swallowed;
 ///    any pipeline [`SyncError`] is logged at warn level and the loop
 ///    continues per spec §"Daemon loop sketch".

--- a/cli/src/unlock.rs
+++ b/cli/src/unlock.rs
@@ -52,7 +52,7 @@ pub enum UnlockReadError {
 }
 
 /// Strategy for sourcing the unlock password. Carried by the CLI's
-/// top-level dispatch into [`pipeline::run_one`] (Task 5), which selects
+/// top-level dispatch into [`crate::pipeline::run_one`] (Task 5), which selects
 /// between the TTY prompt and a `Read`-backed stream based on
 /// `--password-stdin`.
 ///

--- a/cli/src/watcher/notify_driver.rs
+++ b/cli/src/watcher/notify_driver.rs
@@ -48,7 +48,7 @@ pub struct NotifyWatcher {
 impl NotifyWatcher {
     /// Begin watching `folder` recursively. Subsequent calls to
     /// [`Self::poll`] surface any filesystem activity that
-    /// [`is_sync_relevant`] accepts.
+    /// `is_sync_relevant` accepts.
     ///
     /// # Errors
     ///

--- a/core/src/identity/card.rs
+++ b/core/src/identity/card.rs
@@ -186,9 +186,9 @@ pub struct ContactCard {
     /// Creation timestamp, Unix milliseconds. Encoded under the §6 CBOR key
     /// `"created_at"`; the struct name is more descriptive of the unit.
     pub created_at_ms: u64,
-    /// Ed25519 self-signature over [`signed_bytes`]. 64 bytes.
+    /// Ed25519 self-signature over [`Self::signed_bytes`]. 64 bytes.
     pub self_sig_ed: Ed25519Sig,
-    /// ML-DSA-65 self-signature over [`signed_bytes`]. 3309 bytes.
+    /// ML-DSA-65 self-signature over [`Self::signed_bytes`]. 3309 bytes.
     pub self_sig_pq: Vec<u8>,
 }
 
@@ -272,13 +272,13 @@ impl ContactCard {
             .map_err(|e| CardError::CborEncode(e.to_string()))
     }
 
-    /// Inverse of [`to_canonical_cbor`]. Validates that `card_version == 1`
+    /// Inverse of [`Self::to_canonical_cbor`]. Validates that `card_version == 1`
     /// and that every fixed-size field has the correct byte length.
     /// Tolerates inputs whose map keys arrive in non-§6 order; canonical
-    /// re-encoding via [`to_canonical_cbor`] then yields the spec byte form
+    /// re-encoding via [`Self::to_canonical_cbor`] then yields the spec byte form
     /// — see module docs.
     ///
-    /// Does **not** verify signatures. Call [`verify_self`] for that.
+    /// Does **not** verify signatures. Call [`Self::verify_self`] for that.
     pub fn from_canonical_cbor(bytes: &[u8]) -> Result<Self, CardError> {
         let value: Value =
             ciborium::de::from_reader(bytes).map_err(|e| CardError::CborDecode(e.to_string()))?;
@@ -397,7 +397,7 @@ impl ContactCard {
         Ok(card)
     }
 
-    /// Self-sign: build [`signed_bytes`], hand to
+    /// Self-sign: build [`Self::signed_bytes`], hand to
     /// [`crate::crypto::sig::sign`] with [`SigRole::Card`], and stash the
     /// resulting two signatures into [`Self::self_sig_ed`] and
     /// [`Self::self_sig_pq`].
@@ -405,7 +405,7 @@ impl ContactCard {
     /// The `pk_*` fields on `self` must already match the keypairs whose
     /// secret halves are passed here — the card commits to the embedded
     /// public keys, so a mismatch goes undetected by `sign` but is caught
-    /// by [`verify_self`].
+    /// by [`Self::verify_self`].
     pub fn sign(&mut self, ed_sk: &Ed25519Secret, pq_sk: &MlDsa65Secret) -> Result<(), CardError> {
         let m = self.signed_bytes()?;
         let HybridSig { sig_ed, sig_pq } = sig::sign(SigRole::Card, &m, ed_sk, pq_sk)?;

--- a/core/src/sync/commit/mod.rs
+++ b/core/src/sync/commit/mod.rs
@@ -3,11 +3,11 @@
 //!
 //! The module ships two entry points, split across files:
 //!
-//! - [`apply_decisions`] (C.1.1b Task 10, in [`apply`]): pure helper
+//! - `apply_decisions` (C.1.1b Task 10, in the `apply` submodule): pure helper
 //!   that enforces the bijection between [`crate::sync::DraftMerge::vetoes`]
 //!   and the caller's [`crate::sync::VetoDecision`] slice and returns
 //!   the post-decision merged record set.
-//! - [`commit_with_decisions`] (C.1.1b Task 11, in [`write`]): the disk-
+//! - [`commit_with_decisions`] (C.1.1b Task 11, in the `write` submodule): the disk-
 //!   mutation orchestrator. Re-opens the vault (signature + block-
 //!   fingerprint verification), re-checks the on-disk manifest envelope's
 //!   BLAKE3 against `draft.manifest_hash` for TOCTOU freshness, applies

--- a/core/src/sync/commit/write.rs
+++ b/core/src/sync/commit/write.rs
@@ -54,7 +54,7 @@ const SCHEMA_VERSION_V1: u32 = 1;
 /// Re-opens the vault (verifies the manifest hybrid signature and runs
 /// `verify_block_fingerprints` per design §D6), re-hashes the on-disk
 /// manifest envelope for TOCTOU freshness against `draft.manifest_hash`,
-/// applies the caller's [`VetoDecision`] slice via [`apply_decisions`],
+/// applies the caller's [`VetoDecision`] slice via `apply_decisions`,
 /// re-encrypts every diverging block with a fresh AEAD nonce and BLAKE3-
 /// fingerprints the new bytes, builds a new manifest body (updated
 /// `BlockEntry.fingerprint` / `vector_clock_summary` / `last_mod_ms`
@@ -70,7 +70,7 @@ const SCHEMA_VERSION_V1: u32 = 1;
 ///   between [`crate::sync::prepare_merge`] and this call. The disk is
 ///   untouched; caller retries from [`crate::sync::sync_once`].
 /// - [`SyncError::MissingVetoDecision`] / [`SyncError::UnknownVetoDecision`]
-///   — propagated from [`apply_decisions`] when `decisions` does not
+///   — propagated from `apply_decisions` when `decisions` does not
 ///   form a bijection with `draft.vetoes`.
 /// - [`SyncError::InvalidArgument`] — structural mismatch between
 ///   `draft` and the on-disk manifest (a `block_uuid` in

--- a/core/src/sync/once.rs
+++ b/core/src/sync/once.rs
@@ -27,7 +27,7 @@ use crate::vault::orchestrators::{read_vault_manifest_full, MANIFEST_FILENAME};
 /// (this slice's Concurrent-arm extension).
 ///
 /// Steps:
-///   1. Calls [`crate::vault::orchestrators::read_vault_manifest_full`]
+///   1. Calls `crate::vault::orchestrators::read_vault_manifest_full`
 ///      with the caller-held `&UnlockedIdentity` to read + verify-and-
 ///      decrypt the manifest body without re-running Argon2, AND
 ///      surface the verified owner contact card + raw on-disk envelope
@@ -43,7 +43,7 @@ use crate::vault::orchestrators::{read_vault_manifest_full, MANIFEST_FILENAME};
 ///   4. On `Concurrent`, BLAKE3-hashes the envelope bytes from step 1
 ///      to produce the freshness [`ManifestHash`] (TOCTOU anchor for
 ///      C.1.1b's commit path), then calls
-///      [`crate::sync::ingest::ingest_conflict_copies`] with the same
+///      `crate::sync::ingest::ingest_conflict_copies` with the same
 ///      bytes + the pre-derived owner public keys + IBK to assemble
 ///      the [`VaultBundle`], and finally computes a [`DiffPlan`] from
 ///      its diverging blocks.

--- a/core/src/sync/outcome.rs
+++ b/core/src/sync/outcome.rs
@@ -16,7 +16,7 @@ pub struct RollbackEvidence {
 
 /// Block UUIDs whose state diverges between the canonical manifest
 /// and at least one authenticated conflict-copy. Computed by
-/// [`crate::sync::ingest::compute_diff_plan`] from the assembled
+/// `crate::sync::ingest::compute_diff_plan` from the assembled
 /// [`VaultBundle`]. Consumed by C.1.1b's `prepare_merge`.
 ///
 /// Sorted ascending (BTreeMap key order in the bundle's

--- a/core/src/sync/prepare.rs
+++ b/core/src/sync/prepare.rs
@@ -6,7 +6,7 @@
 //! See `docs/superpowers/specs/2026-05-18-c1-1b-sync-merge-design.md`
 //! §"prepare_merge". The module exposes [`prepare_merge`] (the
 //! orchestrator entry point, re-exported via [`crate::sync`]) and
-//! [`tombstone_veto_set`] (pure-function veto detector, `pub(crate)` —
+//! `tombstone_veto_set` (pure-function veto detector, `pub(crate)` —
 //! kept internal and consumed by `prepare_merge` per record).
 
 use std::collections::{BTreeMap, BTreeSet};
@@ -303,7 +303,7 @@ fn parent_block_clock(
 /// Turn the C.1.1a [`VaultBundle`] into a [`DraftMerge`]. AEAD-decrypts
 /// each diverging block envelope on demand, composes pairwise merges
 /// via the existing [`merge_block`] primitive, and surfaces
-/// record-level tombstone vetoes via [`tombstone_veto_set`].
+/// record-level tombstone vetoes via `tombstone_veto_set`.
 ///
 /// # Inputs
 ///
@@ -322,11 +322,11 @@ fn parent_block_clock(
 /// # Algorithm
 ///
 /// 1. Derive the owner public-key material + reader secret keys once
-///    (see [`derive_block_reader_keys`]).
+///    (see `derive_block_reader_keys`).
 /// 2. For each `block_uuid` in `plan.diverging_blocks`, AEAD-decrypt the
 ///    canonical envelope and every copy envelope, then iteratively merge
 ///    via [`merge_block`]; the accumulator's records + per-block vector
-///    clock advance per fold step. Run [`tombstone_veto_set`] across
+///    clock advance per fold step. Run `tombstone_veto_set` across
 ///    the merged record set vs the per-copy plaintexts for the same
 ///    `record_uuid` and collect any vetoes. Extend the running
 ///    `merged_records` map (keyed by `record_uuid` — `merge_block`
@@ -340,7 +340,7 @@ fn parent_block_clock(
 /// The per-copy block clock is looked up by matching each envelope's
 /// BLAKE3-256 fingerprint against [`crate::vault::manifest::BlockEntry`]
 /// `::fingerprint` on every copy manifest in `bundle.copies` (see
-/// [`parent_block_clock`]). The 1a ingestion layer does NOT guarantee
+/// `parent_block_clock`). The 1a ingestion layer does NOT guarantee
 /// positional alignment between `bundle.copies[i]` and
 /// `divergence.copy_envelopes[i]` — the two slices come from
 /// independent filesystem scans (`enumerate_manifest_siblings` vs.
@@ -360,7 +360,7 @@ fn parent_block_clock(
 ///   bundle/plan disagreement), when the canonical manifest is missing
 ///   a `BlockEntry` for a divergent block_uuid, or when a copy block
 ///   envelope's fingerprint matches no copy manifest's `BlockEntry`
-///   (orphan sibling — see [`parent_block_clock`]).
+///   (orphan sibling — see `parent_block_clock`).
 ///
 /// # Purity & cost
 ///
@@ -707,7 +707,7 @@ mod tests {
 
 #[cfg(test)]
 mod parent_block_clock_tests {
-    //! Unit tests for [`parent_block_clock`] — proves the
+    //! Unit tests for `parent_block_clock` — proves the
     //! fingerprint-matching pairing is sound across the cases that
     //! positional-index pairing got wrong: copies missing this block,
     //! copies referencing a different envelope for the same block_uuid,

--- a/core/src/unlock/bundle.rs
+++ b/core/src/unlock/bundle.rs
@@ -158,7 +158,8 @@ pub enum BundleError {
 /// Carries the four `(sk, pk)` pairs of the v1 hybrid suite, plus the
 /// 16-byte user UUID, a display name, and a creation timestamp.
 ///
-/// Secret-key fields are wrapped in [`Sensitive`] (or [`SecretBytes`] for
+/// Secret-key fields are wrapped in [`Sensitive`] (or
+/// [`SecretBytes`](crate::crypto::secret::SecretBytes) for
 /// runtime-sized PQC keys) so they zeroize on drop. The bundle does not
 /// derive `Clone`, `Debug`, or `PartialEq`: cloning would silently
 /// duplicate secret material; a derived `Debug` would leak it; equality is
@@ -325,7 +326,7 @@ impl IdentityBundle {
         encode_map(&entries)
     }
 
-    /// Inverse of [`to_canonical_cbor`]. Validates that every required field
+    /// Inverse of [`Self::to_canonical_cbor`]. Validates that every required field
     /// is present, fixed-size fields have the correct byte length, no
     /// unknown fields appear, no duplicates appear, and the input was
     /// already in RFC 8949 §4.2.1 canonical form.

--- a/core/src/vault/block.rs
+++ b/core/src/vault/block.rs
@@ -1511,7 +1511,7 @@ pub fn decode_block_file(bytes: &[u8]) -> Result<BlockFile, BlockError> {
 ///
 /// Returns `Ok(())` only if BOTH signature halves verify — there is no
 /// OR-short-circuit. A failure of either Ed25519 or ML-DSA-65 yields
-/// [`BlockError::Signature`] (or its inner variants), matching the
+/// [`BlockError::Sig`] (or its inner variants), matching the
 /// same enforcement as [`decrypt_block`] step 2.
 pub fn verify_block_signature(
     block: &BlockFile,

--- a/core/src/vault/conflict.rs
+++ b/core/src/vault/conflict.rs
@@ -76,7 +76,7 @@ pub enum ClockRelation {
     /// greater. The incoming clock is "newer" than the local one in the
     /// happens-before partial order.
     IncomingDominates,
-    /// `local` dominates `incoming` (mirror of [`IncomingDominates`]).
+    /// `local` dominates `incoming` (mirror of [`IncomingDominates`](Self::IncomingDominates)).
     /// In a manifest-load context this is the rollback signal.
     IncomingDominated,
     /// Neither dominates the other: there exists a device where
@@ -142,7 +142,7 @@ pub fn clock_relation(local: &[VectorClockEntry], incoming: &[VectorClockEntry])
 ///
 /// Pure function. Does **not** apply `+1` for any "merging device" —
 /// that is an orchestrator concern (see
-/// [`super::orchestrators`]'s private `tick_clock`). The merge primitive
+/// `super::orchestrators`'s private `tick_clock`). The merge primitive
 /// here only computes the join in the lattice of vector clocks.
 ///
 /// Properties (proved by `core/tests/proptest.rs` in a subsequent
@@ -281,7 +281,7 @@ pub struct MergedRecord {
 /// `tombstoned_at_ms == last_mod_ms`, live inputs are clamped to
 /// `tombstoned_at_ms ≤ last_mod_ms`. On well-formed inputs (where
 /// the invariant already holds) the clamp is a no-op. See
-/// [`clamp_death_clock`] for the helper.
+/// `clamp_death_clock` for the helper.
 ///
 /// Pure function. Total over all `Record` pairs that share a
 /// `record_uuid`: returns a complete [`MergedRecord`] with no error

--- a/core/src/vault/manifest.rs
+++ b/core/src/vault/manifest.rs
@@ -197,7 +197,7 @@ pub enum ManifestError {
     DuplicateBlockUuid,
 
     /// A canonical-CBOR rule was violated (float, tag, …). Lifted from
-    /// the shared [`crate::vault::canonical`] helpers.
+    /// the shared `crate::vault::canonical` helpers.
     #[error("canonical CBOR violation: {0}")]
     Canonical(#[from] CanonicalError),
 

--- a/core/src/vault/mod.rs
+++ b/core/src/vault/mod.rs
@@ -17,7 +17,7 @@
 //! The PR-B orchestrators ([`create_vault`], [`open_vault`],
 //! [`save_block`], [`share_block`]) compose the lower pure-function
 //! layers into a single side-effecting entry point per user-visible
-//! operation. They live in [`orchestrators`] (re-exported here so the
+//! operation. They live in the `orchestrators` module (re-exported here so the
 //! public API stays `secretary_core::vault::create_vault`, etc.).
 
 pub mod block;

--- a/core/src/vault/orchestrators.rs
+++ b/core/src/vault/orchestrators.rs
@@ -894,8 +894,9 @@ fn tick_clock(clock: &mut Vec<VectorClockEntry>, device_uuid: &[u8; 16]) -> Resu
 /// caller's own owner card is NOT automatically included — pass it
 /// explicitly if the caller should be a recipient (this matches the
 /// "send-only mode" semantics where the owner can encrypt for others
-/// without keeping a copy themselves). [`encrypt_block`] rejects an empty
-/// recipient list with [`BlockError::EmptyRecipientList`].
+/// without keeping a copy themselves). [`encrypt_block`](crate::vault::block::encrypt_block)
+/// rejects an empty recipient list with
+/// [`BlockError::EmptyRecipientList`](crate::vault::block::BlockError::EmptyRecipientList).
 ///
 /// `device_uuid` identifies the writing device. This device's counter in
 /// both the block's vector clock AND the manifest's vault-level vector
@@ -1430,7 +1431,7 @@ fn rewrite_block_with_recipients(
 /// `save_block` time (the "send-only" mode where the author encrypts
 /// for others without keeping a copy) cannot later call `share_block`
 /// on that same block; the decrypt step in §6.4 surfaces as
-/// [`BlockError::NotARecipient`] propagated through
+/// [`BlockError::NotARecipient`](crate::vault::block::BlockError::NotARecipient) propagated through
 /// [`VaultError::Block`]. This restriction is intentional: the
 /// alternative would mean retaining the BCK in some side channel,
 /// which is exactly the property send-only mode opts out of.
@@ -1696,7 +1697,7 @@ pub fn share_block(
 /// revoke instead requires the target *be* present
 /// ([`VaultError::RecipientNotPresent`] otherwise) and splits the resolved
 /// cards into the "keep" set vs the revoked one. The shared re-key engine
-/// ([`rewrite_block_with_recipients`]) is then invoked with
+/// (`rewrite_block_with_recipients`) is then invoked with
 /// `card_to_persist = None` — revoke grants no new access, so no contact card
 /// is written.
 ///

--- a/core/src/vault/record.rs
+++ b/core/src/vault/record.rs
@@ -48,7 +48,7 @@
 //!
 //! - We collect every unrecognised key into the `unknown` map.
 //! - On re-encode we splice unknown entries back alongside the known
-//!   entries and let [`encode_canonical_map`] re-sort them by canonical
+//!   entries and let `encode_canonical_map` re-sort them by canonical
 //!   CBOR-encoded key. Since canonical sort is total and stable, the
 //!   resulting byte layout matches the input exactly when the input was
 //!   itself canonical.
@@ -336,7 +336,7 @@ pub struct Record {
     pub record_type: String,
     /// Field name → field. [`BTreeMap`] for in-memory iteration
     /// determinism only; the wire ordering is decided by
-    /// [`canonical_sort_entries`] against materialised CBOR-encoded key
+    /// `canonical_sort_entries` against materialised CBOR-encoded key
     /// bytes (length-then-bytewise), which differs from `BTreeMap`'s
     /// `String` ordering for keys of differing UTF-8 lengths (e.g. `"z"`
     /// sorts before `"ab"` in canonical CBOR but after it in

--- a/desktop/src-tauri/src/commands/delete.rs
+++ b/desktop/src-tauri/src/commands/delete.rs
@@ -7,7 +7,7 @@
 //! [`VaultSession::with_unlocked`].
 //!
 //! Error mapping is split by primitive class:
-//! - record tombstone/resurrect use a local [`map_record_delete_error`]
+//! - record tombstone/resurrect use a local `map_record_delete_error`
 //!   mirroring `edit::map_save_error` (BlockNotFound / RecordNotFound stay
 //!   typed; everything else folds to `RecordSaveFailed`),
 //! - block trash/restore/list use the shared [`map_ffi_error`], which already

--- a/desktop/src-tauri/src/dtos/mod.rs
+++ b/desktop/src-tauri/src/dtos/mod.rs
@@ -10,11 +10,11 @@
 //! - `From<&BridgeType>` impls live next to the DTO.
 //! - All DTOs `#[serde(rename_all = "camelCase")]`.
 //!
-//! Submodules: [`manifest`] (D.1.1 manifest/summary/settings DTOs),
-//! [`browse`] (D.1.2 block-detail / record / field / revealed-field DTOs),
-//! [`create`] (D.1.3 vault-create DTOs), [`edit`] (D.1.4 record-edit DTOs),
-//! [`trash`] (D.1.5 trashed-block DTO), [`contact`] (D.1.6 contact-summary
-//! DTOs), [`recipient`] (D.1.8 per-block recipient DTOs), and [`sync`]
+//! Submodules: `manifest` (D.1.1 manifest/summary/settings DTOs),
+//! `browse` (D.1.2 block-detail / record / field / revealed-field DTOs),
+//! `create` (D.1.3 vault-create DTOs), `edit` (D.1.4 record-edit DTOs),
+//! `trash` (D.1.5 trashed-block DTO), `contact` (D.1.6 contact-summary
+//! DTOs), `recipient` (D.1.8 per-block recipient DTOs), and `sync`
 //! (D.1.14 sync-status / outcome DTOs).
 
 mod browse;

--- a/desktop/src-tauri/src/session.rs
+++ b/desktop/src-tauri/src/session.rs
@@ -207,7 +207,7 @@ impl VaultSession {
 
     /// Persist new settings to the vault. Validates bounds via
     /// [`settings::save_to_vault`] (which calls
-    /// [`settings::validate_save_value`] before the bridge's `save_block`);
+    /// `settings::validate_save_value` before the bridge's `save_block`);
     /// on success, updates the in-memory `inner.settings` to match disk.
     pub fn set_settings(&mut self, new_settings: &Settings) -> Result<(), AppError> {
         self.with_unlocked_mut(|u| {

--- a/desktop/src-tauri/src/settings/mod.rs
+++ b/desktop/src-tauri/src/settings/mod.rs
@@ -2,11 +2,11 @@
 //!
 //! Internally split across two private siblings:
 //!
-//! - [`parse`] holds the Task-2 pure value types and string→struct
+//! - `parse` holds the Task-2 pure value types and string→struct
 //!   conversions (`Settings`, `parse_settings_field`, `serialize_settings`,
 //!   `validate_save_value`). No filesystem or vault touching — every input
 //!   is a `&str` and every output is owned data.
-//! - [`io`] holds the Task-3 vault I/O facade (`load_from_vault`,
+//! - `io` holds the Task-3 vault I/O facade (`load_from_vault`,
 //!   `save_to_vault`) and per-vault device-UUID persistence
 //!   (`load_or_create_device_uuid`, `device_uuid_path_in`). These reach
 //!   into the bridge's `UnlockedIdentity` / `OpenVaultManifest` handles

--- a/desktop/src-tauri/src/timer.rs
+++ b/desktop/src-tauri/src/timer.rs
@@ -1,6 +1,6 @@
 //! Auto-lock timer logic.
 //!
-//! The actual OS-thread spawn + Tauri event emission live in [`main`];
+//! The actual OS-thread spawn + Tauri event emission live in `main`;
 //! this module is the pure tick body — testable without spinning up a
 //! Tauri runtime.
 //!
@@ -24,7 +24,7 @@ use std::sync::Mutex;
 
 use crate::session::VaultSession;
 
-/// Outcome of a single timer tick. The thread loop in [`main`] uses this
+/// Outcome of a single timer tick. The thread loop in `main` uses this
 /// to decide whether to emit the `vault-locked` event.
 #[derive(Debug, PartialEq, Eq)]
 pub enum TickOutcome {

--- a/docs/handoffs/2026-06-27-docs-cargo-doc-warnings-92-shipped.md
+++ b/docs/handoffs/2026-06-27-docs-cargo-doc-warnings-92-shipped.md
@@ -1,0 +1,90 @@
+# NEXT_SESSION.md — #92 cargo-doc warning cleanup + CI gate ✅ SHIPPED (PR opening)
+
+**Session date:** 2026-06-27 (second session of the day). Started from a clean baton — PR #313 (the #183 UUID-newtype re-key refactor) had merged to `main` as `8078a7fb`; removed the merged worktree/branch (`.worktrees/rekey-newtypes-183` / `feature/rekey-newtypes-183`). User picked **#92** (clean up pre-existing `cargo doc` warnings + add a regression gate). Executed in project-local worktree `.worktrees/docs-warnings-92`, branch `feature/docs-warnings-92`.
+
+**Status:** ✅ **SHIPPED — branch `feature/docs-warnings-92`, PR opening.** Pure doc-comment + CI-YAML change. **No code / signature / visibility / on-disk-format / spec / `conformance.py` / KAT-JSON / FFI-surface / Cargo-manifest change; no behavior change** (every changed `.rs` line is a `///` or `//!` doc-comment — verified by a diff filter). `Closes #92` rides in the commit + PR body.
+
+## (1) What we shipped this session
+
+**The hazard (from #92).** `cargo doc` was never a CI gate, so broken intra-doc links and public-doc→private-item links had accumulated. The issue cited ~28 in `secretary-core`; by this session the **whole workspace had 66** (the C.1.1b sync functions had since landed; #183 added one; the cli/ffi/desktop/browser crates had their own rot). User chose **"whole workspace now"** over a core-only fix + follow-up issue — fix everything, then add a workspace-wide gate so it cannot regress.
+
+**Scope settled with the user (options format).** Core was already at 0 after the first commit; the fork was core-only-plus-follow-up vs. the whole workspace. User picked the whole workspace.
+
+**The two-class fix rule** (applied uniformly across all 7 crates):
+1. **"unresolved link to `X`"** — referent exists but the path is out of scope:
+   - sibling method / assoc-fn / struct field on the same type → `[`Self::X`]`;
+   - enum variant of the enclosing enum → `[`X`](Self::X)`;
+   - a real **public** item elsewhere → re-anchor to a full navigable path `[`X`](crate::path::X)` / `[`X`](other_crate::path::X)` (kept as a clickable link);
+   - genuinely **private** / `pub(crate)` / moved / a bin `main` → **downgrade** to plain backticks `` `X` `` (no widening of visibility).
+2. **"public documentation for `A` links to private item `B`"** — B is `pub(crate)`/private and unreachable in public docs → **downgrade** `[`B`]` to `` `B` ``. Never made an item `pub` just to satisfy a doc link (preserves encapsulation).
+   - Real bug fixed along the way: `BlockError::Signature` → the actual variant `BlockError::Sig` (block.rs).
+
+**Mechanics:**
+- `secretary-core` (34 sites) fixed by hand (commit 1): identity/card.rs, unlock/bundle.rs, vault/{mod,block,conflict,manifest,orchestrators,record}.rs, sync/{commit,once,outcome,prepare}.rs.
+- The other 6 crates fixed via **6 parallel subagents** (one per crate), each given the rule + a per-crate `cargo doc … | grep -cE '^warning:'` → 0 verification: `secretary-cli` (13), `secretary-ffi-bridge` (12), `secretary-ffi-uniffi` (7), `secretary-ffi-py` (8), `secretary-browser-host` (6), `secretary-desktop` (12 + 2 `main` links I fixed first). Each agent reported its per-site fix class.
+- **CI gate:** a new `doc` job in [.github/workflows/rust-lint.yml](.github/workflows/rust-lint.yml) mirrors the `clippy` job's **Linux+macOS matrix + Tauri GTK deps + rust-cache**, running `cargo doc --no-deps --workspace` under `RUSTDOCFLAGS=-D warnings`. The matrix matters: rustdoc only documents the **cfg-active** code per platform, so a macOS-only doc-link bug would slip past a Linux-only run.
+- **CLAUDE.md** Commands section gained the local `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --workspace` line (so the workflow's "mirrors the documented local commands" claim holds).
+
+**Branch commits** (off `main` @ `8078a7fb`):
+| SHA | What |
+|---|---|
+| `4c213f53` | **docs(#92)**: fix all 34 `cargo doc` link warnings in `secretary-core` |
+| `b95a7587` | **docs(#92)**: clear remaining warnings (cli/ffi/desktop/browser) + add the `doc` CI gate |
+| `7ece29d0` | **docs(#92)**: document the gate in CLAUDE.md Commands |
+| (+ handoff commit) | this baton + retargeted `NEXT_SESSION.md` symlink |
+
+### Acceptance (verified this session, in the worktree)
+```bash
+cd /Users/hherb/src/secretary/.worktrees/docs-warnings-92
+RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --workspace   # exit 0 (was 66 warnings)
+cargo test --release --workspace                             # 1456 passed, 0 failed
+cargo clippy --release --workspace --tests -- -D warnings    # clean (exit 0)
+cargo fmt --all --check                                      # clean (exit 0)
+python3 -c "import yaml; yaml.safe_load(open('.github/workflows/rust-lint.yml'))"  # YAML valid
+bash ffi/scripts/check-lean-binding.sh --self-test && bash ffi/scripts/check-lean-binding.sh  # #189 green
+```
+- **Diff is provably doc-only:** `git diff -- '*.rs' | grep '^[+-]' | grep -v '^[+-]\s*\(///\|//!\)'` returns nothing — every changed Rust line is a doc-comment. Link correctness is machine-verified: `cargo doc -D warnings` passing proves every re-anchored path resolves to a real item. 1456-test count is unchanged from #183 (no tests added/removed).
+
+## (2) What's next
+**#92 done (PR open). Pick a fresh item.** Active parallel worktrees this session (avoid collisions): `.worktrees/d4-browser-autofill` (D.4), `.worktrees/desktop-block-crud-ui`, `.claude/worktrees/hardcore-robinson-373901`. Collision-free candidates:
+- **#172** — Trash view `list_trashed_blocks` does a full decrypt per trashed block on every open. Meaty core Rust (caching / lazy-decrypt), security-sensitive (secret-bearing decrypt path). Good Rust learning.
+- **#105** — group multi-arg test helper signatures (`sync_helpers` + `sync_merge_vetoes`) into small param structs — continues #183's transposition-safety theme; test-only, low risk.
+- **SecretaryApp Swift 6 follow-up** (optional, no issue) — the XcodeGen `ios/SecretaryApp/` target was out of #231's "SwiftPM targets" scope and still builds Swift 5; promoting it extends the strict-concurrency bar to the app shell.
+- **#290** — allowlist the 3 D.4 freshness false-positives in `threat-model.md`. **Still collision-risky** while `.worktrees/d4-browser-autofill` is active — coordinate before touching D.4 docs.
+
+**Possible follow-up from this work (optional, no issue yet):** the `doc` gate now protects the workspace. If the rustdoc surface is judged worth hardening further, `cargo doc` could additionally be run with `--document-private-items` in a separate non-blocking lane to catch private-item link rot too — but that produces a large, noisy baseline and was deliberately **not** taken on here (the public-doc gate is the contract that matters).
+
+**Acceptance criteria template:** a failing test/build reproducing the gap on `main`, the typed-error/enforcement surface *proven* not assumed (security paths, [[feedback_verify_deferred_items]]), the platform's full test gate green, spec/`conformance.py` updated in lockstep if observable bytes/semantics change.
+
+**Open follow-up issues (carried):** #290 / #284 / #280 / #277 / #273 / #269 / #255 / #247 / #246 / #234 / #232 / #224 / #218 / #186 / #172 / #167 / #105. (#92 closing via this PR; #183 closed last session.)
+
+## (3) Open decisions and risks
+- **Whole-workspace scope (resolved with user).** Could have shipped core-only + filed a follow-up; user chose to retire all 66 in one PR and gate the whole workspace. No core/cli/ffi/desktop/browser doc warnings remain.
+- **Private/`pub(crate)` referents downgraded to plain backticks, not made public.** Linking public docs to a private item is the warning; widening visibility to "fix" it would leak internals into the public API surface. Backtick-downgrade is the encapsulation-preserving fix and is always correct. Public referents in other modules were instead **re-anchored** to full paths so they stay navigable.
+- **`doc` job uses the Linux+macOS matrix (deliberate).** rustdoc documents only the cfg-active code per platform; a single-OS run would miss platform-gated doc-link bugs (e.g. macOS Secure-Enclave code, Linux-only code). Cost is one extra `cargo doc` build per OS, amortized by rust-cache.
+- **README / ROADMAP unchanged (deliberate).** #92 is a docs-hygiene chore, not a milestone slice (ROADMAP tracks A.x phases / D.1.x slices) and adds no product capability (README is product/architecture). CLAUDE.md **was** updated because we added a gate it documents.
+- **Risk:** none to product behavior — doc-comment text + a CI YAML job only; no code, no API, no on-disk bytes, no FFI surface touched. The new gate could in principle fail CI on the **desktop/browser** crates' Linux build if the Tauri apt deps drift — but the `doc` job copies the already-proven `clippy` job's dep list verbatim, so it shares clippy's fate.
+
+## (4) Exact commands to resume
+```bash
+cd /Users/hherb/src/secretary
+git fetch --prune origin && git checkout main && git pull --ff-only origin main
+# If PR merged: branch + worktree can be removed:
+#   git worktree remove .worktrees/docs-warnings-92 && git branch -D feature/docs-warnings-92
+git worktree list && git status -s
+
+# Re-verify this session's work (from the worktree if the PR is still open):
+cd .worktrees/docs-warnings-92
+RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --workspace   # the new gate
+cargo test --release --workspace
+cargo clippy --release --workspace --tests -- -D warnings
+```
+
+## (5) Handoff file model
+`NEXT_SESSION.md` is a **relative symlink** to this file in `docs/handoffs/`. Authored once here; symlink retargeted in the same commit on the feature branch. New-path handoff → no add/add conflict. Branch cut from `origin/main` (`8078a7fb`); at handoff time `origin/main` is an ancestor of `HEAD` (verified), so no history-binding merge was needed.
+
+## Closing inventory
+- **State on close:** PR opening on `feature/docs-warnings-92` (`4c213f53` core + `b95a7587` rest+gate + `7ece29d0` CLAUDE.md + handoff). Worktree `.worktrees/docs-warnings-92`.
+- **Acceptance:** `RUSTDOCFLAGS=-D warnings cargo doc --no-deps --workspace` exit 0 (was 66 warnings); full workspace green (1456 passed, 0 failed); clippy `-D warnings` clean; fmt clean; workflow YAML valid; #189 lean-binding guard green. Diff provably doc-comment + CI-YAML only → all language gates unaffected. `#92` closes via the PR.
+- **README.md / ROADMAP.md:** unchanged (rationale in §3). **CLAUDE.md:** updated (added the `cargo doc -D warnings` local command).
+- **NEXT_SESSION.md:** symlink → `docs/handoffs/2026-06-27-docs-cargo-doc-warnings-92-shipped.md`.

--- a/ffi/secretary-ffi-bridge/src/contacts/revoke.rs
+++ b/ffi/secretary-ffi-bridge/src/contacts/revoke.rs
@@ -17,7 +17,7 @@ use crate::vault::OpenVaultManifest;
 /// the owner AND, because the revoke target is a current recipient, the target
 /// itself). Every card loaded from `contacts/` is re-verified (both
 /// Ed25519 ∧ ML-DSA-65 self-signature halves) at load time via
-/// [`load_card_bytes`] before its public keys are trusted — identical to the
+/// `load_card_bytes` before its public keys are trusted — identical to the
 /// share path, because the cards are re-read from disk here where a post-import
 /// swap would otherwise feed an unverified KEM key to the re-key.
 /// CannotRevokeOwner / RecipientNotPresent / NotAuthor / MissingRecipientCard

--- a/ffi/secretary-ffi-bridge/src/contacts/share.rs
+++ b/ffi/secretary-ffi-bridge/src/contacts/share.rs
@@ -15,7 +15,7 @@ use crate::vault::OpenVaultManifest;
 /// `BlockEntry.recipients` (always includes the owner). Every card loaded from
 /// `contacts/` — existing recipients AND the new recipient — is re-verified
 /// (both Ed25519 ∧ ML-DSA-65 self-signature halves) at load time via
-/// [`load_card_bytes`] before its public keys are trusted; verification at
+/// `load_card_bytes` before its public keys are trusted; verification at
 /// import time does NOT cover this path because the cards are re-read from disk
 /// here, where a post-import swap (an attacker with write access to `contacts/`,
 /// the threat `core::vault::restore_block` guards against) would otherwise pass

--- a/ffi/secretary-ffi-bridge/src/device.rs
+++ b/ffi/secretary-ffi-bridge/src/device.rs
@@ -6,7 +6,7 @@
 //! # Why a one-shot handle
 //!
 //! `secretary_core::vault::device_slot::add_device_slot` returns an
-//! [`EnrolledDevice`] whose `device_secret` is a `SecretBytes` — the only
+//! [`EnrolledDevice`](secretary_core::vault::device_slot::EnrolledDevice) whose `device_secret` is a `SecretBytes` — the only
 //! copy of the 32-byte device secret that leaves the core.  The caller (B.3)
 //! must deliver it exactly once to the platform Secure Enclave / biometric
 //! release layer, then drop it.  The three foreign languages lack a
@@ -212,7 +212,7 @@ pub fn add_device_slot(
 /// manifest decode + signature verification.  Returns two opaque handles:
 /// the live `UnlockedIdentity` and the read-only `OpenVaultManifest`.
 ///
-/// Reuses [`crate::vault::orchestration::split_core_open_vault`] — same
+/// Reuses `crate::vault::orchestration::split_core_open_vault` — same
 /// [`OpenVaultOutput`] shape as the password / recovery folder-in paths.
 ///
 /// # Inputs

--- a/ffi/secretary-ffi-bridge/src/edit/mod.rs
+++ b/ffi/secretary-ffi-bridge/src/edit/mod.rs
@@ -7,7 +7,7 @@
 //!
 //! Each mutating primitive (`append_record` / `edit_record`) decrypts the
 //! target block to a native [`BlockPlaintext`] via
-//! [`decrypt_block_plaintext`], mutates only the target record, and
+//! `decrypt_block_plaintext`, mutates only the target record, and
 //! re-encrypts through `core::vault::save_block`. `create_block` is the
 //! insert path: a fresh empty `BlockPlaintext`.
 

--- a/ffi/secretary-ffi-bridge/src/edit/move_record.rs
+++ b/ffi/secretary-ffi-bridge/src/edit/move_record.rs
@@ -33,7 +33,7 @@ use secretary_core::vault::record::{Record, RecordField};
 ///    field values, and every `unknown` map are preserved; only `record_uuid`
 ///    and the record-level `last_mod_ms` are fresh (set to `new_record_uuid`
 ///    and `now_ms` respectively).  `tombstone = false`, `tombstoned_at_ms = 0`.
-/// 4. Save the mutated target block through [`super::save_plaintext`]
+/// 4. Save the mutated target block through `super::save_plaintext`
 ///    (copy-before-delete).
 /// 5. Tombstone the source record via [`super::tombstone::tombstone_record`].
 ///

--- a/ffi/secretary-ffi-bridge/src/edit/tombstone.rs
+++ b/ffi/secretary-ffi-bridge/src/edit/tombstone.rs
@@ -26,7 +26,7 @@ use crate::vault::OpenVaultManifest;
 /// Fields are NOT cleared — the record stays fully resurrectable. Sets
 /// `tombstone = true`, `tombstoned_at_ms = now_ms`, `last_mod_ms = now_ms`
 /// (maintaining the death-clock invariant), preserves everything else, and
-/// re-encrypts through [`super::save_plaintext`].
+/// re-encrypts through `super::save_plaintext`.
 ///
 /// # Errors
 ///

--- a/ffi/secretary-ffi-bridge/src/trash/list.rs
+++ b/ffi/secretary-ffi-bridge/src/trash/list.rs
@@ -9,7 +9,7 @@
 //! same file `core::vault::restore_block` would (highest canonical-decimal
 //! `<ts>` suffix; non-canonical suffixes such as leading-zero forms are
 //! skipped to match core's §7 grammar) — using the shared
-//! [`decrypt_block_file_bytes`] tail, then immediately let the decrypted
+//! `decrypt_block_file_bytes` tail, then immediately let the decrypted
 //! plaintext drop (zeroize) — only the name is projected out. Record
 //! plaintext NEVER escapes this function.
 
@@ -58,7 +58,7 @@ pub struct TrashedBlock {
 /// - [`FfiVaultError::CorruptVault`] — the manifest handle has been
 ///   wiped, a trash entry has no matching file on disk (an integrity
 ///   violation, surfaced as a typed error rather than silently skipped),
-///   or any decrypt failure from [`decrypt_block_file_bytes`]
+///   or any decrypt failure from `decrypt_block_file_bytes`
 ///   (malformed file, signature/decap/tag failure, closed identity).
 /// - [`FfiVaultError::FolderInvalid`] — a trashed file is present but
 ///   unreadable for non-NotFound IO reasons (permissions, EBUSY, etc).

--- a/ffi/secretary-ffi-bridge/src/vault/mod.rs
+++ b/ffi/secretary-ffi-bridge/src/vault/mod.rs
@@ -35,8 +35,8 @@
 //!
 //! # Submodule layout
 //!
-//! - [`inner`] — `OpenVaultManifestInner` + [`BlockSummary`].
-//! - [`manifest`] — [`OpenVaultManifest`] + accessors + write-back +
+//! - `inner` — `OpenVaultManifestInner` + [`BlockSummary`].
+//! - `manifest` — [`OpenVaultManifest`] + accessors + write-back +
 //!   `ReplaceManifestError`.
 //! - [`orchestration`] — [`OpenVaultOutput`] + [`open_vault_with_password`] +
 //!   [`open_vault_with_recovery`] + the `core::vault::OpenVault`-to-handles

--- a/ffi/secretary-ffi-bridge/src/vault/orchestration.rs
+++ b/ffi/secretary-ffi-bridge/src/vault/orchestration.rs
@@ -1,6 +1,6 @@
 //! Folder-in vault open orchestrators ([`open_vault_with_password`] /
 //! [`open_vault_with_recovery`]) plus the [`OpenVaultOutput`] return shape
-//! and the bridge-internal [`split_core_open_vault`] helper that lifts a
+//! and the bridge-internal `split_core_open_vault` helper that lifts a
 //! `core::vault::OpenVault` into the two FFI handles.
 
 use std::path::Path;

--- a/ffi/secretary-ffi-py/src/lib.rs
+++ b/ffi/secretary-ffi-py/src/lib.rs
@@ -4,7 +4,7 @@
 //! for PyO3's #[pymodule] / #[pyfunction] macros, which expand to unsafe
 //! blocks (the CPython C-API bridge is inherently unsafe). The crate-local
 //! lint relaxation (workspace `forbid` → crate-local `deny`) is required
-//! because `forbid` is non-overridable by inner #[allow]; see Cargo.toml.
+//! because `forbid` is non-overridable by inner `#[allow]`; see Cargo.toml.
 //!
 //! The `#[allow]` is **crate-level** rather than item-level because the
 //! function-style `#[pymodule]` macro generates code at crate scope (an
@@ -17,23 +17,23 @@
 //!
 //! # Module layout
 //!
-//! - [`errors`] — `create_exception!` macros + `FfiUnlockError` /
+//! - `errors` — `create_exception!` macros + `FfiUnlockError` /
 //!   `FfiVaultError` → `PyErr` translators + the `uuid_array_or_value_error`
 //!   length-validation helper.
-//! - [`identity`] — `UnlockedIdentity` pyclass (shared by every entry
+//! - `identity` — `UnlockedIdentity` pyclass (shared by every entry
 //!   point that produces or consumes a live identity).
-//! - [`unlock`] — bytes-in unlock + create entry points (B.2 / B.3a /
+//! - `unlock` — bytes-in unlock + create entry points (B.2 / B.3a /
 //!   B.3b): `open_with_password`, `open_with_recovery`, `create_vault`,
 //!   `MnemonicOutput`, `CreateVaultOutput`.
-//! - [`vault`] — folder-in vault open entry points (B.4a):
+//! - `vault` — folder-in vault open entry points (B.4a):
 //!   `open_vault_with_password`, `open_vault_with_recovery`, plus the
 //!   `OpenVaultManifest` / `OpenVaultOutput` / `BlockSummary` pyclasses.
-//! - [`record`] — block-read entry point (B.4b): `read_block`, plus the
+//! - `record` — block-read entry point (B.4b): `read_block`, plus the
 //!   `FieldHandle` / `Record` / `BlockReadOutput` pyclasses.
-//! - [`save`] — block-save entry point (B.4c): `save_block`, plus the
+//! - `save` — block-save entry point (B.4c): `save_block`, plus the
 //!   `BlockInput` / `RecordInput` / `FieldInput` / `FieldInputValue`
 //!   input pyclasses.
-//! - [`share`] — block-share entry point (B.4d): `share_block`.
+//! - `share` — block-share entry point (B.4d): `share_block`.
 //!
 //! # Rationale documents
 //!

--- a/ffi/secretary-ffi-uniffi/src/lib.rs
+++ b/ffi/secretary-ffi-uniffi/src/lib.rs
@@ -19,12 +19,12 @@
 //!
 //! # Module layout
 //!
-//! - [`errors`] — `UnlockError`, `VaultError`, and the bridge-to-uniffi
+//! - `errors` — `UnlockError`, `VaultError`, and the bridge-to-uniffi
 //!   `From` conversions.
-//! - [`wrappers`] — opaque-handle wrappers around bridge-crate handle
-//!   types, grouped by domain ([`wrappers::identity`],
-//!   [`wrappers::vault`], [`wrappers::block`]).
-//! - [`namespace`] — the namespace functions declared in `secretary.udl`
+//! - `wrappers` — opaque-handle wrappers around bridge-crate handle
+//!   types, grouped by domain (`wrappers::identity`,
+//!   `wrappers::vault`, `wrappers::block`).
+//! - `namespace` — the namespace functions declared in `secretary.udl`
 //!   (open, create, read_block, ...).
 //!
 //! Everything declared in those modules is `pub use`d at crate root so

--- a/ffi/secretary-ffi-uniffi/src/namespace/mod.rs
+++ b/ffi/secretary-ffi-uniffi/src/namespace/mod.rs
@@ -304,7 +304,7 @@ pub fn read_block(
 /// rationale as [`read_block`].
 ///
 /// Converts uniffi-flat input dictionaries to bridge-side types
-/// ([`secretary_ffi_bridge::SecretString`] / [`secretary_core::crypto::secret::SecretBytes`]
+/// ([`secretary_core::crypto::secret::SecretString`] / [`secretary_core::crypto::secret::SecretBytes`]
 /// wrappers preserve zeroize-on-drop) and forwards to
 /// [`secretary_ffi_bridge::save_block`].
 ///


### PR DESCRIPTION
Closes #92.

## What

`cargo doc` was never a CI gate, so broken intra-doc links and public-doc→private-item links had accumulated. The whole workspace had **66** warnings (the issue cited ~28 in `secretary-core`; the C.1.1b sync functions and the cli/ffi/desktop/browser crates added the rest). This PR drives the **whole workspace to 0** and adds a regression gate.

Pure doc-comment + CI-YAML change — **no code, signature, visibility, on-disk-format, spec, `conformance.py`, KAT, or FFI-surface change; no behavior change.** Every changed `.rs` line is a `///` / `//!` doc-comment (verified by a diff filter).

## The two-class fix rule (applied uniformly across all 7 crates)

1. **"unresolved link to `X`"** — referent exists but the path is out of scope:
   - sibling method / assoc-fn / field on the same type → `` [`Self::X`] ``
   - enum variant of the enclosing enum → `` [`X`](Self::X) ``
   - a real **public** item elsewhere → re-anchor to a full navigable path `` [`X`](crate::path::X) `` (kept clickable)
   - genuinely **private** / `pub(crate)` / moved / bin `main` → **downgrade** to plain backticks `` `X` `` (no visibility widened)
2. **"public documentation for `A` links to private item `B`"** → **downgrade** `` [`B`] `` to `` `B` ``. Never made an item `pub` just to satisfy a doc link (preserves encapsulation).

Real bug fixed in passing: `BlockError::Signature` → the actual variant `BlockError::Sig`.

## CI gate

A new `doc` job in `.github/workflows/rust-lint.yml` mirrors the `clippy` job's **Linux+macOS matrix + Tauri GTK deps + rust-cache**, running `cargo doc --no-deps --workspace` under `RUSTDOCFLAGS=-D warnings`. The matrix matters: rustdoc only documents the **cfg-active** code per platform, so a macOS-only doc-link bug would slip past a Linux-only run. CLAUDE.md's Commands section gains the local equivalent.

## Acceptance (verified locally in the worktree)

- `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --workspace` → exit 0 (was 66 warnings)
- `cargo test --release --workspace` → **1456 passed, 0 failed** (unchanged count)
- `cargo clippy --release --workspace --tests -- -D warnings` → clean
- `cargo fmt --all --check` → clean
- workflow YAML parses; #189 lean-binding guard green

🤖 Generated with [Claude Code](https://claude.com/claude-code)