### PR TITLE
test(#103): prove EvidenceStale TOCTOU abort writes no block files

### DIFF
--- a/NEXT_SESSION.md
+++ b/NEXT_SESSION.md
@@ -1,1 +1,1 @@
-docs/handoffs/2026-06-27-secretaryapp-swift6-shipped.md
+docs/handoffs/2026-06-27-sync-toctou-block-writes-103-shipped.md

--- a/core/tests/sync_helpers/mod.rs
+++ b/core/tests/sync_helpers/mod.rs
@@ -10,13 +10,15 @@
 //! across rewrites) holds even within a single tempdir. See the
 //! "Atomic-write contract" section of CLAUDE.md for the rationale.
 
+use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 
-use secretary_core::crypto::secret::Sensitive;
+use secretary_core::crypto::secret::{SecretString, Sensitive};
 use secretary_core::crypto::sig::{Ed25519Secret, MlDsa65Secret};
 use secretary_core::identity::fingerprint::fingerprint;
 use secretary_core::vault::{
-    encode_manifest_file, open_vault, sign_manifest, ManifestHeader, Unlocker, VectorClockEntry,
+    encode_manifest_file, open_vault, sign_manifest, ManifestHeader, Record, RecordField,
+    RecordFieldValue, Unlocker, VectorClockEntry,
 };
 use zeroize::Zeroize as _;
 
@@ -223,6 +225,44 @@ pub fn write_manifest_at(
 /// Local copy because the matching constant in `manifest::UUID_LEN` is
 /// `pub(crate)` to the core crate.
 const SYNC_HELPERS_UUID_LEN: usize = 16;
+
+/// Build a LIVE single-field `"kv"` record. `uuid` controls the
+/// `record_uuid` so callers can give the canonical and sibling sides of
+/// a divergence fixture distinct (non-conflicting) records; `marker`
+/// becomes the value of the sole field `"k"`. Pure: no I/O, no globals —
+/// every field is derived from the four arguments.
+///
+/// `dead_code` is tolerated because not every test target that compiles
+/// `sync_helpers` exercises this constructor.
+#[allow(dead_code)]
+pub fn live_record(
+    uuid: [u8; 16],
+    device_uuid: [u8; 16],
+    last_mod_ms: u64,
+    marker: &str,
+) -> Record {
+    let mut fields = BTreeMap::new();
+    fields.insert(
+        "k".to_string(),
+        RecordField {
+            value: RecordFieldValue::Text(SecretString::from(marker)),
+            last_mod: last_mod_ms,
+            device_uuid,
+            unknown: BTreeMap::new(),
+        },
+    );
+    Record {
+        record_uuid: uuid,
+        record_type: "kv".to_string(),
+        fields,
+        tags: Vec::new(),
+        created_at_ms: 50,
+        last_mod_ms,
+        tombstone: false,
+        tombstoned_at_ms: 0,
+        unknown: BTreeMap::new(),
+    }
+}
 
 /// Look up the first block_uuid in the golden vault's manifest. Used
 /// by helpers that need a real on-disk block to rewrite.

--- a/core/tests/sync_merge_crash.rs
+++ b/core/tests/sync_merge_crash.rs
@@ -21,17 +21,12 @@
 //! because that file already sits at ~500 LOC after Task 13.4 and crash
 //! recovery is a distinct concern from veto handling.
 
-use std::collections::BTreeMap;
-
-use secretary_core::crypto::secret::SecretString;
 use secretary_core::sync::{
     commit_with_decisions, prepare_merge, sync_once, SyncOutcome, SyncState,
 };
 use secretary_core::unlock::open_with_password;
 use secretary_core::vault::block::VectorClockEntry;
-use secretary_core::vault::{
-    open_vault, Record, RecordField, RecordFieldValue, Unlocker, VaultError,
-};
+use secretary_core::vault::{open_vault, Record, Unlocker, VaultError};
 
 mod fixtures;
 mod sync_helpers;
@@ -71,32 +66,8 @@ const SIBLING_MANIFEST_FILENAME: &str = "manifest.cbor.enc.sync-conflict-from-de
 /// `enumerate_block_siblings` picks it up.
 const SIBLING_BLOCK_SUFFIX: &str = ".sync-conflict-from-device-bb";
 
-/// Build a LIVE record with a single field. `uuid` controls the
-/// `record_uuid` so the canonical and sibling sides carry distinct
-/// (non-conflicting) records.
-fn live_record(uuid: [u8; 16], device_uuid: [u8; 16], last_mod_ms: u64, marker: &str) -> Record {
-    let mut fields = BTreeMap::new();
-    fields.insert(
-        "k".to_string(),
-        RecordField {
-            value: RecordFieldValue::Text(SecretString::from(marker)),
-            last_mod: last_mod_ms,
-            device_uuid,
-            unknown: BTreeMap::new(),
-        },
-    );
-    Record {
-        record_uuid: uuid,
-        record_type: "kv".to_string(),
-        fields,
-        tags: Vec::new(),
-        created_at_ms: 50,
-        last_mod_ms,
-        tombstone: false,
-        tombstoned_at_ms: 0,
-        unknown: BTreeMap::new(),
-    }
-}
+// `live_record` now lives in `sync_helpers` (shared with sync_merge_toctou.rs);
+// call sites below use `sync_helpers::live_record`.
 
 /// Read the canonical block file at `block_uuid` and return the
 /// decrypted records inside. The block is decrypted via a freshly opened
@@ -168,7 +139,7 @@ fn partial_commit_recovers_via_idempotent_re_run() {
 
     let (folder, _tmp) = sync_helpers::fresh_vault_two_concurrent_blocks(
         block_uuid,
-        vec![live_record(
+        vec![sync_helpers::live_record(
             CANONICAL_RECORD_UUID,
             CANONICAL_DEVICE_UUID,
             CANONICAL_LAST_MOD_MS,
@@ -176,7 +147,7 @@ fn partial_commit_recovers_via_idempotent_re_run() {
         )],
         canonical_block_clock.clone(),
         canonical_block_clock,
-        vec![live_record(
+        vec![sync_helpers::live_record(
             SIBLING_RECORD_UUID,
             SIBLING_DEVICE_UUID,
             SIBLING_LAST_MOD_MS,

--- a/core/tests/sync_merge_toctou.rs
+++ b/core/tests/sync_merge_toctou.rs
@@ -1,0 +1,229 @@
+//! Integration test for the D5 TOCTOU freshness short-circuit inside
+//! `commit_with_decisions` — the *block-write* half (#103).
+//!
+//! `commit_with_decisions` re-checks the on-disk manifest envelope hash
+//! against `draft.manifest_hash` at step 2 of its prologue, BEFORE step 5
+//! re-encrypts any diverging block ([core/src/sync/commit/write.rs] —
+//! the `EvidenceStale` early return at step 2 precedes the per-block
+//! `rewrite_one_block` loop at step 5). A mid-flight manifest mutation
+//! therefore aborts the commit with [`SyncError::EvidenceStale`] and must
+//! leave the disk *completely* untouched: no manifest write AND no block
+//! write.
+//!
+//! The companion test
+//! [`sync_merge.rs::commit_with_decisions_stale_manifest_hash_aborts_with_no_disk_writes`]
+//! (Task 12) proves the *manifest* half using the empty-divergence
+//! fixture — there are no affected blocks, so manifest byte-equality is
+//! the single commit-point check. This file adds the *block* half: a
+//! divergence-bearing fixture (`bundle.diverging_blocks` non-empty) so
+//! step 5 has real per-block rewrites queued, and asserts those block
+//! files are byte-identical across the failed commit. Together the two
+//! tests prove the freshness re-check has the *complete* short-circuit
+//! property.
+//!
+//! Lives in its own test binary (rather than extending `sync_merge.rs`,
+//! already near the ~500-LOC threshold) per the project's split-by-concept
+//! precedent (`sync_merge_vetoes.rs`, `sync_merge_crash.rs`).
+
+use secretary_core::sync::{
+    commit_with_decisions, prepare_merge, sync_once, SyncOutcome, SyncState,
+};
+use secretary_core::unlock::open_with_password;
+use secretary_core::vault::block::VectorClockEntry;
+
+mod fixtures;
+mod sync_helpers;
+
+use fixtures::extract_vault_uuid;
+
+/// Record UUID carried by the canonical block. Distinct from the sibling
+/// UUID so the merge is a clean union with no per-record vetoes — the
+/// abort under test must fire from the freshness re-check, not a veto.
+const CANONICAL_RECORD_UUID: [u8; 16] = [0xAA; 16];
+/// Record UUID carried by the sibling block (distinct from canonical).
+const SIBLING_RECORD_UUID: [u8; 16] = [0xBB; 16];
+/// Canonical device clock anchor (block `vector_clock_summary` + manifest
+/// `vector_clock` on the canonical side).
+const CANONICAL_DEVICE_UUID: [u8; 16] = [0x0A; 16];
+/// Sibling device clock anchor (block + manifest clocks on the sibling
+/// conflict-copy).
+const SIBLING_DEVICE_UUID: [u8; 16] = [0x0B; 16];
+/// Local device clock anchor (the persisted `SyncState`'s seen-clock
+/// entry; distinct from canonical + sibling so the relation is
+/// `Concurrent` and `sync_once` yields `ConcurrentDetected`).
+const LOCAL_DEVICE_UUID: [u8; 16] = [0x0C; 16];
+/// Clock counter on every single-entry vector clock in this fixture.
+const CLOCK_COUNTER: u64 = 1;
+/// `last_mod_ms` on the canonical record.
+const CANONICAL_LAST_MOD_MS: u64 = 100;
+/// `last_mod_ms` on the sibling record.
+const SIBLING_LAST_MOD_MS: u64 = 200;
+/// `now_ms` the fixture stamps onto both blocks + manifests.
+const FIXTURE_NOW_MS: u64 = 1_000_000;
+/// `now_ms` passed to the (doomed) `commit_with_decisions` call.
+const COMMIT_NOW_MS: u64 = 2_000_000;
+/// Sibling manifest filename. Must start with `manifest.cbor.enc` so
+/// `enumerate_manifest_siblings` discovers it.
+const SIBLING_MANIFEST_FILENAME: &str = "manifest.cbor.enc.sync-conflict-from-device-bb";
+/// Sibling block-file suffix. Must start with a non-empty separator so
+/// `enumerate_block_siblings` picks it up.
+const SIBLING_BLOCK_SUFFIX: &str = ".sync-conflict-from-device-bb";
+
+/// Mutating the canonical manifest between `prepare_merge` and
+/// `commit_with_decisions` — on a fixture whose merge DOES have per-block
+/// rewrites queued — must abort with [`SyncError::EvidenceStale`] AND
+/// leave BOTH the manifest and the diverging block files byte-identical
+/// to their pre-commit state (the complete short-circuit: zero disk
+/// writes).
+///
+/// This is the block-write half of the property proved (for the manifest
+/// only) by `sync_merge.rs::commit_with_decisions_stale_manifest_hash_aborts_with_no_disk_writes`.
+///
+/// Flow:
+/// 1. Build a per-block-divergent canonical/sibling fixture so that after
+///    `sync_once` the bundle/plan carry a non-empty `diverging_blocks`
+///    (asserted — guards against a vacuous test where step 5 has nothing
+///    to write).
+/// 2. `sync_once → prepare_merge`. The draft captures `manifest_hash`
+///    over the current (`CANONICAL_NONCE_A`) canonical manifest envelope.
+///    The draft has no vetoes (distinct record UUIDs → clean union).
+/// 3. Snapshot the canonical manifest + diverging block file bytes.
+/// 4. Open the TOCTOU race window: re-emit the canonical manifest with
+///    the SAME logical content but a different AEAD nonce
+///    (`SIBLING_NONCE_D`). The envelope bytes — hence the BLAKE3 hash —
+///    change, so the on-disk hash diverges from `draft.manifest_hash`,
+///    while `open_vault` (commit step 1) still accepts it (the block
+///    entries / fingerprints / signature are unchanged).
+/// 5. `commit_with_decisions` must return `Err(EvidenceStale)`.
+/// 6. Assert the canonical block file is byte-identical to step 3 — step
+///    5's `rewrite_one_block` never ran (the NEW assertion for #103).
+/// 7. Assert the canonical manifest is byte-identical to its
+///    post-race-window state — no manifest write either.
+#[test]
+fn commit_with_decisions_stale_manifest_with_diverging_blocks_writes_no_block_files() {
+    // Step 0: discover the golden vault's first block_uuid via a throwaway
+    // open (the fixture diverges this exact block on both sides).
+    let (probe_folder, _probe_tmp) = sync_helpers::fresh_vault_with_clock(Vec::new());
+    let block_uuid = sync_helpers::golden_vault_001_first_block_uuid(&probe_folder);
+
+    let canonical_block_clock = vec![VectorClockEntry {
+        device_uuid: CANONICAL_DEVICE_UUID,
+        counter: CLOCK_COUNTER,
+    }];
+    let sibling_block_clock = vec![VectorClockEntry {
+        device_uuid: SIBLING_DEVICE_UUID,
+        counter: CLOCK_COUNTER,
+    }];
+
+    // Step 1: build the divergence-bearing fixture. Canonical block holds
+    // record [0xAA] @100; sibling block holds record [0xBB] @200. Distinct
+    // UUIDs → the merge unions them with no vetoes. Both the canonical
+    // block file and the canonical manifest end up on disk; the manifest
+    // is signed with CANONICAL_NONCE_A.
+    let (folder, _tmp) = sync_helpers::fresh_vault_two_concurrent_blocks(
+        block_uuid,
+        vec![sync_helpers::live_record(
+            CANONICAL_RECORD_UUID,
+            CANONICAL_DEVICE_UUID,
+            CANONICAL_LAST_MOD_MS,
+            "canonical",
+        )],
+        canonical_block_clock.clone(),
+        canonical_block_clock.clone(),
+        vec![sync_helpers::live_record(
+            SIBLING_RECORD_UUID,
+            SIBLING_DEVICE_UUID,
+            SIBLING_LAST_MOD_MS,
+            "sibling",
+        )],
+        sibling_block_clock.clone(),
+        sibling_block_clock,
+        SIBLING_MANIFEST_FILENAME,
+        SIBLING_BLOCK_SUFFIX,
+        FIXTURE_NOW_MS,
+    );
+
+    let password = fixtures::golden_vault_001_password();
+    let vt_bytes = std::fs::read(folder.join("vault.toml")).expect("read vault.toml");
+    let bundle_bytes =
+        std::fs::read(folder.join("identity.bundle.enc")).expect("read identity bundle");
+    let identity =
+        open_with_password(&vt_bytes, &bundle_bytes, &password).expect("open_with_password");
+
+    let vault_uuid = extract_vault_uuid(&folder);
+    let local_clock = vec![VectorClockEntry {
+        device_uuid: LOCAL_DEVICE_UUID,
+        counter: CLOCK_COUNTER,
+    }];
+    let state = SyncState::new(vault_uuid, local_clock).expect("SyncState::new");
+
+    // Step 2: drive sync to a draft. The draft's manifest_hash pins the
+    // CANONICAL_NONCE_A envelope captured here.
+    let outcome = sync_once(&folder, &identity, &state, 0u64).expect("sync_once");
+    let (bundle, plan) = match outcome {
+        SyncOutcome::ConcurrentDetected { bundle, plan, .. } => (bundle, plan),
+        other => panic!("expected ConcurrentDetected, got {other:?}"),
+    };
+    assert!(
+        !bundle.diverging_blocks.is_empty(),
+        "fixture must force per-block divergence so step 5 has real block rewrites to short-circuit",
+    );
+    assert!(
+        plan.diverging_blocks.contains(&block_uuid),
+        "the block we snapshot must be one step 5 would rewrite on a successful commit",
+    );
+
+    let draft = prepare_merge(&folder, &identity, &bundle, &plan).expect("prepare_merge");
+    assert!(
+        draft.vetoes.is_empty(),
+        "distinct record UUIDs must merge with no vetoes (got {} vetoes)",
+        draft.vetoes.len(),
+    );
+
+    // Step 4: open the TOCTOU race window. Re-emit the canonical manifest
+    // with its existing logical content (same vector_clock, same preserved
+    // block entries) but a fresh AEAD nonce. Only the envelope bytes
+    // change, so commit step 1's `open_vault` still accepts the manifest
+    // (it is logically identical to one that already opened cleanly) while
+    // step 2's BLAKE3 freshness re-check sees a hash != draft.manifest_hash.
+    // SIBLING_NONCE_D differs from the fixture's CANONICAL_NONCE_A, so the
+    // re-emitted bytes are guaranteed distinct.
+    sync_helpers::write_manifest_at(
+        &folder,
+        sync_helpers::MANIFEST_FILENAME,
+        canonical_block_clock,
+        &sync_helpers::SIBLING_NONCE_D,
+    );
+
+    // Step 3 (snapshot AFTER the race window — the block file is untouched
+    // by `write_manifest_at`, and we want the manifest baseline to be its
+    // post-mutation state so any commit-side write would be detectable).
+    let manifest_path = folder.join(sync_helpers::MANIFEST_FILENAME);
+    let block_path = sync_helpers::block_file_path(&folder, &block_uuid);
+    let manifest_before = std::fs::read(&manifest_path).expect("read manifest before commit");
+    let block_before = std::fs::read(&block_path).expect("read diverging block before commit");
+
+    // Step 5: the doomed commit.
+    let err = commit_with_decisions(&folder, &password, draft, Vec::new(), COMMIT_NOW_MS)
+        .expect_err("commit_with_decisions must reject a stale draft.manifest_hash");
+    assert!(
+        matches!(err, secretary_core::sync::SyncError::EvidenceStale),
+        "expected SyncError::EvidenceStale, got {err:?}",
+    );
+
+    // Step 6 (NEW, #103): the diverging block file is byte-identical —
+    // step 5's `rewrite_one_block` never persisted a tempfile.
+    let block_after = std::fs::read(&block_path).expect("read diverging block after commit");
+    assert_eq!(
+        block_before, block_after,
+        "EvidenceStale must abort BEFORE any block re-encrypt; diverging block bytes changed",
+    );
+
+    // Step 7: the canonical manifest is byte-identical too — no manifest
+    // write happened either (mirrors the Task 12 manifest-half assertion).
+    let manifest_after = std::fs::read(&manifest_path).expect("read manifest after commit");
+    assert_eq!(
+        manifest_before, manifest_after,
+        "EvidenceStale must abort with NO disk writes; manifest bytes changed",
+    );
+}

--- a/docs/handoffs/2026-06-27-sync-toctou-block-writes-103-shipped.md
+++ b/docs/handoffs/2026-06-27-sync-toctou-block-writes-103-shipped.md
@@ -1,0 +1,82 @@
+# NEXT_SESSION.md — #103 EvidenceStale TOCTOU block-write half ✅ SHIPPED (PR opening)
+
+**Session date:** 2026-06-27 (fourth session of the day). Started from a clean baton — the prior session's SecretaryApp Swift 6 work merged to `main` as `50f1b330` (PR #317). Synced `main`, picked **#103** from the collision-free backlog (user chose it from the options shortlist: core Rust, sync-merge security path, pure TDD). Executed in project-local worktree `.worktrees/sync-toctou-block-writes-103`, branch `feature/sync-toctou-block-writes-103` (cut from `origin/main` @ `50f1b330`).
+
+**Status:** ✅ **SHIPPED — branch `feature/sync-toctou-block-writes-103`, PR opening.** Test-only. **No `src/` change, no FFI / on-disk-format / spec / `conformance.py` / KAT-JSON change, no observable byte/semantics change.** Closes #103.
+
+## (1) What we shipped this session
+
+**The gap (#103, surfaced by PR #102 self-review).** `commit_with_decisions` runs a D5 TOCTOU freshness re-check at step 2 of its prologue ([core/src/sync/commit/write.rs:119-121](core/src/sync/commit/write.rs#L119-L121)): it BLAKE3-hashes the on-disk manifest envelope and aborts with `SyncError::EvidenceStale` if it diverges from `draft.manifest_hash`. Crucially, step 2 runs **before** step 5's per-block `rewrite_one_block` loop ([write.rs:133-149](core/src/sync/commit/write.rs#L133-L149)), so a mid-flight manifest mutation must leave the disk *completely* untouched — no manifest write AND no block write.
+
+The Task-12 test `commit_with_decisions_stale_manifest_hash_aborts_with_no_disk_writes` ([core/tests/sync_merge.rs:409](core/tests/sync_merge.rs#L409)) proved only the **manifest half**: it uses the empty-divergence fixture (`bundle.diverging_blocks` empty), so step 5 had no block writes queued and manifest byte-equality was the single commit-point check. The **block half** was structurally correct but unproven by test.
+
+**The fix — a divergence-bearing companion test.** New `commit_with_decisions_stale_manifest_with_diverging_blocks_writes_no_block_files` in a new binary [core/tests/sync_merge_toctou.rs](core/tests/sync_merge_toctou.rs):
+- Builds the `fresh_vault_two_concurrent_blocks` fixture (canonical record `[0xAA]@100` vs sibling `[0xBB]@200`, distinct UUIDs → clean union, no vetoes) so `bundle.diverging_blocks` is **non-empty** (asserted — guards against a vacuous test) and `plan.diverging_blocks.contains(&block_uuid)` (the snapshot block is one step 5 *would* rewrite).
+- Opens the same `prepare_merge → mutate-manifest → commit_with_decisions` race window. The mutation re-emits the canonical manifest with **identical logical content but a fresh AEAD nonce** (`SIBLING_NONCE_D` vs the fixture's `CANONICAL_NONCE_A`): the envelope bytes — hence the BLAKE3 hash — change, so step 2 trips, while `open_vault` (step 1) still accepts it (block entries / fingerprints / signature unchanged). This cleanly isolates "any envelope change → freshness fires" with no clock-domination concerns.
+- Asserts `Err(EvidenceStale)`, then **NEW for #103**: the diverging block file is byte-identical across the failed commit (step 5 never persisted a tempfile), plus the manifest is byte-identical too (the complete short-circuit).
+
+**Mutation-tested (not assumed).** Temporarily moved the freshness early-return to *after* the block-rewrite loop → the new test failed on **exactly** the block-bytes assertion (`"EvidenceStale must abort BEFORE any block re-encrypt; diverging block bytes changed"`), not the `EvidenceStale` match. This proves the new assertion is a real ordering guard, not vacuous. Mutation reverted; `git diff core/src/sync/commit/write.rs` is empty (verified).
+
+**Supporting refactor.** Lifted the pure `live_record` helper into the shared `sync_helpers` module (it was about to be duplicated; `sync_merge_crash.rs` now calls `sync_helpers::live_record` too, and its now-unused `BTreeMap`/`SecretString`/`RecordField`/`RecordFieldValue` imports were trimmed) per [[feedback_pure_functions]].
+
+**Branch commits** (off `main` @ `50f1b330`):
+| SHA | What |
+|---|---|
+| `a11748d8` | **test(#103)**: prove EvidenceStale TOCTOU abort writes no block files (new `sync_merge_toctou.rs` + `live_record` lift to `sync_helpers` + `sync_merge_crash.rs` dedup) |
+| (+ handoff commit) | this baton + retargeted `NEXT_SESSION.md` symlink |
+
+### Acceptance (verified this session, in the worktree)
+```bash
+cd /Users/hherb/src/secretary/.worktrees/sync-toctou-block-writes-103
+cargo test --release --workspace                       # ALL green, 0 failed
+cargo clippy --release --workspace --tests -- -D warnings   # clean
+cargo fmt --all -- --check                             # clean
+```
+- New + affected binaries: `sync_merge_toctou` (new test passes), `sync_merge_crash` (6 pass after the `live_record` lift), `sync_merge` (9 pass, Task-12 manifest-half untouched).
+- Full workspace: every `test result:` line shows `0 failed`.
+- **File-size discipline:** `sync_merge.rs` left untouched at 495 LOC (< 500); new test in its own binary per the split-by-concept precedent (`sync_merge_vetoes.rs`, `sync_merge_crash.rs`).
+
+## (2) What's next
+**This item is done (PR open). Pick a fresh item.** Active parallel worktrees this session (avoid collisions): `.worktrees/d4-browser-autofill` (D.4), `.worktrees/desktop-block-crud-ui`, `.claude/worktrees/hardcore-robinson-373901` (D.3 iOS XCFramework #200). Stale/merged worktrees still on disk (removable once their PRs are confirmed merged — see §4): `.worktrees/secretaryapp-swift6` (#317 ✅), `.worktrees/trash-list-memo-172` (#315 ✅), `.worktrees/parse-trash-dup-uuid` (#316 ✅). Collision-free candidates:
+- **#147** — `timer::tick` should surface mutex **poisoning** distinctly from contention (desktop Rust; a poisoned session mutex silently stops the auto-lock timer forever — add a `tracing::error!` + a `tracing-test` assertion). Mild collision risk with the active desktop worktree — check `desktop/src-tauri/src/timer.rs` isn't being touched there first.
+- **#117** — cap the `TtyVetoUx` re-prompt loop at N invalid replies, default to safe `KeepLocal` (CLI Rust; defensive).
+- **#105** — group multi-arg test-helper signatures into param structs (`sync_helpers` + `sync_merge_vetoes`); test-only, continues #183's transposition-safety theme.
+- Pick a fresh meaty-Rust item from the carried backlog below (user is a Rust novice learning on this project; prefers core Rust with real security-path substance).
+
+**Acceptance criteria template:** a failing test/build (or mutation test) reproducing the gap on `main`, the typed-error/enforcement surface *proven* not assumed (security paths, [[feedback_verify_deferred_items]] / [[feedback_security_no_assumptions]]), the platform's full test gate green, spec/`conformance.py` updated in lockstep if observable bytes/semantics change.
+
+**Open follow-up issues (carried):** #307 / #290 / #284 / #280 / #277 / #273 / #269 / #255 / #247 / #246 / #234 / #232 / #224 / #218 / #186 / #167 / #162 / #161 / #160 / #159 / #158 / #147 / #145 / #144 / #140 / #139 / #138 / #135 / #134 / #133 / #132 / #129 / #127 / #126 / #123 / #122 / #120 / #117 / #105 / #103 (now closed).
+
+## (3) Open decisions and risks
+- **Pre-existing freshness FAIL is NOT mine.** `uv run core/tests/python/spec_test_name_freshness.py` reports 3 unresolved citations (`origin_binding` / `registrable_domain` / `exact_origin` in `docs/threat-model.md` L234). These are the **#290** D.4 design-concept false-positives — already failing on `main`, collision-risky to fix while `.worktrees/d4-browser-autofill` is active. My change touches no docs and adds no citations.
+- **Race-window design choice (deliberate):** re-emit the manifest with the **same logical content + a fresh AEAD nonce**, rather than bumping the vector clock like the Task-12 manifest-half test does. Reusing the fixture's own canonical clock guarantees `open_vault` (step 1) still accepts it (no clock-domination edge cases), so the failure provably fires from the step-2 BLAKE3 re-check on the envelope-byte change — the cleanest isolation of the property under test.
+- **Vacuity guarded two ways:** (a) the test asserts `!bundle.diverging_blocks.is_empty()` + `plan.diverging_blocks.contains(&block_uuid)` so step 5 genuinely has block writes to short-circuit; (b) the mutation test (check moved after the block loop) confirmed the new assertion *fails* when the invariant breaks.
+- **README.md / ROADMAP.md unchanged (deliberate).** A core test-coverage regression guard adds no product capability and is not a roadmap slice; per [[feedback_readme_style]] status sections avoid test-count walls. CLAUDE.md unchanged (no new documented command; the test runs under the existing `cargo test --release --workspace`).
+- **Risk:** none to product behavior — test-only, no `src/` change. The guarded invariant was already structurally correct; this is a regression guard, not a fix.
+
+## (4) Exact commands to resume
+```bash
+cd /Users/hherb/src/secretary
+git fetch --prune origin && git checkout main && git pull --ff-only origin main
+# If #103 PR merged, remove this worktree + branch:
+#   git worktree remove .worktrees/sync-toctou-block-writes-103 && git branch -D feature/sync-toctou-block-writes-103
+# Stale merged worktrees safe to prune (confirm each PR merged first):
+#   git worktree remove .worktrees/secretaryapp-swift6   && git branch -D feature/secretaryapp-swift6     # #317
+#   git worktree remove .worktrees/trash-list-memo-172   && git branch -D feature/trash-list-memo-172     # #315
+#   git worktree remove .worktrees/parse-trash-dup-uuid  && git branch -D feature/parse-trash-dup-uuid    # #316
+git worktree list && git status -s
+
+# Re-verify this session's work (from the worktree if the PR is still open):
+cd .worktrees/sync-toctou-block-writes-103
+cargo test --release --workspace --test sync_merge_toctou --test sync_merge_crash --test sync_merge
+cargo clippy --release --workspace --tests -- -D warnings
+```
+
+## (5) Handoff file model
+`NEXT_SESSION.md` is a **relative symlink** to this file in `docs/handoffs/`. Authored once here; symlink retargeted in the same commit on the feature branch. New-path handoff → no add/add conflict. Branch cut from `origin/main` (`50f1b330`); at handoff time `origin/main` is an ancestor of `HEAD` (verified via `git merge-base --is-ancestor`), so no history-binding merge was needed.
+
+## Closing inventory
+- **State on close:** PR opening on `feature/sync-toctou-block-writes-103` (`a11748d8` test + handoff). Worktree `.worktrees/sync-toctou-block-writes-103`.
+- **Acceptance:** full workspace `cargo test --release` green (0 failed); clippy `-D warnings` clean; fmt clean. New test mutation-verified non-vacuous. Diff is test-only (3 files: new `sync_merge_toctou.rs`, `sync_helpers` `live_record` lift, `sync_merge_crash` dedup).
+- **README.md / ROADMAP.md / CLAUDE.md:** unchanged (rationale in §3).
+- **NEXT_SESSION.md:** symlink → `docs/handoffs/2026-06-27-sync-toctou-block-writes-103-shipped.md`.


### PR DESCRIPTION
Closes #103.

## What
Adds the **block-write half** of the D5 TOCTOU freshness short-circuit proof for `commit_with_decisions`.

The Task-12 test `commit_with_decisions_stale_manifest_hash_aborts_with_no_disk_writes` proves the freshness re-check aborts with **no manifest write**, but it uses the empty-divergence fixture, so step 5 (`rewrite_one_block`) had no block writes queued — the block half was structurally correct but unproven.

New test `commit_with_decisions_stale_manifest_with_diverging_blocks_writes_no_block_files` (new binary `core/tests/sync_merge_toctou.rs`):
- Divergence-bearing fixture (`bundle.diverging_blocks` non-empty, asserted; `plan.diverging_blocks` contains the snapshot block).
- Same `prepare_merge → mutate-manifest → commit_with_decisions` race window. The mutation re-emits the canonical manifest with **identical logical content + a fresh AEAD nonce** (`SIBLING_NONCE_D` vs the fixture's `CANONICAL_NONCE_A`), so the envelope hash diverges from `draft.manifest_hash` while `open_vault` (step 1) still accepts it.
- Asserts `Err(EvidenceStale)`, then **NEW**: the diverging block file AND the manifest are byte-identical across the failed commit.

Together with Task 12 this proves the **complete** short-circuit: zero manifest writes AND zero block writes.

## Why it's not vacuous
Mutation-tested: temporarily moving the freshness early-return to *after* the block-rewrite loop makes the new test fail on **exactly** the block-bytes assertion (not the `EvidenceStale` match), confirming it is a real ordering guard. Mutation reverted (`git diff core/src/sync/commit/write.rs` empty).

## Supporting refactor
Lifted the pure `live_record` helper into the shared `sync_helpers` module (was duplicated-in-waiting); `sync_merge_crash.rs` now uses it and its now-unused imports were trimmed.

## Scope
Test-only. **No `src/` change**, no FFI / on-disk-format / spec / `conformance.py` / KAT-JSON change, **no observable byte/semantics change**. `sync_merge.rs` left at 495 LOC (< 500); new test in its own binary per the split-by-concept precedent.

## Verification
- `cargo test --release --workspace` — all green, 0 failed
- `cargo clippy --release --workspace --tests -- -D warnings` — clean
- `cargo fmt --all -- --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)