### PR TITLE
feat(android): vault-create FFI seam (cloud-drive provisioning, slice 1/6)

### DIFF
--- a/NEXT_SESSION.md
+++ b/NEXT_SESSION.md
@@ -1,1 +1,1 @@
-docs/handoffs/2026-06-27-timer-poison-distinct-147-shipped.md
+docs/handoffs/2026-06-27-android-cloud-drive-slice1-vault-create-port-shipped.md

--- a/android/kit/src/androidTest/kotlin/org/secretary/browse/UniffiVaultCreatePortInstrumentedTest.kt
+++ b/android/kit/src/androidTest/kotlin/org/secretary/browse/UniffiVaultCreatePortInstrumentedTest.kt
@@ -7,16 +7,13 @@ import org.junit.Assert.assertThrows
 import org.junit.Test
 import org.junit.runner.RunWith
 import java.io.File
+import java.nio.file.Files
 
 @RunWith(AndroidJUnit4::class)
 class UniffiVaultCreatePortInstrumentedTest {
 
     private fun freshDir(prefix: String): File =
-        File.createTempFile(prefix, "").let { f ->
-            f.delete()
-            check(f.mkdirs()) { "could not mkdir ${f.path}" }
-            f
-        }
+        Files.createTempDirectory(prefix).toFile()
 
     @Test
     fun create_then_open_round_trips_with_24_word_phrase() = runBlocking {

--- a/android/kit/src/androidTest/kotlin/org/secretary/browse/UniffiVaultCreatePortInstrumentedTest.kt
+++ b/android/kit/src/androidTest/kotlin/org/secretary/browse/UniffiVaultCreatePortInstrumentedTest.kt
@@ -1,0 +1,60 @@
+package org.secretary.browse
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertThrows
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.io.File
+
+@RunWith(AndroidJUnit4::class)
+class UniffiVaultCreatePortInstrumentedTest {
+
+    private fun freshDir(prefix: String): File =
+        File.createTempFile(prefix, "").let { f ->
+            f.delete()
+            check(f.mkdirs()) { "could not mkdir ${f.path}" }
+            f
+        }
+
+    @Test
+    fun create_then_open_round_trips_with_24_word_phrase() = runBlocking {
+        val dir = freshDir("create-roundtrip-")
+        try {
+            val createPort = uniffiVaultCreatePort()
+            val pw = "create-instr-pw".toByteArray(Charsets.UTF_8)
+            val created = createPort.createInFolder(dir.path, pw, "Instr-Bob")
+            val wordCount = created.phrase.toString(Charsets.UTF_8).split(" ").size
+            assertEquals(24, wordCount)
+
+            // The created vault opens with the same password and reports the display name.
+            val session = uniffiVaultOpenPort().openWithPassword(dir.path, pw)
+            try {
+                // A freshly-created vault has no user blocks yet; opening + listing must not throw.
+                assertEquals(0, session.blockSummaries().size)
+            } finally {
+                session.wipe()
+            }
+        } finally {
+            dir.deleteRecursively()
+        }
+    }
+
+    @Test
+    fun create_in_non_empty_folder_throws_folder_not_empty() {
+        val dir = freshDir("create-nonempty-")
+        try {
+            File(dir, "junk").writeText("x")
+            assertThrows(VaultProvisioningError.FolderNotEmpty::class.java) {
+                runBlocking {
+                    uniffiVaultCreatePort().createInFolder(
+                        dir.path, "pw".toByteArray(Charsets.UTF_8), "Nope",
+                    )
+                }
+            }
+        } finally {
+            dir.deleteRecursively()
+        }
+    }
+}

--- a/android/kit/src/main/kotlin/org/secretary/browse/UniffiVaultCreatePort.kt
+++ b/android/kit/src/main/kotlin/org/secretary/browse/UniffiVaultCreatePort.kt
@@ -16,8 +16,9 @@ import uniffi.secretary.createVaultInFolder
  * caller-owned (caller zeroizes after the user acknowledges it).
  *
  * [createFn] is the injectable FFI seam: it returns the one-shot recovery-phrase bytes (or null).
- * Its default invokes the real binding inside `.use { … }` so the native [uniffi.secretary.MnemonicOutput]
- * handle is always released. [clockMs] supplies `created_at_ms` (injected for deterministic tests).
+ * Its default invokes the real binding inside `.use { … }` so the native
+ * [uniffi.secretary.MnemonicOutput] handle is always released.
+ * [clockMs] supplies `created_at_ms` (injected for deterministic tests).
  */
 class UniffiVaultCreatePort(
     private val ioDispatcher: CoroutineDispatcher = Dispatchers.IO,

--- a/android/kit/src/main/kotlin/org/secretary/browse/UniffiVaultCreatePort.kt
+++ b/android/kit/src/main/kotlin/org/secretary/browse/UniffiVaultCreatePort.kt
@@ -1,0 +1,59 @@
+package org.secretary.browse
+
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import uniffi.secretary.VaultException
+import uniffi.secretary.createVaultInFolder
+
+/**
+ * The real [VaultCreatePort] over the generated `uniffi.secretary.createVaultInFolder` call. Kotlin
+ * mirror of iOS `UniffiVaultCreatePort`.
+ *
+ * [createInFolder] re-derives the vault key with Argon2id, so it runs on [ioDispatcher]
+ * (default [Dispatchers.IO]) to keep the caller responsive. The path is UTF-8 encoded and the
+ * password [ByteArray] is forwarded per call; neither is retained. The returned phrase is
+ * caller-owned (caller zeroizes after the user acknowledges it).
+ *
+ * [createFn] is the injectable FFI seam: it returns the one-shot recovery-phrase bytes (or null).
+ * Its default invokes the real binding inside `.use { … }` so the native [uniffi.secretary.MnemonicOutput]
+ * handle is always released. [clockMs] supplies `created_at_ms` (injected for deterministic tests).
+ */
+class UniffiVaultCreatePort(
+    private val ioDispatcher: CoroutineDispatcher = Dispatchers.IO,
+    private val clockMs: () -> Long = System::currentTimeMillis,
+    private val createFn: (ByteArray, ByteArray, String, ULong) -> ByteArray? =
+        { folderPath, password, displayName, createdAtMs ->
+            createVaultInFolder(folderPath, password, displayName, createdAtMs).use { it.takePhrase() }
+        },
+) : VaultCreatePort {
+    override suspend fun createInFolder(
+        folderPath: String,
+        password: ByteArray,
+        displayName: String,
+    ): CreatedVault =
+        withContext(ioDispatcher) {
+            val phrase = mapProvisioningErrors {
+                createFn(folderPath.toByteArray(Charsets.UTF_8), password, displayName, clockMs().toULong())
+            } ?: throw VaultProvisioningError.CreateFailed("recovery phrase unavailable")
+            CreatedVault(phrase)
+        }
+}
+
+/** Run an FFI call, translating any [VaultException] into the domain [VaultProvisioningError]. */
+internal inline fun <T> mapProvisioningErrors(block: () -> T): T =
+    try {
+        block()
+    } catch (e: VaultException) {
+        throw mapVaultProvisioningError(e)
+    }
+
+/** Map a create-surface [VaultException] to the typed [VaultProvisioningError]. */
+internal fun mapVaultProvisioningError(e: VaultException): VaultProvisioningError =
+    when (e) {
+        is VaultException.VaultFolderNotEmpty -> VaultProvisioningError.FolderNotEmpty
+        else -> VaultProvisioningError.CreateFailed(e.message ?: (e::class.simpleName ?: "create failed"))
+    }
+
+/** Production factory for the real create port (live binding + IO dispatcher). */
+fun uniffiVaultCreatePort(): VaultCreatePort = UniffiVaultCreatePort()

--- a/android/kit/src/test/kotlin/org/secretary/browse/UniffiVaultCreatePortTest.kt
+++ b/android/kit/src/test/kotlin/org/secretary/browse/UniffiVaultCreatePortTest.kt
@@ -2,7 +2,6 @@ package org.secretary.browse
 
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Assertions.assertEquals
-import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import uniffi.secretary.VaultException
@@ -39,37 +38,47 @@ class UniffiVaultCreatePortTest {
 
     @Test
     fun `null phrase maps to CreateFailed`() = runTest {
+        // NOTE: mirrors UniffiVaultSyncPortTest error-path idiom — await inside runTest (which
+        // drains the test scheduler) rather than nesting runBlocking inside a separate event loop.
         val port = UniffiVaultCreatePort(createFn = { _, _, _, _ -> null })
-        val e = assertThrows(VaultProvisioningError.CreateFailed::class.java) {
-            kotlinx.coroutines.runBlocking {
-                port.createInFolder("/tmp/v", "pw".toByteArray(Charsets.UTF_8), "Bob")
-            }
+        val thrown = try {
+            port.createInFolder("/tmp/v", "pw".toByteArray(Charsets.UTF_8), "Bob")
+            null
+        } catch (e: VaultProvisioningError.CreateFailed) {
+            e
         }
-        assertTrue(e.detail.contains("recovery phrase"))
+        assertTrue(thrown is VaultProvisioningError.CreateFailed)
+        assertTrue((thrown as VaultProvisioningError.CreateFailed).detail.contains("recovery phrase"))
     }
 
     @Test
     fun `VaultFolderNotEmpty maps to FolderNotEmpty`() = runTest {
+        // NOTE: mirrors UniffiVaultSyncPortTest error-path idiom — see null-phrase test above.
         val port = UniffiVaultCreatePort(
             createFn = { _, _, _, _ -> throw VaultException.VaultFolderNotEmpty() },
         )
-        assertThrows(VaultProvisioningError.FolderNotEmpty::class.java) {
-            kotlinx.coroutines.runBlocking {
-                port.createInFolder("/tmp/v", "pw".toByteArray(Charsets.UTF_8), "Bob")
-            }
+        val thrown = try {
+            port.createInFolder("/tmp/v", "pw".toByteArray(Charsets.UTF_8), "Bob")
+            null
+        } catch (e: VaultProvisioningError.FolderNotEmpty) {
+            e
         }
+        assertTrue(thrown is VaultProvisioningError.FolderNotEmpty)
     }
 
     @Test
     fun `other VaultException maps to CreateFailed`() = runTest {
+        // NOTE: mirrors UniffiVaultSyncPortTest error-path idiom — see null-phrase test above.
         val port = UniffiVaultCreatePort(
             createFn = { _, _, _, _ -> throw VaultException.CorruptVault("bad bytes") },
         )
-        val e = assertThrows(VaultProvisioningError.CreateFailed::class.java) {
-            kotlinx.coroutines.runBlocking {
-                port.createInFolder("/tmp/v", "pw".toByteArray(Charsets.UTF_8), "Bob")
-            }
+        val thrown = try {
+            port.createInFolder("/tmp/v", "pw".toByteArray(Charsets.UTF_8), "Bob")
+            null
+        } catch (e: VaultProvisioningError.CreateFailed) {
+            e
         }
-        assertTrue(e.detail.isNotBlank())
+        assertTrue(thrown is VaultProvisioningError.CreateFailed)
+        assertTrue((thrown as VaultProvisioningError.CreateFailed).detail.isNotBlank())
     }
 }

--- a/android/kit/src/test/kotlin/org/secretary/browse/UniffiVaultCreatePortTest.kt
+++ b/android/kit/src/test/kotlin/org/secretary/browse/UniffiVaultCreatePortTest.kt
@@ -1,0 +1,75 @@
+package org.secretary.browse
+
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import uniffi.secretary.VaultException
+
+class UniffiVaultCreatePortTest {
+    @Test
+    fun `returns the phrase from a successful create`() = runTest {
+        val port = UniffiVaultCreatePort(
+            createFn = { _, _, _, _ -> "abandon ability".toByteArray(Charsets.UTF_8) },
+        )
+        val created = port.createInFolder("/tmp/vault", "pw".toByteArray(Charsets.UTF_8), "Bob")
+        assertTrue("abandon ability".toByteArray(Charsets.UTF_8).contentEquals(created.phrase))
+    }
+
+    @Test
+    fun `forwards utf8 path, password, display name and clock to createFn`() = runTest {
+        var seenPath: ByteArray? = null
+        var seenPw: ByteArray? = null
+        var seenName: String? = null
+        var seenClock: ULong? = null
+        val port = UniffiVaultCreatePort(
+            clockMs = { 1_700_000_000_000L },
+            createFn = { fp, pw, dn, ts ->
+                seenPath = fp; seenPw = pw; seenName = dn; seenClock = ts
+                "x".toByteArray(Charsets.UTF_8)
+            },
+        )
+        port.createInFolder("/tmp/v", byteArrayOf(1, 2, 3), "Alice")
+        assertTrue("/tmp/v".toByteArray(Charsets.UTF_8).contentEquals(seenPath!!))
+        assertTrue(byteArrayOf(1, 2, 3).contentEquals(seenPw!!))
+        assertEquals("Alice", seenName)
+        assertEquals(1_700_000_000_000UL, seenClock)
+    }
+
+    @Test
+    fun `null phrase maps to CreateFailed`() = runTest {
+        val port = UniffiVaultCreatePort(createFn = { _, _, _, _ -> null })
+        val e = assertThrows(VaultProvisioningError.CreateFailed::class.java) {
+            kotlinx.coroutines.runBlocking {
+                port.createInFolder("/tmp/v", "pw".toByteArray(Charsets.UTF_8), "Bob")
+            }
+        }
+        assertTrue(e.detail.contains("recovery phrase"))
+    }
+
+    @Test
+    fun `VaultFolderNotEmpty maps to FolderNotEmpty`() = runTest {
+        val port = UniffiVaultCreatePort(
+            createFn = { _, _, _, _ -> throw VaultException.VaultFolderNotEmpty() },
+        )
+        assertThrows(VaultProvisioningError.FolderNotEmpty::class.java) {
+            kotlinx.coroutines.runBlocking {
+                port.createInFolder("/tmp/v", "pw".toByteArray(Charsets.UTF_8), "Bob")
+            }
+        }
+    }
+
+    @Test
+    fun `other VaultException maps to CreateFailed`() = runTest {
+        val port = UniffiVaultCreatePort(
+            createFn = { _, _, _, _ -> throw VaultException.CorruptVault("bad bytes") },
+        )
+        val e = assertThrows(VaultProvisioningError.CreateFailed::class.java) {
+            kotlinx.coroutines.runBlocking {
+                port.createInFolder("/tmp/v", "pw".toByteArray(Charsets.UTF_8), "Bob")
+            }
+        }
+        assertTrue(e.detail.isNotBlank())
+    }
+}

--- a/android/vault-access/src/main/kotlin/org/secretary/browse/VaultCreatePort.kt
+++ b/android/vault-access/src/main/kotlin/org/secretary/browse/VaultCreatePort.kt
@@ -1,0 +1,22 @@
+package org.secretary.browse
+
+/**
+ * The product of a successful create: the one-shot 24-word recovery phrase as UTF-8 bytes.
+ * The caller owns zeroizing [phrase] once it has been shown to and acknowledged by the user
+ * (mirrors iOS `CreatedVault`). Plain class (not `data class`) so the secret bytes are never
+ * structurally compared, copied, or logged via a generated `toString`/`equals`.
+ */
+class CreatedVault(val phrase: ByteArray)
+
+/**
+ * Creates a brand-new v1 vault in an existing, empty real-filesystem folder, returning the
+ * recovery phrase. The pure seam mirrors iOS `VaultCreatePort`; the real impl (`:kit`
+ * `UniffiVaultCreatePort`) runs Argon2id off the main thread. [password] is forwarded per call
+ * and never retained.
+ *
+ * [folderPath] is a real POSIX path (UTF-8) to an existing empty directory — the caller is
+ * responsible for creating it. A non-empty folder surfaces [VaultProvisioningError.FolderNotEmpty].
+ */
+interface VaultCreatePort {
+    suspend fun createInFolder(folderPath: String, password: ByteArray, displayName: String): CreatedVault
+}

--- a/android/vault-access/src/main/kotlin/org/secretary/browse/VaultCreatePort.kt
+++ b/android/vault-access/src/main/kotlin/org/secretary/browse/VaultCreatePort.kt
@@ -16,6 +16,8 @@ class CreatedVault(val phrase: ByteArray)
  *
  * [folderPath] is a real POSIX path (UTF-8) to an existing empty directory — the caller is
  * responsible for creating it. A non-empty folder surfaces [VaultProvisioningError.FolderNotEmpty].
+ * A missing or non-directory [folderPath] is implementation-defined and surfaces as
+ * [VaultProvisioningError.CreateFailed].
  */
 interface VaultCreatePort {
     suspend fun createInFolder(folderPath: String, password: ByteArray, displayName: String): CreatedVault

--- a/android/vault-access/src/main/kotlin/org/secretary/browse/VaultProvisioningError.kt
+++ b/android/vault-access/src/main/kotlin/org/secretary/browse/VaultProvisioningError.kt
@@ -1,0 +1,15 @@
+package org.secretary.browse
+
+/**
+ * Typed failures from the create-vault surface. Throwable (mirrors [VaultBrowseError] /
+ * [org.secretary.sync.VaultSyncError]) so the provisioning coordinator can `catch (e: VaultProvisioningError)`.
+ * Kotlin mirror of iOS `VaultProvisioningError`. Only the arms slice 1 can produce are defined here;
+ * later slices (SAF mkdir, password pre-check) add `FolderInvalid` / `PasswordMismatch`.
+ */
+sealed class VaultProvisioningError(message: String? = null) : Exception(message) {
+    /** The target folder already exists and is non-empty (FFI `VaultFolderNotEmpty`). */
+    data object FolderNotEmpty : VaultProvisioningError()
+
+    /** Any other create failure, with a diagnostic detail (the mapper's else-fold). */
+    data class CreateFailed(val detail: String) : VaultProvisioningError(detail)
+}

--- a/android/vault-access/src/test/kotlin/org/secretary/browse/CreatedVaultTest.kt
+++ b/android/vault-access/src/test/kotlin/org/secretary/browse/CreatedVaultTest.kt
@@ -1,0 +1,23 @@
+package org.secretary.browse
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class CreatedVaultTest {
+    @Test
+    fun `CreatedVault exposes the phrase bytes verbatim`() {
+        val phrase = "ripple ozone".toByteArray(Charsets.UTF_8)
+        val created = CreatedVault(phrase)
+        assertTrue(phrase.contentEquals(created.phrase))
+    }
+
+    @Test
+    fun `provisioning error arms are distinct and carry detail`() {
+        val notEmpty: VaultProvisioningError = VaultProvisioningError.FolderNotEmpty
+        val failed: VaultProvisioningError = VaultProvisioningError.CreateFailed("boom")
+        assertEquals("boom", (failed as VaultProvisioningError.CreateFailed).detail)
+        assertTrue(notEmpty is VaultProvisioningError.FolderNotEmpty)
+        assertTrue(notEmpty !== failed)
+    }
+}

--- a/android/vault-access/src/test/kotlin/org/secretary/browse/CreatedVaultTest.kt
+++ b/android/vault-access/src/test/kotlin/org/secretary/browse/CreatedVaultTest.kt
@@ -1,6 +1,7 @@
 package org.secretary.browse
 
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertSame
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 
@@ -10,6 +11,7 @@ class CreatedVaultTest {
         val phrase = "ripple ozone".toByteArray(Charsets.UTF_8)
         val created = CreatedVault(phrase)
         assertTrue(phrase.contentEquals(created.phrase))
+        assertSame(phrase, created.phrase)
     }
 
     @Test

--- a/docs/handoffs/2026-06-27-android-cloud-drive-slice1-vault-create-port-shipped.md
+++ b/docs/handoffs/2026-06-27-android-cloud-drive-slice1-vault-create-port-shipped.md
@@ -1,0 +1,86 @@
+# NEXT_SESSION.md — Android cloud-drive provisioning, Slice 1 (VaultCreatePort) ✅ SHIPPED (PR opening)
+
+**Session date:** 2026-06-27. Began with a "take stock" of what's left for usable private iOS + Android apps (both are already functional walking skeletons with full CRUD + unlock + sync; the FFI write surface is complete). Agreed roadmap order: **(1) Android vault provisioning → (2) verify Android biometric on a physical phone → (3) iOS device-unlock routing + trash/restore polish.** Started item (1). Executed in project-local worktree `.worktrees/android-cloud-drive`, branch `feature/android-cloud-drive-provisioning` (cut from `main` @ `4e2f993d`).
+
+**Status:** ✅ **SHIPPED Slice 1 of 6 — branch `feature/android-cloud-drive-provisioning`, PR opening.** Kotlin/Android only. **No core `src/` change, no FFI surface change (wraps the already-bound `createVaultInFolder`), no on-disk-format / spec / `conformance.py` / KAT change.**
+
+## (1) What we shipped this session
+
+**Context — the epic.** Android can currently only open the bundled `golden_vault_001` demo; there is no folder picker and no create-vault flow. The user wants the vault to live in a **cloud-drive folder** (Drive/Dropbox/OneDrive) synced across iOS + Android + desktop. The hard constraint: the Rust core does direct POSIX I/O (`std::fs` + `tempfile::persist`) with **no storage-abstraction seam**, but Android cloud-drive apps expose folders only via SAF `content://` (no real path). The approved design is a **SAF working-copy shim** — operate on an app-private POSIX working copy, mirror to/from the SAF folder, with a **push-before-pull** invariant so the existing sync engine + the cloud provider's conflict-copy mechanism do all merging (no merge logic in Kotlin).
+
+- **Design spec:** [`docs/superpowers/specs/2026-06-27-android-cloud-drive-provisioning-design.md`](../superpowers/specs/2026-06-27-android-cloud-drive-provisioning-design.md) — full architecture, the 6-slice plan, foreclosed alternatives (FUSE/lazy-fetch rejected — no VFS seam), error handling, testing.
+- **Slice-1 plan:** [`docs/superpowers/plans/2026-06-27-android-cloud-drive-slice1-vault-create-port.md`](../superpowers/plans/2026-06-27-android-cloud-drive-slice1-vault-create-port.md).
+
+**Slice 1 (this PR) — the `VaultCreatePort`.** The smallest reviewable increment: the ability to *create* a vault from Kotlin (unblocks the create wizard in slice 4). Mirrors the existing `VaultOpenPort` / `UniffiVaultOpenPort` split exactly.
+
+- **Pure contract (`:vault-access`, package `org.secretary.browse`):**
+  - `interface VaultCreatePort { suspend fun createInFolder(folderPath: String, password: ByteArray, displayName: String): CreatedVault }` — takes a real POSIX path, like `VaultOpenPort.openWithPassword`. Slice 5's working-copy lifecycle will pass the app-private working subdir to the same call; the SAF mirror sits *above* this port (no rework).
+  - `class CreatedVault(val phrase: ByteArray)` — **plain class, not `data class`** (no generated `toString`/`equals`/`copy` over the secret phrase bytes; caller owns zeroizing).
+  - `sealed class VaultProvisioningError` with **only** `FolderNotEmpty` + `CreateFailed(detail)` (YAGNI — `FolderInvalid`/`PasswordMismatch` belong to the SAF-mkdir and wizard slices).
+- **Real adapter (`:kit`):** `UniffiVaultCreatePort` — wraps `uniffi.secretary.createVaultInFolder`, runs Argon2id on `ioDispatcher` via `withContext`, releases the native `MnemonicOutput` handle via `.use { it.takePhrase() }`. Injectable `createFn` seam (returns `ByteArray?`) makes the success/error/clock logic host-testable without the `.so`. Error mapping: `VaultFolderNotEmpty → FolderNotEmpty`, else → `CreateFailed`; null phrase → `CreateFailed("recovery phrase unavailable")` — byte-identical to the iOS `mapProvisioningError` contract.
+
+**TDD throughout (subagent-driven: implementer → spec+quality review per task → whole-branch review).**
+- Host: `CreatedVaultTest` (2), `UniffiVaultCreatePortTest` (5: happy path, arg+clock forwarding, null→CreateFailed, VaultFolderNotEmpty→FolderNotEmpty, other→CreateFailed).
+- Instrumented (real `.so` on emulator-5554 / API 36): create→open round-trip asserts 24-word phrase + `blockSummaries().size == 0` (a fresh vault has empty `blocks` — confirmed `orchestrators.rs:294`); non-empty folder → `FolderNotEmpty`.
+
+**Reviews.** Per-task reviews clean (spec ✅ + quality approved). Whole-branch review (opus): **Ready to merge: Yes**, no Critical/Important; independently re-ran host tests green. Six Minor carry-overs: **five fixed** in-branch (one commit each) — `assertSame` no-copy proof, KDoc path-behavior note, dropped nested `runBlocking` to match the sibling sync-test idiom, KDoc link reflow, atomic `Files.createTempDirectory` (removes a `freshDir` delete→mkdir TOCTOU). **One intentionally skipped:** zeroizing the *test* password `ByteArray` — the literal is interned in the class constant pool, so zeroizing the copy is theater with no production relevance ([[feedback_security_no_assumptions]] — the deferral is proven, not assumed). Fix diff re-reviewed: approved, negative tests cannot silently pass (null-sentinel + `assertTrue` fails on no-throw).
+
+**Branch commits** (off `main` @ `4e2f993d`):
+| SHA | What |
+|---|---|
+| `1fa27ccc` | docs: design spec (SAF working-copy shim, push-before-pull) |
+| `4f96a700` | docs: slice-1 plan |
+| `af42882e` | feat: pure `VaultCreatePort` + `CreatedVault` + `VaultProvisioningError` (`:vault-access`) |
+| `25bdb6a9` | feat: `UniffiVaultCreatePort` adapter + error mapping (`:kit`) |
+| `a3ff9f6f` | test: instrumented create→open round-trip |
+| `615e5452`..`94bc966c` | 5 carry-over Minor fixes (one per commit) |
+| (+ handoff commit) | this baton + retargeted `NEXT_SESSION.md` symlink |
+
+### Acceptance (verified this session, in the worktree)
+```bash
+cd /Users/hherb/src/secretary/.worktrees/android-cloud-drive/android
+./gradlew :vault-access:test :kit:testDebugUnitTest          # BUILD SUCCESSFUL — host 2+5 green
+export ANDROID_SDK_ROOT=/Users/hherb/Library/Android/sdk ANDROID_HOME=/Users/hherb/Library/Android/sdk
+./gradlew :kit:connectedDebugAndroidTest \
+  -Pandroid.testInstrumentationRunnerArguments.class=org.secretary.browse.UniffiVaultCreatePortInstrumentedTest  # 2/2 on emulator-5554
+```
+(`connectedAndroidTest` rejects `--tests`; use the `-P…class=` filter — project Android gotcha.)
+
+## (2) What's next
+**Slice 1 is done (PR open). Continue the epic with Slice 2.** Each slice is its own plan + PR through the review loop. Remaining slices (from the design spec):
+2. `VaultLocationStore` + `SafVaultLocationStore` (persist the SAF tree URI + `takePersistableUriPermission`; mirror iOS `BookmarkVaultLocationStore`).
+3. `CloudFolderPort` + pure `VaultMirrorPlanner` + `VaultMirror` (the SAF↔working-copy mirror; **block-first** flush ordering).
+4. Provisioning view models + `VaultSelectionScreen` / `CreateVaultWizardScreen` + `AppRoot` routing (keep the demo entry).
+5. Working-copy lifecycle: materialize → `sync_once` → operate → **flush-after-every-commit** + pending-flush retry (push-before-pull).
+6. Instrumented E2E + offline-flush + conflict-copy-ingest tests (two working copies over one SAF tree, mirroring `cli/tests/two_instance_convergence.rs`).
+
+**Also still on the top-level roadmap (after the epic, or in parallel):** verify Android biometric/Keystore on a **physical** phone (only iPhone has the on-device proof today); iOS device-unlock routing decision + trash/restore UI on both platforms.
+
+**Acceptance template:** TDD (RED proven), typed-error surface proven not assumed on security paths, host + instrumented gate green, pure logic in `:vault-access` / FFI+Android in `:kit`, no merge logic in Kotlin (the core owns CRDT).
+
+**File a tracking epic issue** when starting Slice 2 (none exists yet — confirmed no open Android-provisioning issue).
+
+## (3) Open decisions and risks
+- **Storage model (resolved by user):** all-cloud-drive on every device → Android needs the SAF working-copy shim (chosen over real-folder/Syncthing and over "app-private now"). Slices 2–6 build it. Syncthing avoids the shim but the user wants native cloud-drive; the design keeps a real-folder `CloudFolderPort` impl possible as a later additive option.
+- **Slice-1 seam is forward-compatible:** taking `folderPath: String` (a real path) means the shim sits *above* this port; the create call is unchanged when slice 5 hands it the working-copy subdir.
+- **Risk:** low. Slice 1 adds two new Kotlin files + tests, wraps an already-shipped FFI, changes no core/FFI/format. No observable byte/semantics change.
+- **Generated-binding ktlint noise** (`Unable to auto-format secretary.kt`) is on the **uniffi-generated** file, pre-existing, not this slice's code.
+
+## (4) Exact commands to resume
+```bash
+cd /Users/hherb/src/secretary
+git fetch --prune origin && git checkout main && git pull --ff-only origin main
+# If this PR merged, remove the worktree + branch:
+#   git worktree remove .worktrees/android-cloud-drive && git branch -D feature/android-cloud-drive-provisioning
+git worktree list && git status -s
+# Start Slice 2 from the design spec's component table; brainstorm → plan → subagent-driven execute.
+```
+
+## (5) Handoff file model
+`NEXT_SESSION.md` is a **relative symlink** to this file in `docs/handoffs/`. Authored once here; symlink retargeted in the same commit on the feature branch (new path → no add/add conflict; `main` updates cleanly on merge). Per [[feedback_next_session_in_pr]] / [[feedback_next_session_main_authoritative]] the baton rides inside the PR — do **not** sync to `main` during the pause window.
+
+## Closing inventory
+- **State on close:** PR opening on `feature/android-cloud-drive-provisioning` (10 commits: 2 docs + 3 feat/test + 5 fixes + handoff). Worktree `.worktrees/android-cloud-drive`.
+- **Acceptance:** host `:vault-access:test` + `:kit:testDebugUnitTest` green; instrumented `:kit:connectedDebugAndroidTest` 2/2 on emulator-5554; whole-branch review approved; carry-over fixes re-reviewed clean.
+- **README.md / ROADMAP.md / CLAUDE.md:** unchanged (slice 1 of an in-flight epic; no new product capability or documented command yet — per [[feedback_readme_style]]).
+- **NEXT_SESSION.md:** symlink → `docs/handoffs/2026-06-27-android-cloud-drive-slice1-vault-create-port-shipped.md`.

--- a/docs/superpowers/plans/2026-06-27-android-cloud-drive-slice1-vault-create-port.md
+++ b/docs/superpowers/plans/2026-06-27-android-cloud-drive-slice1-vault-create-port.md
@@ -1,0 +1,467 @@
+# Android Cloud-Drive Provisioning — Slice 1: VaultCreatePort Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a Kotlin `VaultCreatePort` (pure seam in `:vault-access`) and its real `UniffiVaultCreatePort` adapter (in `:kit`) that creates a complete v1 vault in a real filesystem folder via the already-bound `createVaultInFolder` FFI and returns the one-shot 24-word recovery phrase.
+
+**Architecture:** Mirror the existing `VaultOpenPort` / `UniffiVaultOpenPort` split — a pure interface + value types in `:vault-access` (host-tested, no Android/FFI), and a real adapter in `:kit` that runs the FFI (Argon2id) off the main thread on `Dispatchers.IO`. The adapter takes an injectable `createFn` seam so the success/error/clock logic is host-testable without the native library; an instrumented test proves the real binding end-to-end.
+
+**Tech Stack:** Kotlin, kotlinx-coroutines, uniffi-generated `uniffi.secretary` bindings, JUnit 5 (host, `:vault-access` + `:kit` unit tests), AndroidX test (instrumented `:kit` androidTest).
+
+**Scope note:** This is slice 1 of 6 in the epic specified at
+`docs/superpowers/specs/2026-06-27-android-cloud-drive-provisioning-design.md`.
+It deliberately does NOT touch SAF, the location store, the working-copy mirror,
+the provisioning UI, or app routing — those are slices 2–6 and will each get
+their own plan. This slice's `VaultCreatePort.createInFolder` takes a real POSIX
+folder path (exactly like `VaultOpenPort.openWithPassword(vaultFolder: String, …)`);
+later slices pass it the app-private working-copy subdir.
+
+## Global Constraints
+
+- **Module split discipline:** pure interfaces + value types live in `:vault-access`; all FFI/Android I/O lives in `:kit`. (Mirrors `VaultOpenPort` in `:vault-access` vs `UniffiVaultOpenPort` in `:kit`.)
+- **Mirror iOS naming** where an analogue exists: iOS `VaultCreatePort` / `CreatedVault` / `VaultProvisioningError` (`ios/SecretaryVaultAccess/Sources/SecretaryVaultAccess/VaultProvisioning.swift`).
+- **Off-main-thread crypto:** `createInFolder` re-derives the vault key with Argon2id, so the real adapter MUST run it on `ioDispatcher` (default `Dispatchers.IO`), like `UniffiVaultOpenPort`.
+- **Secrets are not retained:** the port forwards `password` per call and never stores it; the returned phrase is caller-owned and the caller owns zeroizing it (document this in KDoc, matching the iOS `CreatedVault` contract).
+- **Exact FFI names (verified against the UDL):** the binding function is `uniffi.secretary.createVaultInFolder(folderPath: ByteArray, password: ByteArray, displayName: String, createdAtMs: ULong): MnemonicOutput`; `MnemonicOutput.takePhrase(): ByteArray?` is ONE-SHOT (second call returns null); `MnemonicOutput` is `AutoCloseable` (use `.use { … }`). The non-empty-folder error is `uniffi.secretary.VaultException.VaultFolderNotEmpty`.
+- **Lint/format clean, tests green** before each commit. Kotlin files stay focused; split toward a directory module before any file approaches ~500 lines (none here will).
+- **Commit per task** with a conventional-commit message.
+
+**Test commands** (run from the `android/` Gradle root):
+
+```bash
+cd /Users/hherb/src/secretary/.worktrees/android-cloud-drive/android
+./gradlew :vault-access:test            # host JVM unit tests (Task 1)
+./gradlew :kit:testDebugUnitTest        # host JVM unit tests (Task 2)
+./gradlew :kit:connectedDebugAndroidTest  # instrumented, needs a running emulator (Task 3)
+```
+
+Emulator/adb are not on the bare PATH on this machine — start an emulator with the
+absolute SDK paths before Task 3 (see the Android-toolchain notes); Tasks 1–2 need
+no device.
+
+---
+
+### Task 1: Pure provisioning contract in `:vault-access`
+
+**Files:**
+- Create: `android/vault-access/src/main/kotlin/org/secretary/browse/VaultCreatePort.kt`
+- Create: `android/vault-access/src/main/kotlin/org/secretary/browse/VaultProvisioningError.kt`
+- Test: `android/vault-access/src/test/kotlin/org/secretary/browse/CreatedVaultTest.kt`
+
+**Interfaces:**
+- Consumes: nothing (leaf types).
+- Produces:
+  - `class CreatedVault(val phrase: ByteArray)` — product of a successful create; `phrase` is the UTF-8 recovery-phrase bytes, caller-owned.
+  - `sealed class VaultProvisioningError(message: String?) : Exception(message)` with arms `data object FolderNotEmpty` and `data class CreateFailed(val detail: String)`.
+  - `interface VaultCreatePort { suspend fun createInFolder(folderPath: String, password: ByteArray, displayName: String): CreatedVault }`.
+
+- [ ] **Step 1: Write the failing test**
+
+```kotlin
+// android/vault-access/src/test/kotlin/org/secretary/browse/CreatedVaultTest.kt
+package org.secretary.browse
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class CreatedVaultTest {
+    @Test
+    fun `CreatedVault exposes the phrase bytes verbatim`() {
+        val phrase = "ripple ozone".toByteArray(Charsets.UTF_8)
+        val created = CreatedVault(phrase)
+        assertTrue(phrase.contentEquals(created.phrase))
+    }
+
+    @Test
+    fun `provisioning error arms are distinct and carry detail`() {
+        val notEmpty: VaultProvisioningError = VaultProvisioningError.FolderNotEmpty
+        val failed: VaultProvisioningError = VaultProvisioningError.CreateFailed("boom")
+        assertEquals("boom", (failed as VaultProvisioningError.CreateFailed).detail)
+        assertTrue(notEmpty is VaultProvisioningError.FolderNotEmpty)
+        assertTrue(notEmpty !== failed)
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd /Users/hherb/src/secretary/.worktrees/android-cloud-drive/android && ./gradlew :vault-access:test`
+Expected: FAIL — compilation error, `CreatedVault` / `VaultProvisioningError` unresolved.
+
+- [ ] **Step 3: Write the value types and the port interface**
+
+```kotlin
+// android/vault-access/src/main/kotlin/org/secretary/browse/VaultProvisioningError.kt
+package org.secretary.browse
+
+/**
+ * Typed failures from the create-vault surface. Throwable (mirrors [VaultBrowseError] /
+ * [org.secretary.sync.VaultSyncError]) so the provisioning coordinator can `catch (e: VaultProvisioningError)`.
+ * Kotlin mirror of iOS `VaultProvisioningError`. Only the arms slice 1 can produce are defined here;
+ * later slices (SAF mkdir, password pre-check) add `FolderInvalid` / `PasswordMismatch`.
+ */
+sealed class VaultProvisioningError(message: String? = null) : Exception(message) {
+    /** The target folder already exists and is non-empty (FFI `VaultFolderNotEmpty`). */
+    data object FolderNotEmpty : VaultProvisioningError()
+
+    /** Any other create failure, with a diagnostic detail (the mapper's else-fold). */
+    data class CreateFailed(val detail: String) : VaultProvisioningError(detail)
+}
+```
+
+```kotlin
+// android/vault-access/src/main/kotlin/org/secretary/browse/VaultCreatePort.kt
+package org.secretary.browse
+
+/**
+ * The product of a successful create: the one-shot 24-word recovery phrase as UTF-8 bytes.
+ * The caller owns zeroizing [phrase] once it has been shown to and acknowledged by the user
+ * (mirrors iOS `CreatedVault`). Plain class (not `data class`) so the secret bytes are never
+ * structurally compared, copied, or logged via a generated `toString`/`equals`.
+ */
+class CreatedVault(val phrase: ByteArray)
+
+/**
+ * Creates a brand-new v1 vault in an existing, empty real-filesystem folder, returning the
+ * recovery phrase. The pure seam mirrors iOS `VaultCreatePort`; the real impl (`:kit`
+ * `UniffiVaultCreatePort`) runs Argon2id off the main thread. [password] is forwarded per call
+ * and never retained.
+ *
+ * [folderPath] is a real POSIX path (UTF-8) to an existing empty directory — the caller is
+ * responsible for creating it. A non-empty folder surfaces [VaultProvisioningError.FolderNotEmpty].
+ */
+interface VaultCreatePort {
+    suspend fun createInFolder(folderPath: String, password: ByteArray, displayName: String): CreatedVault
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd /Users/hherb/src/secretary/.worktrees/android-cloud-drive/android && ./gradlew :vault-access:test`
+Expected: PASS (both tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /Users/hherb/src/secretary/.worktrees/android-cloud-drive
+git add android/vault-access/src/main/kotlin/org/secretary/browse/VaultCreatePort.kt \
+        android/vault-access/src/main/kotlin/org/secretary/browse/VaultProvisioningError.kt \
+        android/vault-access/src/test/kotlin/org/secretary/browse/CreatedVaultTest.kt
+git commit -m "feat(android): pure VaultCreatePort seam + CreatedVault/VaultProvisioningError"
+```
+
+---
+
+### Task 2: `UniffiVaultCreatePort` real adapter + error mapping in `:kit`
+
+**Files:**
+- Create: `android/kit/src/main/kotlin/org/secretary/browse/UniffiVaultCreatePort.kt`
+- Test: `android/kit/src/test/kotlin/org/secretary/browse/UniffiVaultCreatePortTest.kt`
+
+**Interfaces:**
+- Consumes: `VaultCreatePort`, `CreatedVault`, `VaultProvisioningError` (Task 1); `uniffi.secretary.createVaultInFolder`, `uniffi.secretary.VaultException`, `uniffi.secretary.MnemonicOutput`.
+- Produces:
+  - `class UniffiVaultCreatePort(ioDispatcher: CoroutineDispatcher = Dispatchers.IO, clockMs: () -> Long = System::currentTimeMillis, createFn: (ByteArray, ByteArray, String, ULong) -> ByteArray? = …) : VaultCreatePort` — the injectable `createFn` returns the phrase bytes (or null); its default calls the real FFI inside `.use { it.takePhrase() }`.
+  - `fun uniffiVaultCreatePort(): VaultCreatePort` — production factory.
+  - `internal fun mapVaultProvisioningError(e: VaultException): VaultProvisioningError`.
+
+- [ ] **Step 1: Write the failing test**
+
+```kotlin
+// android/kit/src/test/kotlin/org/secretary/browse/UniffiVaultCreatePortTest.kt
+package org.secretary.browse
+
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import uniffi.secretary.VaultException
+
+class UniffiVaultCreatePortTest {
+    @Test
+    fun `returns the phrase from a successful create`() = runTest {
+        val port = UniffiVaultCreatePort(
+            createFn = { _, _, _, _ -> "abandon ability".toByteArray(Charsets.UTF_8) },
+        )
+        val created = port.createInFolder("/tmp/vault", "pw".toByteArray(Charsets.UTF_8), "Bob")
+        assertTrue("abandon ability".toByteArray(Charsets.UTF_8).contentEquals(created.phrase))
+    }
+
+    @Test
+    fun `forwards utf8 path, password, display name and clock to createFn`() = runTest {
+        var seenPath: ByteArray? = null
+        var seenPw: ByteArray? = null
+        var seenName: String? = null
+        var seenClock: ULong? = null
+        val port = UniffiVaultCreatePort(
+            clockMs = { 1_700_000_000_000L },
+            createFn = { fp, pw, dn, ts ->
+                seenPath = fp; seenPw = pw; seenName = dn; seenClock = ts
+                "x".toByteArray(Charsets.UTF_8)
+            },
+        )
+        port.createInFolder("/tmp/v", byteArrayOf(1, 2, 3), "Alice")
+        assertTrue("/tmp/v".toByteArray(Charsets.UTF_8).contentEquals(seenPath!!))
+        assertTrue(byteArrayOf(1, 2, 3).contentEquals(seenPw!!))
+        assertEquals("Alice", seenName)
+        assertEquals(1_700_000_000_000UL, seenClock)
+    }
+
+    @Test
+    fun `null phrase maps to CreateFailed`() = runTest {
+        val port = UniffiVaultCreatePort(createFn = { _, _, _, _ -> null })
+        val e = assertThrows(VaultProvisioningError.CreateFailed::class.java) {
+            kotlinx.coroutines.runBlocking {
+                port.createInFolder("/tmp/v", "pw".toByteArray(Charsets.UTF_8), "Bob")
+            }
+        }
+        assertTrue(e.detail.contains("recovery phrase"))
+    }
+
+    @Test
+    fun `VaultFolderNotEmpty maps to FolderNotEmpty`() = runTest {
+        val port = UniffiVaultCreatePort(
+            createFn = { _, _, _, _ -> throw VaultException.VaultFolderNotEmpty() },
+        )
+        assertThrows(VaultProvisioningError.FolderNotEmpty::class.java) {
+            kotlinx.coroutines.runBlocking {
+                port.createInFolder("/tmp/v", "pw".toByteArray(Charsets.UTF_8), "Bob")
+            }
+        }
+    }
+
+    @Test
+    fun `other VaultException maps to CreateFailed`() = runTest {
+        val port = UniffiVaultCreatePort(
+            createFn = { _, _, _, _ -> throw VaultException.CorruptVault("bad bytes") },
+        )
+        val e = assertThrows(VaultProvisioningError.CreateFailed::class.java) {
+            kotlinx.coroutines.runBlocking {
+                port.createInFolder("/tmp/v", "pw".toByteArray(Charsets.UTF_8), "Bob")
+            }
+        }
+        assertTrue(e.detail.isNotBlank())
+    }
+}
+```
+
+Note: `VaultException.VaultFolderNotEmpty` is fieldless — the generated constructor is no-arg
+(`VaultException.VaultFolderNotEmpty()`). If codegen requires a message argument, pass `""`.
+`VaultException.CorruptVault(detail)` carries a `string detail` per the UDL.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd /Users/hherb/src/secretary/.worktrees/android-cloud-drive/android && ./gradlew :kit:testDebugUnitTest`
+Expected: FAIL — `UniffiVaultCreatePort` / `VaultProvisioningError` unresolved.
+
+- [ ] **Step 3: Write the adapter + mapper**
+
+```kotlin
+// android/kit/src/main/kotlin/org/secretary/browse/UniffiVaultCreatePort.kt
+package org.secretary.browse
+
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import uniffi.secretary.VaultException
+import uniffi.secretary.createVaultInFolder
+
+/**
+ * The real [VaultCreatePort] over the generated `uniffi.secretary.createVaultInFolder` call. Kotlin
+ * mirror of iOS `UniffiVaultCreatePort`.
+ *
+ * [createInFolder] re-derives the vault key with Argon2id, so it runs on [ioDispatcher]
+ * (default [Dispatchers.IO]) to keep the caller responsive. The path is UTF-8 encoded and the
+ * password [ByteArray] is forwarded per call; neither is retained. The returned phrase is
+ * caller-owned (caller zeroizes after the user acknowledges it).
+ *
+ * [createFn] is the injectable FFI seam: it returns the one-shot recovery-phrase bytes (or null).
+ * Its default invokes the real binding inside `.use { … }` so the native [uniffi.secretary.MnemonicOutput]
+ * handle is always released. [clockMs] supplies `created_at_ms` (injected for deterministic tests).
+ */
+class UniffiVaultCreatePort(
+    private val ioDispatcher: CoroutineDispatcher = Dispatchers.IO,
+    private val clockMs: () -> Long = System::currentTimeMillis,
+    private val createFn: (ByteArray, ByteArray, String, ULong) -> ByteArray? =
+        { folderPath, password, displayName, createdAtMs ->
+            createVaultInFolder(folderPath, password, displayName, createdAtMs).use { it.takePhrase() }
+        },
+) : VaultCreatePort {
+    override suspend fun createInFolder(
+        folderPath: String,
+        password: ByteArray,
+        displayName: String,
+    ): CreatedVault =
+        withContext(ioDispatcher) {
+            val phrase = mapProvisioningErrors {
+                createFn(folderPath.toByteArray(Charsets.UTF_8), password, displayName, clockMs().toULong())
+            } ?: throw VaultProvisioningError.CreateFailed("recovery phrase unavailable")
+            CreatedVault(phrase)
+        }
+}
+
+/** Run an FFI call, translating any [VaultException] into the domain [VaultProvisioningError]. */
+internal inline fun <T> mapProvisioningErrors(block: () -> T): T =
+    try {
+        block()
+    } catch (e: VaultException) {
+        throw mapVaultProvisioningError(e)
+    }
+
+/** Map a create-surface [VaultException] to the typed [VaultProvisioningError]. */
+internal fun mapVaultProvisioningError(e: VaultException): VaultProvisioningError =
+    when (e) {
+        is VaultException.VaultFolderNotEmpty -> VaultProvisioningError.FolderNotEmpty
+        else -> VaultProvisioningError.CreateFailed(e.message ?: (e::class.simpleName ?: "create failed"))
+    }
+
+/** Production factory for the real create port (live binding + IO dispatcher). */
+fun uniffiVaultCreatePort(): VaultCreatePort = UniffiVaultCreatePort()
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd /Users/hherb/src/secretary/.worktrees/android-cloud-drive/android && ./gradlew :kit:testDebugUnitTest`
+Expected: PASS (all five tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /Users/hherb/src/secretary/.worktrees/android-cloud-drive
+git add android/kit/src/main/kotlin/org/secretary/browse/UniffiVaultCreatePort.kt \
+        android/kit/src/test/kotlin/org/secretary/browse/UniffiVaultCreatePortTest.kt
+git commit -m "feat(android): UniffiVaultCreatePort adapter over createVaultInFolder + error mapping"
+```
+
+---
+
+### Task 3: Instrumented real-binding round-trip in `:kit` androidTest
+
+**Files:**
+- Create: `android/kit/src/androidTest/kotlin/org/secretary/browse/UniffiVaultCreatePortInstrumentedTest.kt`
+
+**Interfaces:**
+- Consumes: `uniffiVaultCreatePort()` (Task 2), `uniffiVaultOpenPort()` (existing), the real `.so`.
+- Produces: nothing (verification only).
+
+This is the slice's proof that the real binding works on a device/emulator: create →
+open round-trip (mirrors the Kotlin smoke `Assert 39`) plus the non-empty-folder error
+(`Assert 40`). It needs the native library, so it lives in `androidTest`, like the
+existing `SyncRoundTripInstrumentedTest`.
+
+- [ ] **Step 1: Write the test**
+
+```kotlin
+// android/kit/src/androidTest/kotlin/org/secretary/browse/UniffiVaultCreatePortInstrumentedTest.kt
+package org.secretary.browse
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertThrows
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.io.File
+
+@RunWith(AndroidJUnit4::class)
+class UniffiVaultCreatePortInstrumentedTest {
+
+    private fun freshDir(prefix: String): File =
+        File.createTempFile(prefix, "").let { f ->
+            f.delete()
+            check(f.mkdirs()) { "could not mkdir ${f.path}" }
+            f
+        }
+
+    @Test
+    fun create_then_open_round_trips_with_24_word_phrase() = runBlocking {
+        val dir = freshDir("create-roundtrip-")
+        try {
+            val createPort = uniffiVaultCreatePort()
+            val pw = "create-instr-pw".toByteArray(Charsets.UTF_8)
+            val created = createPort.createInFolder(dir.path, pw, "Instr-Bob")
+            val wordCount = created.phrase.toString(Charsets.UTF_8).split(" ").size
+            assertEquals(24, wordCount)
+
+            // The created vault opens with the same password and reports the display name.
+            val session = uniffiVaultOpenPort().openWithPassword(dir.path, pw)
+            try {
+                // A freshly-created vault has no user blocks yet; opening + listing must not throw.
+                assertEquals(0, session.blockSummaries().size)
+            } finally {
+                session.wipe()
+            }
+        } finally {
+            dir.deleteRecursively()
+        }
+    }
+
+    @Test
+    fun create_in_non_empty_folder_throws_folder_not_empty() {
+        val dir = freshDir("create-nonempty-")
+        try {
+            File(dir, "junk").writeText("x")
+            assertThrows(VaultProvisioningError.FolderNotEmpty::class.java) {
+                runBlocking {
+                    uniffiVaultCreatePort().createInFolder(
+                        dir.path, "pw".toByteArray(Charsets.UTF_8), "Nope",
+                    )
+                }
+            }
+        } finally {
+            dir.deleteRecursively()
+        }
+    }
+}
+```
+
+Note: a brand-new vault has no user-created blocks, so `blockSummaries()` is empty.
+If the manifest is seeded with a default block at creation (check `create.rs` behaviour),
+relax the assertion to `assertTrue(session.blockSummaries().size >= 0)` and instead assert
+the open simply succeeded without throwing — the load-bearing checks are the 24-word phrase
+and that open does not reject the password.
+
+- [ ] **Step 2: Start an emulator, then run the test**
+
+Run (emulator must be booted; use absolute SDK paths if `adb`/`emulator` aren't on PATH):
+```bash
+cd /Users/hherb/src/secretary/.worktrees/android-cloud-drive/android
+./gradlew :kit:connectedDebugAndroidTest --tests "org.secretary.browse.UniffiVaultCreatePortInstrumentedTest"
+```
+Expected: both tests PASS against the real `.so`.
+
+- [ ] **Step 3: Run the host unit tests once more to confirm no regression**
+
+Run: `./gradlew :vault-access:test :kit:testDebugUnitTest`
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd /Users/hherb/src/secretary/.worktrees/android-cloud-drive
+git add android/kit/src/androidTest/kotlin/org/secretary/browse/UniffiVaultCreatePortInstrumentedTest.kt
+git commit -m "test(android): instrumented create→open round-trip for UniffiVaultCreatePort"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage (slice 1 scope only):** The spec's component #1 (`VaultCreatePort` +
+`UniffiVaultCreatePort` wrapping the already-bound `createVaultInFolder`) is implemented
+by Tasks 1–2; the instrumented round-trip (Task 3) covers the spec's "instrumented:
+create→… round-trip" testing requirement for this component. SAF, location store, mirror,
+UI, and routing are explicitly out of slice-1 scope and tracked for slices 2–6.
+
+**Placeholder scan:** No TBD/TODO/"handle errors appropriately". The two `Note:` callouts
+are concrete fallbacks (codegen constructor arity; default-block seeding) with exact
+instructions, not deferred work.
+
+**Type consistency:** `createInFolder(folderPath: String, password: ByteArray, displayName: String): CreatedVault`
+is identical across the interface (Task 1), the adapter (Task 2), and both tests.
+`VaultProvisioningError.FolderNotEmpty` / `.CreateFailed(detail)` are used consistently in
+the mapper and all assertions. `createFn` arity `(ByteArray, ByteArray, String, ULong) -> ByteArray?`
+matches its default lambda and every injected test double. `CreatedVault(val phrase: ByteArray)`
+is constructed and read identically everywhere.

--- a/docs/superpowers/specs/2026-06-27-android-cloud-drive-provisioning-design.md
+++ b/docs/superpowers/specs/2026-06-27-android-cloud-drive-provisioning-design.md
@@ -1,0 +1,206 @@
+# Android cloud-drive vault provisioning + SAF working-copy shim
+
+- **Date:** 2026-06-27
+- **Status:** Approved design (pre-implementation)
+- **Sub-project:** D.4 (Android native app)
+- **Branch:** `feature/android-cloud-drive-provisioning`
+
+## Goal
+
+Make the Android app usable for real personal use: let the user **open their own
+vault** and **create a new vault**, stored in a **cloud-drive folder** (Google
+Drive / Dropbox / OneDrive) so it stays in sync with the iOS and desktop clients.
+Today the Android app can only open the bundled `golden_vault_001` demo staged
+into app-private storage — there is no folder picker and no create-vault flow.
+
+This is the first item in the agreed roadmap order for reaching usable private
+iOS + Android apps. iOS already has the equivalent (file picker + create wizard);
+this brings Android to parity, with one Android-specific complication described
+below.
+
+## The core constraint
+
+The Rust core (`secretary-core`) does direct POSIX filesystem I/O — `std::fs`
+plus atomic `rename(2)` via `tempfile::NamedTempFile::persist`
+(`core/src/vault/io.rs`). **There is no storage-abstraction seam** (no VFS trait,
+no `Read`/`Write` bound) to plug an alternate backend into.
+
+Android cloud-drive apps expose their synced folders **only through the Storage
+Access Framework (SAF)** as `content://` URIs with a stream API — there is no
+real filesystem path behind them. Therefore the core cannot operate on a SAF
+folder directly.
+
+iOS does not hit this: Files-provider folders (iCloud Drive, Dropbox) resolve to
+real file URLs that `std::fs` can use, so the iOS app passes the picked folder's
+path straight to the core. Android needs a shim.
+
+This constraint forecloses the two "clever" alternatives:
+
+- **FUSE / virtual-FS mount over SAF** — Android does not allow unprivileged FUSE
+  for apps. Rejected.
+- **Lazy / on-demand fetch** — would require intercepting the core's individual
+  file reads; there is no trait to hook. Rejected.
+
+The only viable shape is a **full POSIX working copy** in app-private storage that
+the core operates on, mirrored to and from the SAF cloud folder.
+
+## How sync works (confirmed model)
+
+The sync engine requires no new work; the shim reuses it untouched.
+
+- A vault is a **folder of files** (`vault.toml`, `identity.bundle.enc`,
+  `manifest.cbor.enc`, `blocks/<uuid>.cbor.enc`, `contacts/`, `devices/`,
+  `trash/`). On a record edit, only **`manifest.cbor.enc` and the one changed
+  block file** are rewritten; everything else is immutable after creation.
+  (`docs/vault-format.md` §1, §4.4, §6.5, §9.)
+- The deployment model is **one shared vault folder + a per-device `SyncState`
+  file**. An external sync tool (the cloud-drive app) physically copies one
+  device's updated files into every other device's copy of the folder.
+  (`docs/adr/0003-cloud-folder-sync.md`; `cli/tests/two_instance_convergence.rs`
+  uses exactly this topology — two daemons, one shared `vault_dir`, separate
+  `--state-dir`.)
+- `sync_once(vault_folder, identity, state, now_ms)` (`core/src/sync/once.rs`) is
+  a near-pure comparison of the folder's manifest vector clock against the
+  caller-persisted `SyncState`. Equal → `NothingToDo`; incoming dominates →
+  `AppliedAutomatically`; concurrent → ingest authenticated conflict-copy
+  siblings (`manifest.cbor.enc*`) and CRDT-merge; incoming dominated →
+  `RollbackRejected`.
+- **Convergence requires only a file copy** into the shared folder, not a special
+  network protocol. The peer's next `sync_once` reads the new bytes and merges.
+  Record-level merge is field-LWW with a death clock; deletions are sticky
+  (tombstone-on-tie). (`docs/crypto-design.md` §10–11; `core/src/vault/conflict.rs`.)
+
+## Architecture
+
+```
+   SAF cloud folder                 app-private working copy            core (unchanged)
+   content:// tree   ──materialize─▶  /data/.../working/<uuid>/  ──path──▶ open/unlock/
+   (Drive/Dropbox)   ◀──flush───────  (real POSIX path)                   sync_once/save_block
+```
+
+Per session: **materialize** (copy SAF tree → working copy) → **`sync_once`**
+against the working copy (folds in peer changes + any conflict-copy siblings the
+cloud created) → **operate** (existing browse/CRUD, unchanged) → **flush** (copy
+changed files, **block-first**, working copy → SAF) after each commit.
+
+Every interesting invariant stays where it already lives: atomicity (the core's
+`tempfile::persist` into the working copy), CRDT merge (the existing sync engine),
+hybrid verify-before-decrypt (unchanged). The shim is only responsible for *which
+bytes to move, and in what order*.
+
+### The shim's central invariant: push-before-pull
+
+The shim never merges. It guarantees one ordering rule so the existing sync engine
+plus the cloud provider's own conflict-copy mechanism do all merging:
+
+> **Before pulling cloud→working, always flush any pending local edits
+> working→cloud.**
+
+Because we flush after every commit, the working copy is normally clean. If a
+flush failed (offline), the working copy holds un-pushed edits; on the next open
+we retry the push **first**, then pull. If both sides changed while offline, our
+push lands our manifest where a peer manifest already exists → the cloud provider
+creates a `manifest (conflicted copy).cbor.enc` sibling → the next `sync_once`
+against the working copy authenticates and CRDT-merges it. This is exactly the
+desktop path and the `two_instance_convergence` topology, so merge semantics stay
+entirely inside the audited core.
+
+## Components
+
+Following the existing `:vault-access` (pure, host-tested) / `:kit` (real adapters,
+FFI + Android) split.
+
+| # | Component | Module | iOS analogue |
+|---|---|---|---|
+| 1 | `VaultCreatePort` + `UniffiVaultCreatePort` (wraps already-bound `createVaultInFolder`) | port in `:vault-access`, impl in `:kit` | `UniffiVaultCreatePort.swift` |
+| 2 | `VaultLocationStore` + `SafVaultLocationStore` (persist tree URI + display name + vault_uuid; `takePersistableUriPermission`) | port in `:vault-access`, impl in `:kit` | `BookmarkVaultLocationStore.swift` |
+| 3 | `CloudFolderPort` (list / read / write / delete over SAF) + `VaultMirrorPlanner` (**pure** free functions) + `VaultMirror` orchestrator | ports + pure logic in `:vault-access`, SAF impl in `:kit` | *(Android-only; no iOS equivalent)* |
+| 4 | `VaultSelectionViewModel`, `VaultProvisioningViewModel` | `:vault-access` UI | `VaultSelectionViewModel.swift`, `VaultProvisioningViewModel.swift` |
+| 5 | `VaultSelectionScreen`, `CreateVaultWizardScreen`, SAF picker launchers, `AppRoot` routing | `:app` | `VaultSelectionScreen.swift`, `CreateVaultWizardView.swift` |
+| 6 | Working-copy lifecycle (materialize→sync→operate→flush) + flush-after-commit hook in `UniffiVaultSession` + pending-flush retry | `:kit` + `:app` | *(re-points existing sync at the working copy)* |
+
+`VaultMirrorPlanner` is where the non-trivial logic concentrates (which files to
+move, block-first ordering, changed-file detection) and is fully host-testable
+with zero Android dependencies. All SAF specifics live behind `CloudFolderPort`.
+
+Per project convention, design each new file as a focused unit and split toward a
+directory module before any file approaches ~500 lines.
+
+## Settled decisions
+
+| Decision | Choice | Rationale |
+|---|---|---|
+| Storage model | Full POSIX working copy in app-private storage, mirrored to/from SAF | Only viable shape given no VFS seam in the core |
+| Sync transport | Cloud drive (Drive/Dropbox/OneDrive) on every device | User decision; iOS + desktop reach it natively, Android via this shim |
+| Flush granularity | Changed-files-only (manifest + differing blocks), **block-first** | A partial flush leaves cloud with new-block + stale-manifest, which the core already recovers from via fingerprint recheck (`vault-format.md` §9) |
+| Flush trigger | After every commit, off the main thread | Safest against Android process-kill; small in-flight indicator covers SAF latency |
+| Pull trigger | On open + manual "Sync now" + on foreground | SAF gives no reliable change notification and cloud providers do not push |
+| Merge ownership | Entirely in the core; shim only enforces push-before-pull | Keeps CRDT semantics in the audited Rust, not in Kotlin |
+
+## Data flows
+
+- **Open existing:** load location → retry-pending-flush → materialize SAF→working
+  → `sync_once(working, state)`, persist `SyncState` (app-private, keyed by
+  vault_uuid) → unlock(working) → browse.
+- **Create new:** pick parent tree (`ACTION_OPEN_DOCUMENT_TREE`) →
+  `createVaultInFolder` into a fresh working subdir → flush working→new SAF child
+  dir → persist location → show 24-word recovery phrase → open.
+- **Edit:** `save_block(working)` → enqueue flush of {manifest + changed block},
+  block-first → background flush to SAF → in-flight indicator clears.
+- **Sync now / on foreground:** flush-pending → materialize → `sync_once` →
+  refresh; on conflict → existing conflict sheet → `sync_commit_decisions(working)`
+  → flush.
+
+## Error handling
+
+- **SAF permission revoked / stale** → location load returns `Unavailable` →
+  selection screen prompts re-pick (mirrors iOS stale-bookmark `.unavailable`).
+- **Flush failure (offline / SAF error)** → keep edit in working copy, mark
+  pending, show a non-blocking "saved locally, not yet synced" badge, retry on
+  next op/open.
+- **Partial flush** (block out, manifest not) → cloud recovers via the core's
+  fingerprint recheck on open; the retry completes it.
+- **Create into a non-empty target** → `FolderNotEmpty` (mirrors iOS).
+
+## Testing
+
+- **Host (JVM, no device):** `VaultMirrorPlanner` (materialize/flush plans,
+  block-first ordering, changed-file detection); view-model state machines with
+  fake ports; location-store serialization.
+- **Instrumented (emulator, real `.so` + real SAF):** create→flush→materialize→open
+  round-trip; offline-flush-then-retry; two working copies sharing one SAF tree to
+  exercise conflict-copy ingest (mirrors `cli/tests/two_instance_convergence.rs`).
+
+## Out of scope
+
+- Real-device biometric verification on a physical Android phone (separate
+  roadmap step, tracked independently).
+- Multi-recipient contact import / block sharing UI.
+- Autofill / browser integration.
+- A SAF-free real-folder (Syncthing / All-Files-Access) storage mode — the
+  push-before-pull design does not preclude adding it later as an alternate
+  `CloudFolderPort`/location-store implementation.
+- Play Store release infrastructure.
+
+## Suggested slicing (each its own PR, review loop intact)
+
+1. `VaultCreatePort` + `UniffiVaultCreatePort` (smallest; unblocks create).
+2. `VaultLocationStore` + `SafVaultLocationStore`.
+3. `CloudFolderPort` + pure `VaultMirrorPlanner` + `VaultMirror`.
+4. Provisioning view models + screens + `AppRoot` routing (keep the demo entry).
+5. Working-copy lifecycle + sync re-pointing + flush-after-commit + pending-flush
+   retry.
+6. Instrumented E2E + offline/conflict tests.
+
+A tracking GitHub issue (epic) will be filed when implementation starts.
+
+## Key references
+
+- `core/src/vault/io.rs` — `write_atomic` / `tempfile::persist` (the real-path requirement).
+- `core/src/sync/once.rs`, `core/src/sync/ingest.rs`, `core/src/sync/state.rs` — sync engine + conflict-copy ingest + `SyncState`.
+- `docs/vault-format.md` §1, §4.4, §6.5, §9 — folder layout + mutation pattern + write ordering.
+- `docs/crypto-design.md` §10–11 — manifest fork detection + record CRDT merge.
+- `docs/adr/0003-cloud-folder-sync.md` — the shared-folder deployment model.
+- `cli/tests/two_instance_convergence.rs` — the real-world topology this mirrors.
+- iOS reference: `ios/SecretaryApp/Sources/{VaultSelectionScreen,CreateVaultWizardView}.swift`, `ios/SecretaryKit/Sources/SecretaryKit/VaultAccess/{UniffiVaultCreatePort,BookmarkVaultLocationStore}.swift`.
+- Android current state: `android/app/src/main/kotlin/org/secretary/app/{AppRoot,AppVaultProvisioning}.kt`, `android/kit/src/main/kotlin/org/secretary/browse/UniffiVaultOpenPort.kt`, `android/vault-access/src/main/kotlin/org/secretary/browse/VaultOpenPort.kt`.


### PR DESCRIPTION
## Summary

Slice **1 of 6** of the Android cloud-drive vault-provisioning epic. Adds the ability to **create a vault from Kotlin**, the smallest reviewable increment toward letting the Android app open/create the user's own vault (today it can only open the bundled `golden_vault_001` demo).

- **Pure contract** (`:vault-access`, `org.secretary.browse`): `VaultCreatePort`, `CreatedVault` (plain class — no generated `toString`/`equals`/`copy` over the secret phrase), `VaultProvisioningError` (`FolderNotEmpty` / `CreateFailed` only — YAGNI).
- **Real adapter** (`:kit`): `UniffiVaultCreatePort` wraps the already-bound `createVaultInFolder`, runs Argon2id off-main-thread (`withContext(ioDispatcher)`), releases the native `MnemonicOutput` via `.use {}`, maps FFI errors to typed domain errors. Mirrors the existing `UniffiVaultOpenPort` exactly.

No core `src/`, FFI surface, on-disk-format, spec, `conformance.py`, or KAT changes.

## Design & plan
- Spec: `docs/superpowers/specs/2026-06-27-android-cloud-drive-provisioning-design.md` (SAF working-copy shim, **push-before-pull** invariant — all CRDT merge stays in the audited core).
- Plan: `docs/superpowers/plans/2026-06-27-android-cloud-drive-slice1-vault-create-port.md`.

## Tests
- Host: `:vault-access:test` (2) + `:kit:testDebugUnitTest` (5) — green.
- Instrumented (real `.so`, emulator API 36): create→open round-trip (24-word phrase + opens) and non-empty-folder→`FolderNotEmpty` — 2/2.

## Reviews
Subagent-driven: per-task spec+quality reviews clean; whole-branch review (opus) **Ready to merge: Yes**, no Critical/Important, host tests independently re-run green. Five Minor carry-overs fixed in-branch (one commit each); one (zeroizing a *test* password) intentionally skipped — interned literal, no production relevance.

## Forward compatibility
`createInFolder(folderPath: String, …)` takes a real POSIX path (like `VaultOpenPort.openWithPassword`); the SAF working-copy shim (slices 2–6) sits **above** this port, so no rework — slice 5 hands it the app-private working-copy subdir.

🤖 Generated with [Claude Code](https://claude.com/claude-code)