### PR TITLE
fix(core): reject duplicate block_uuid in manifest trash array on decode

### DIFF
--- a/core/src/vault/manifest.rs
+++ b/core/src/vault/manifest.rs
@@ -196,6 +196,12 @@ pub enum ManifestError {
     #[error("blocks array contains duplicate block_uuid")]
     DuplicateBlockUuid,
 
+    /// Two or more `trash` entries shared the same `block_uuid`. The
+    /// manifest tracks only the most-recent tombstone per block (§7), so a
+    /// repeated `block_uuid` is nonsensical — a sign of corruption or attack.
+    #[error("trash array contains duplicate block_uuid")]
+    DuplicateTrashUuid,
+
     /// A canonical-CBOR rule was violated (float, tag, …). Lifted from
     /// the shared `crate::vault::canonical` helpers.
     #[error("canonical CBOR violation: {0}")]
@@ -631,6 +637,8 @@ fn unknown_value_inner(u: &UnknownValue) -> Result<Value, ManifestError> {
 /// 8. `vector_clock` and every `vector_clock_summary` have no duplicate
 ///    `device_uuid`.
 /// 9. `blocks` has no duplicate `block_uuid`.
+/// 10. `trash` has no duplicate `block_uuid` (§7 tracks the most-recent
+///     tombstone per block only).
 ///
 /// Forward-compat unknown keys are preserved into the relevant `unknown`
 /// bag verbatim.
@@ -945,7 +953,16 @@ fn parse_trash(v: Value) -> Result<Vec<TrashEntry>, ManifestError> {
             })
         }
     };
-    items.into_iter().map(parse_trash_entry).collect()
+    let out: Vec<TrashEntry> = items
+        .into_iter()
+        .map(parse_trash_entry)
+        .collect::<Result<_, _>>()?;
+    let mut ids: Vec<[u8; UUID_LEN]> = out.iter().map(|t| t.block_uuid).collect();
+    ids.sort();
+    if ids.windows(2).any(|w| w[0] == w[1]) {
+        return Err(ManifestError::DuplicateTrashUuid);
+    }
+    Ok(out)
 }
 
 fn parse_trash_entry(v: Value) -> Result<TrashEntry, ManifestError> {
@@ -2269,6 +2286,41 @@ mod tests {
         assert!(
             matches!(err, ManifestError::DuplicateBlockUuid),
             "expected DuplicateBlockUuid, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn rejects_duplicate_trash_uuid() {
+        // The manifest carries the most-recent tombstone per block_uuid only
+        // (vault-format §7), so two trash entries sharing a block_uuid are
+        // nonsensical — a sign of corruption or attack — and rejected on
+        // decode, mirroring the `blocks` duplicate rule.
+        let dupe = [0x88; UUID_LEN];
+        let make_trash = |suffix: u8| TrashEntry {
+            block_uuid: dupe,
+            tombstoned_at_ms: u64::from(suffix),
+            tombstoned_by: [0xd1; UUID_LEN],
+            fingerprint: Some([suffix; BLOCK_FINGERPRINT_LEN]),
+            unknown: BTreeMap::new(),
+        };
+        let m = Manifest {
+            manifest_version: MANIFEST_VERSION_V1,
+            vault_uuid: [0x01; UUID_LEN],
+            format_version: FORMAT_VERSION_V1,
+            suite_id: SUITE_ID_V1,
+            owner_user_uuid: [0x02; UUID_LEN],
+            vector_clock: Vec::new(),
+            blocks: Vec::new(),
+            trash: vec![make_trash(1), make_trash(2)],
+            kdf_params: dummy_kdf_params(),
+            unknown: BTreeMap::new(),
+        };
+        let bytes = encode_manifest(&m).expect("encode duplicates");
+        let err = decode_manifest(&bytes)
+            .expect_err("duplicate trash block_uuid must be rejected on decode");
+        assert!(
+            matches!(err, ManifestError::DuplicateTrashUuid),
+            "expected DuplicateTrashUuid, got {err:?}"
         );
     }
 


### PR DESCRIPTION
## What & why

`decode_manifest`'s `parse_trash` accepted a manifest whose `trash` array carried two entries with the **same `block_uuid`**, while `parse_blocks` has always rejected the analogous duplicate in `blocks` (`DuplicateBlockUuid`). The manifest tracks only the **most-recent tombstone per block** (vault-format §7: *"the manifest's `TrashEntry` carries the most recent `tombstoned_at_ms` only"*), so a repeated trash `block_uuid` is nonsensical — a sign of corruption or a crafted manifest — and should be rejected by the strict decoder rather than silently carried.

Surfaced during the review of #315 (the trashed-block name memo): an `Explore` pass noted `parse_trash` lacked the uniqueness validation that `parse_blocks` enforces. Unreachable via normal vault operations (`trash_block` requires the block to be live first), so this is pure defense-in-depth against malformed/hostile input — but it closes a real asymmetry in the strict decoder.

## The change

- New typed `ManifestError::DuplicateTrashUuid`.
- `parse_trash` now mirrors `parse_blocks` exactly (collect → sort uuids → window-pair scan → reject).
- `decode_manifest` validation doc-list extended (item 10).
- `rejects_duplicate_trash_uuid` unit test paralleling `rejects_duplicate_block_uuid`.

## Scope / safety

**No on-disk byte-format change.** A well-formed manifest has no duplicate trash uuids, so the golden vault and `conformance.py` are unaffected — this only makes the strict decoder reject input it should never have accepted. No spec-doc change beyond the implied §7 rule (block_uuid uniqueness is likewise enforced in code, not enumerated in the spec prose).

## Verification

- `cargo test --release --workspace` — all green, incl. new `rejects_duplicate_trash_uuid`
- `cargo clippy --release --workspace --tests -- -D warnings` — clean (exit 0)
- `cargo fmt --all --check` — clean
- `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --workspace` — clean (exit 0)
- `uv run core/tests/python/conformance.py` — PASS (golden vault still decodes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)