### PR TITLE
feat(android): VaultLocationStore + SAF location persistence (cloud-drive provisioning, slice 2/6)

### DIFF
--- a/NEXT_SESSION.md
+++ b/NEXT_SESSION.md
@@ -1,1 +1,1 @@
-docs/handoffs/2026-06-27-android-cloud-drive-slice1-vault-create-port-shipped.md
+docs/handoffs/2026-06-27-android-cloud-drive-slice2-location-store-shipped.md

--- a/android/kit/src/main/kotlin/org/secretary/browse/SafVaultLocationStore.kt
+++ b/android/kit/src/main/kotlin/org/secretary/browse/SafVaultLocationStore.kt
@@ -8,33 +8,54 @@ import android.net.Uri
  * The real [VaultLocationStore] over SharedPreferences + the SAF persistable-URI
  * permission grant. Kotlin mirror of iOS `BookmarkVaultLocationStore`.
  *
- * The class body holds NO Android types: it is constructed from four String-based
- * function seams so the persist/load/clear/availability logic (encode/decode plus the
- * take-permission-before-write ordering) is host-testable with fakes, exactly like
- * Slice 1's `createFn` seam. The live SAF + SharedPreferences wiring lives only in the
- * [safVaultLocationStore] factory, exercised on-device.
+ * The class body holds NO Android types: it is constructed from five String-based
+ * function seams so the persist/load/clear/availability logic (encode/decode, the
+ * take-permission-before-write ordering, and the release-superseded-grant cleanup) is
+ * host-testable with fakes, exactly like Slice 1's `createFn` seam. The live SAF +
+ * SharedPreferences wiring lives only in the [safVaultLocationStore] factory, exercised
+ * on-device.
+ *
+ * Persistable-URI grants count against an Android per-package cap, and clearing the pref
+ * alone does NOT relinquish the SAF grant, so this store releases a grant the moment it
+ * is superseded ([persist] with a different tree URI) or forgotten ([clear]) — otherwise
+ * the design's "stale permission → re-pick" loop would leak a grant on every re-pick.
+ * (iOS needs no analogue: a `UserDefaults` bookmark consumes no system-wide slot.)
  *
  * @param readPref returns the persisted blob, or null if none.
  * @param writePref persists the blob, or clears it when given null.
  * @param takePermission acquires a durable (persistable) read+write grant for the tree URI string.
+ * @param releasePermission relinquishes a previously-taken durable grant for the tree URI string.
  * @param hasPermission reports whether a durable grant for the tree URI string is still held.
  */
 class SafVaultLocationStore(
     private val readPref: () -> String?,
     private val writePref: (String?) -> Unit,
     private val takePermission: (String) -> Unit,
+    private val releasePermission: (String) -> Unit,
     private val hasPermission: (String) -> Boolean,
 ) : VaultLocationStore {
     override fun load(): VaultLocation? = readPref()?.let { decodeVaultLocation(it) }
 
     override fun persist(location: VaultLocation) {
+        val prior = load()
         // Acquire the durable grant BEFORE recording the location: never persist a tree
         // URI we have not secured persistable access to.
         takePermission(location.treeUri)
         writePref(encodeVaultLocation(location))
+        // Release the superseded grant AFTER the new one is secured + recorded, so a
+        // mid-persist failure can never leave us holding neither. Skip when the URI is
+        // unchanged — we just re-took it, and releasing would drop the grant we depend on.
+        if (prior != null && prior.treeUri != location.treeUri) {
+            releasePermission(prior.treeUri)
+        }
     }
 
-    override fun clear() = writePref(null)
+    override fun clear() {
+        // Release the grant before forgetting the location: clearing the pref alone does
+        // not relinquish the SAF grant, so the persisted-URI permission would leak.
+        load()?.let { releasePermission(it.treeUri) }
+        writePref(null)
+    }
 
     override fun isAvailable(location: VaultLocation): Boolean = hasPermission(location.treeUri)
 }
@@ -56,6 +77,7 @@ fun safVaultLocationStore(context: Context): VaultLocationStore {
             editor.apply()
         },
         takePermission = { uri -> resolver.takePersistableUriPermission(Uri.parse(uri), grantFlags) },
+        releasePermission = { uri -> resolver.releasePersistableUriPermission(Uri.parse(uri), grantFlags) },
         hasPermission = { uri ->
             val target = Uri.parse(uri)
             resolver.persistedUriPermissions.any {

--- a/android/kit/src/main/kotlin/org/secretary/browse/SafVaultLocationStore.kt
+++ b/android/kit/src/main/kotlin/org/secretary/browse/SafVaultLocationStore.kt
@@ -1,0 +1,69 @@
+package org.secretary.browse
+
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+
+/**
+ * The real [VaultLocationStore] over SharedPreferences + the SAF persistable-URI
+ * permission grant. Kotlin mirror of iOS `BookmarkVaultLocationStore`.
+ *
+ * The class body holds NO Android types: it is constructed from four String-based
+ * function seams so the persist/load/clear/availability logic (encode/decode plus the
+ * take-permission-before-write ordering) is host-testable with fakes, exactly like
+ * Slice 1's `createFn` seam. The live SAF + SharedPreferences wiring lives only in the
+ * [safVaultLocationStore] factory, exercised on-device.
+ *
+ * @param readPref returns the persisted blob, or null if none.
+ * @param writePref persists the blob, or clears it when given null.
+ * @param takePermission acquires a durable (persistable) read+write grant for the tree URI string.
+ * @param hasPermission reports whether a durable grant for the tree URI string is still held.
+ */
+class SafVaultLocationStore(
+    private val readPref: () -> String?,
+    private val writePref: (String?) -> Unit,
+    private val takePermission: (String) -> Unit,
+    private val hasPermission: (String) -> Boolean,
+) : VaultLocationStore {
+    override fun load(): VaultLocation? = readPref()?.let { decodeVaultLocation(it) }
+
+    override fun persist(location: VaultLocation) {
+        // Acquire the durable grant BEFORE recording the location: never persist a tree
+        // URI we have not secured persistable access to.
+        takePermission(location.treeUri)
+        writePref(encodeVaultLocation(location))
+    }
+
+    override fun clear() = writePref(null)
+
+    override fun isAvailable(location: VaultLocation): Boolean = hasPermission(location.treeUri)
+}
+
+/**
+ * Production factory wiring the real SAF + SharedPreferences seams from [context]. The
+ * only Android-bound code in this file; not host-tested (covered on-device / by Slice
+ * 6's instrumented E2E).
+ */
+fun safVaultLocationStore(context: Context): VaultLocationStore {
+    val prefs = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+    val resolver = context.contentResolver
+    val grantFlags = Intent.FLAG_GRANT_READ_URI_PERMISSION or Intent.FLAG_GRANT_WRITE_URI_PERMISSION
+    return SafVaultLocationStore(
+        readPref = { prefs.getString(KEY_LOCATION, null) },
+        writePref = { blob ->
+            val editor = prefs.edit()
+            if (blob == null) editor.remove(KEY_LOCATION) else editor.putString(KEY_LOCATION, blob)
+            editor.apply()
+        },
+        takePermission = { uri -> resolver.takePersistableUriPermission(Uri.parse(uri), grantFlags) },
+        hasPermission = { uri ->
+            val target = Uri.parse(uri)
+            resolver.persistedUriPermissions.any {
+                it.uri == target && it.isReadPermission && it.isWritePermission
+            }
+        },
+    )
+}
+
+private const val PREFS_NAME = "secretary.vault.location"
+private const val KEY_LOCATION = "location"

--- a/android/kit/src/test/kotlin/org/secretary/browse/SafVaultLocationStoreTest.kt
+++ b/android/kit/src/test/kotlin/org/secretary/browse/SafVaultLocationStoreTest.kt
@@ -1,0 +1,76 @@
+package org.secretary.browse
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class SafVaultLocationStoreTest {
+    private val location = VaultLocation("My Vault", "content://x/tree/y")
+
+    /** In-memory seams recording interactions for ordering/forwarding assertions. */
+    private class Fakes(initialPref: String? = null) {
+        var pref: String? = initialPref
+        val events = mutableListOf<String>()
+        val permitted = mutableSetOf<String>()
+
+        fun store(): SafVaultLocationStore = SafVaultLocationStore(
+            readPref = { pref },
+            writePref = { blob -> events.add("write:$blob"); pref = blob },
+            takePermission = { uri -> events.add("take:$uri"); permitted.add(uri) },
+            hasPermission = { uri -> uri in permitted },
+        )
+    }
+
+    @Test
+    fun `persist takes the permission before writing the pref`() {
+        val f = Fakes()
+        f.store().persist(location)
+        assertEquals(
+            listOf("take:content://x/tree/y", "write:${encodeVaultLocation(location)}"),
+            f.events,
+        )
+    }
+
+    @Test
+    fun `load decodes the persisted blob`() {
+        val f = Fakes(initialPref = encodeVaultLocation(location))
+        assertEquals(location, f.store().load())
+    }
+
+    @Test
+    fun `load returns null when nothing is persisted`() {
+        assertNull(Fakes().store().load())
+    }
+
+    @Test
+    fun `load returns null for a malformed blob`() {
+        assertNull(Fakes(initialPref = "garbage").store().load())
+    }
+
+    @Test
+    fun `clear writes null and load then returns null`() {
+        val f = Fakes(initialPref = encodeVaultLocation(location))
+        val store = f.store()
+        store.clear()
+        assertNull(f.pref)
+        assertNull(store.load())
+    }
+
+    @Test
+    fun `persist replaces a prior location`() {
+        val store = Fakes().store()
+        store.persist(VaultLocation("old", "content://x/tree/old"))
+        store.persist(location)
+        assertEquals(location, store.load())
+    }
+
+    @Test
+    fun `isAvailable forwards to the permission probe`() {
+        val store = Fakes().store()
+        assertFalse(store.isAvailable(location))
+        store.persist(location)
+        assertTrue(store.isAvailable(location))
+    }
+}

--- a/android/kit/src/test/kotlin/org/secretary/browse/SafVaultLocationStoreTest.kt
+++ b/android/kit/src/test/kotlin/org/secretary/browse/SafVaultLocationStoreTest.kt
@@ -19,6 +19,7 @@ class SafVaultLocationStoreTest {
             readPref = { pref },
             writePref = { blob -> events.add("write:$blob"); pref = blob },
             takePermission = { uri -> events.add("take:$uri"); permitted.add(uri) },
+            releasePermission = { uri -> events.add("release:$uri"); permitted.remove(uri) },
             hasPermission = { uri -> uri in permitted },
         )
     }
@@ -72,5 +73,46 @@ class SafVaultLocationStoreTest {
         assertFalse(store.isAvailable(location))
         store.persist(location)
         assertTrue(store.isAvailable(location))
+    }
+
+    @Test
+    fun `clear releases the grant before forgetting the location`() {
+        val f = Fakes()
+        val store = f.store()
+        store.persist(location)
+        store.clear()
+        // The grant is relinquished, not just the pref — else it leaks toward Android's cap.
+        assertFalse(store.isAvailable(location))
+        assertNull(f.pref)
+    }
+
+    @Test
+    fun `persist replacing a different URI releases the prior grant after securing the new one`() {
+        val f = Fakes()
+        val store = f.store()
+        val old = VaultLocation("old", "content://x/tree/old")
+        store.persist(old)
+        f.events.clear()
+        store.persist(location)
+        assertEquals(
+            listOf(
+                "take:content://x/tree/y",
+                "write:${encodeVaultLocation(location)}",
+                "release:content://x/tree/old",
+            ),
+            f.events,
+        )
+        assertFalse(store.isAvailable(old))
+        assertTrue(store.isAvailable(location))
+    }
+
+    @Test
+    fun `persist replacing the same URI keeps the grant and releases nothing`() {
+        val f = Fakes()
+        val store = f.store()
+        store.persist(location)
+        store.persist(location.copy(displayName = "renamed"))
+        assertTrue(store.isAvailable(location))
+        assertFalse(f.events.any { it.startsWith("release:") })
     }
 }

--- a/android/vault-access/src/main/kotlin/org/secretary/browse/VaultLocation.kt
+++ b/android/vault-access/src/main/kotlin/org/secretary/browse/VaultLocation.kt
@@ -1,0 +1,14 @@
+package org.secretary.browse
+
+/**
+ * A remembered vault location: a human-readable [displayName] plus the SAF tree URI
+ * string [treeUri] returned by the Android Storage Access Framework picker.
+ *
+ * Neither field is secret — the tree URI is a path-style `content://` token with no
+ * key material, and the name is a folder label — so persisting this type (e.g. in
+ * SharedPreferences) carries no secret-residue risk. No vault key or credential ever
+ * flows through it. A plain `data class` (unlike secret-bearing `CreatedVault`)
+ * because value equality / `toString` are useful and safe here. Kotlin mirror of iOS
+ * `VaultLocation`.
+ */
+data class VaultLocation(val displayName: String, val treeUri: String)

--- a/android/vault-access/src/main/kotlin/org/secretary/browse/VaultLocationCodec.kt
+++ b/android/vault-access/src/main/kotlin/org/secretary/browse/VaultLocationCodec.kt
@@ -37,5 +37,7 @@ fun decodeVaultLocation(encoded: String): VaultLocation? {
     if (payload.length < nameLen) return null
     val displayName = payload.substring(0, nameLen)
     val treeUri = payload.substring(nameLen)
+    // An empty SAF tree URI is never valid — conservative under-report, same as other malformed cases.
+    if (treeUri.isEmpty()) return null
     return VaultLocation(displayName, treeUri)
 }

--- a/android/vault-access/src/main/kotlin/org/secretary/browse/VaultLocationCodec.kt
+++ b/android/vault-access/src/main/kotlin/org/secretary/browse/VaultLocationCodec.kt
@@ -1,9 +1,11 @@
 package org.secretary.browse
 
 /**
- * Pure, reversible encoding of a [VaultLocation] to/from a single persisted string
- * (one atomic SharedPreferences value, so a location can never half-persist with a URI
- * but no name). Free functions, no Android dependency → fully host-testable.
+ * Pure encoding of a [VaultLocation] to/from a single persisted string (one atomic
+ * SharedPreferences value, so a location can never half-persist with a URI but no name).
+ * The encoding is reversible for any location with a non-empty tree URI — the only domain
+ * that ever reaches the codec in practice, since a real location comes from the SAF picker.
+ * Free functions, no Android dependency → fully host-testable.
  *
  * Format: `"<VERSION>:<displayName.length>:<displayName><treeUri>"`. The display name is
  * length-prefixed (UTF-16 code units, matching `String.length` / `String.substring`) so
@@ -21,9 +23,9 @@ fun encodeVaultLocation(location: VaultLocation): String =
 
 /**
  * Decode a string produced by [encodeVaultLocation]. Returns null for anything malformed
- * — wrong/absent version tag, missing length delimiter, non-numeric or negative length, or
- * a payload shorter than the declared name length — a conservative under-report mirroring
- * `FileDeviceEnrollmentMetadataStore.load`. Never throws.
+ * — empty tree URI, wrong/absent version tag, missing length delimiter, non-numeric or
+ * negative length, or a payload shorter than the declared name length — a conservative
+ * under-report mirroring `FileDeviceEnrollmentMetadataStore.load`. Never throws.
  */
 fun decodeVaultLocation(encoded: String): VaultLocation? {
     val prefix = "$VAULT_LOCATION_CODEC_VERSION:"

--- a/android/vault-access/src/main/kotlin/org/secretary/browse/VaultLocationCodec.kt
+++ b/android/vault-access/src/main/kotlin/org/secretary/browse/VaultLocationCodec.kt
@@ -1,0 +1,41 @@
+package org.secretary.browse
+
+/**
+ * Pure, reversible encoding of a [VaultLocation] to/from a single persisted string
+ * (one atomic SharedPreferences value, so a location can never half-persist with a URI
+ * but no name). Free functions, no Android dependency → fully host-testable.
+ *
+ * Format: `"<VERSION>:<displayName.length>:<displayName><treeUri>"`. The display name is
+ * length-prefixed (UTF-16 code units, matching `String.length` / `String.substring`) so
+ * it needs no escaping and may contain any character — including the `:` delimiter. The
+ * only structural delimiters are the version tag and the single colon after the length
+ * digits.
+ */
+
+/** Codec format version; bump when the encoding changes so old blobs decode to null. */
+internal const val VAULT_LOCATION_CODEC_VERSION = "v1"
+
+/** Encode [location] to its persisted string form. */
+fun encodeVaultLocation(location: VaultLocation): String =
+    "$VAULT_LOCATION_CODEC_VERSION:${location.displayName.length}:${location.displayName}${location.treeUri}"
+
+/**
+ * Decode a string produced by [encodeVaultLocation]. Returns null for anything malformed
+ * — wrong/absent version tag, missing length delimiter, non-numeric or negative length, or
+ * a payload shorter than the declared name length — a conservative under-report mirroring
+ * `FileDeviceEnrollmentMetadataStore.load`. Never throws.
+ */
+fun decodeVaultLocation(encoded: String): VaultLocation? {
+    val prefix = "$VAULT_LOCATION_CODEC_VERSION:"
+    if (!encoded.startsWith(prefix)) return null
+    val rest = encoded.substring(prefix.length)
+    val colon = rest.indexOf(':')
+    if (colon < 0) return null
+    val nameLen = rest.substring(0, colon).toIntOrNull() ?: return null
+    if (nameLen < 0) return null
+    val payload = rest.substring(colon + 1)
+    if (payload.length < nameLen) return null
+    val displayName = payload.substring(0, nameLen)
+    val treeUri = payload.substring(nameLen)
+    return VaultLocation(displayName, treeUri)
+}

--- a/android/vault-access/src/main/kotlin/org/secretary/browse/VaultLocationStore.kt
+++ b/android/vault-access/src/main/kotlin/org/secretary/browse/VaultLocationStore.kt
@@ -1,0 +1,29 @@
+package org.secretary.browse
+
+/**
+ * Persists ONE remembered vault location and reports whether its SAF permission is
+ * still granted. The port keeps the platform persistence + SAF permission machinery
+ * behind a boundary so the (later) selection view-model is host-testable against a
+ * fake. Single-vault by design (this slice): [persist] replaces any prior location.
+ *
+ * Kotlin mirror of iOS `VaultLocationStore`, minus iOS's `beginAccess`: on Android a
+ * SAF tree exposes no real filesystem path, so resolving a location to an operable
+ * path is the working-copy *materialize* step (a later slice), not this store's job.
+ */
+interface VaultLocationStore {
+    /** The remembered location, or null if none has been selected. */
+    fun load(): VaultLocation?
+
+    /** Remember [location], replacing any prior one. */
+    fun persist(location: VaultLocation)
+
+    /** Forget the remembered location. */
+    fun clear()
+
+    /**
+     * Whether the persistable SAF permission for [location] is still held (the tree has
+     * not been revoked / the granting provider uninstalled). The selection screen uses a
+     * false result to prompt a re-pick (mirrors iOS's stale-bookmark `.unavailable`).
+     */
+    fun isAvailable(location: VaultLocation): Boolean
+}

--- a/android/vault-access/src/test/kotlin/org/secretary/browse/VaultLocationCodecTest.kt
+++ b/android/vault-access/src/test/kotlin/org/secretary/browse/VaultLocationCodecTest.kt
@@ -1,0 +1,59 @@
+package org.secretary.browse
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Test
+
+class VaultLocationCodecTest {
+    private val tree = "content://com.android.externalstorage.documents/tree/primary%3AVault"
+
+    @Test
+    fun `round-trips a typical location`() {
+        val loc = VaultLocation("My Vault", tree)
+        assertEquals(loc, decodeVaultLocation(encodeVaultLocation(loc)))
+    }
+
+    @Test
+    fun `round-trips a display name containing the colon delimiter`() {
+        val loc = VaultLocation("a:b:c", tree)
+        assertEquals(loc, decodeVaultLocation(encodeVaultLocation(loc)))
+    }
+
+    @Test
+    fun `round-trips an empty display name`() {
+        val loc = VaultLocation("", tree)
+        assertEquals(loc, decodeVaultLocation(encodeVaultLocation(loc)))
+    }
+
+    @Test
+    fun `decodes null for a wrong version tag`() {
+        assertNull(decodeVaultLocation("v2:3:abc$tree"))
+    }
+
+    @Test
+    fun `decodes null for a missing length delimiter`() {
+        assertNull(decodeVaultLocation("v1:abc"))
+    }
+
+    @Test
+    fun `decodes null for a non-numeric length`() {
+        assertNull(decodeVaultLocation("v1:x:abc"))
+    }
+
+    @Test
+    fun `decodes null when payload is shorter than the declared name length`() {
+        assertNull(decodeVaultLocation("v1:99:short"))
+    }
+
+    @Test
+    fun `decodes null for an empty string`() {
+        assertNull(decodeVaultLocation(""))
+    }
+
+    @Test
+    fun `VaultLocation is value-equal (deliberate data class, unlike CreatedVault)`() {
+        assertEquals(VaultLocation("n", "u"), VaultLocation("n", "u"))
+        assertNotEquals(VaultLocation("n", "u"), VaultLocation("n", "v"))
+    }
+}

--- a/android/vault-access/src/test/kotlin/org/secretary/browse/VaultLocationCodecTest.kt
+++ b/android/vault-access/src/test/kotlin/org/secretary/browse/VaultLocationCodecTest.kt
@@ -52,6 +52,11 @@ class VaultLocationCodecTest {
     }
 
     @Test
+    fun `decodes null when tree URI is empty (name exhausts payload)`() {
+        assertNull(decodeVaultLocation("v1:3:abc"))
+    }
+
+    @Test
     fun `VaultLocation is value-equal (deliberate data class, unlike CreatedVault)`() {
         assertEquals(VaultLocation("n", "u"), VaultLocation("n", "u"))
         assertNotEquals(VaultLocation("n", "u"), VaultLocation("n", "v"))

--- a/docs/handoffs/2026-06-27-android-cloud-drive-slice2-location-store-shipped.md
+++ b/docs/handoffs/2026-06-27-android-cloud-drive-slice2-location-store-shipped.md
@@ -23,6 +23,8 @@
 
 **Reviews.** Per-task: Task 1 ✅ (1 Minor — empty-`treeUri` accepted by decode — **fixed**, `1e51fc22`, as a conservative-under-report guard the persisted format depends on); Task 2 ✅ (3 Minors, all non-defects: test-count verbosity / const placement matches house style / replace-test asserts via `load()` — reviewer "fine"). Whole-branch review (opus): **Ready to merge: Yes**, no Critical/Important. Two Minor KDoc nits (empty-treeUri case missing from the malformed-list; "reversible" overclaim) **fixed** in `70a5ec24`.
 
+**Post-review `/review` fix (persistable-URI grant leak).** A precision PR review flagged that `SafVaultLocationStore.clear()` (and `persist()` superseding a *different* tree URI) relinquished nothing — `takePersistableUriPermission` consumes an Android per-package grant slot, and clearing the SharedPreferences blob alone does **not** release the SAF grant, so the design's "stale permission → re-pick" loop would leak a grant on every re-pick toward the system cap. **Fixed** by adding a fifth `releasePermission` seam (mirroring `takePermission`): `persist` releases the prior grant *after* securing+recording the new one (skipped when the URI is unchanged); `clear` releases before forgetting. iOS needs no analogue (a `UserDefaults` bookmark consumes no system-wide slot). Three new falsifiable host cases (clear-releases, replace-different-releases-old with an ordered event assertion, replace-same-keeps); `:kit` suite now 10/10 green.
+
 **Branch commits** (off `main` @ `4a254e4a`):
 | SHA | What |
 |---|---|

--- a/docs/handoffs/2026-06-27-android-cloud-drive-slice2-location-store-shipped.md
+++ b/docs/handoffs/2026-06-27-android-cloud-drive-slice2-location-store-shipped.md
@@ -1,0 +1,77 @@
+# NEXT_SESSION.md — Android cloud-drive provisioning, Slice 2 (VaultLocationStore) ✅ SHIPPED (PR opening)
+
+**Session date:** 2026-06-27 (second session of the day). Resumed the **Android cloud-drive vault-provisioning epic** from the Slice-1 baton. Slice 1 (`VaultCreatePort`, PR #320) had merged at 10:36; this session filed the epic tracking issue and shipped **Slice 2 of 6 — the `VaultLocationStore`**. Executed in project-local worktree `.worktrees/android-cloud-drive-locstore`, branch `feature/android-cloud-drive-locstore` (cut from `main` @ `4a254e4a`). Kotlin/Android only. **No core `src/` change, no FFI surface change, no on-disk-format / spec / `conformance.py` / KAT change.**
+
+## (1) What we shipped this session
+
+**Epic tracking issue filed:** **[#321](https://github.com/hherb/secretary/issues/321)** — "Epic: Android cloud-drive vault provisioning (SAF working-copy shim)", with the 6-slice checklist (Slice 1 ticked).
+
+**Context — the epic.** Let the Android app open/create the user's own vault in a **cloud-drive folder** (Drive/Dropbox/OneDrive). The Rust core does direct POSIX I/O with no storage seam, but Android cloud-drive folders are reachable only via SAF `content://` URIs → the approved design is a **SAF working-copy shim** with a **push-before-pull** invariant. Full architecture + 6-slice plan: [`docs/superpowers/specs/2026-06-27-android-cloud-drive-provisioning-design.md`](../superpowers/specs/2026-06-27-android-cloud-drive-provisioning-design.md). Slice-2 plan: [`docs/superpowers/plans/2026-06-27-android-cloud-drive-slice2-location-store.md`](../superpowers/plans/2026-06-27-android-cloud-drive-slice2-location-store.md).
+
+**Slice 2 (this PR) — the `VaultLocationStore`.** Remembers ONE vault location (a SAF tree URI string + display name), takes a durable persistable-URI permission, and reports whether that permission is still granted. Parity port of iOS `VaultLocation` / `VaultLocationStore` / `BookmarkVaultLocationStore`.
+
+- **Pure layer (`:vault-access`, package `org.secretary.browse`):**
+  - `data class VaultLocation(val displayName: String, val treeUri: String)` — **`data class`** (value equality is useful + safe; carries NO secret, unlike Slice-1's plain-class `CreatedVault`). No `vault_uuid` (brainstorm decision — unknown at persist time; `SyncState` keying is a Slice-5 concern).
+  - `interface VaultLocationStore { load(): VaultLocation?; persist(location); clear(); isAvailable(location): Boolean }` — synchronous (no crypto → no `suspend`). **No `beginAccess → path`**: SAF exposes no real path until working-copy *materialize* (Slice 3/5), so the honest Slice-2 surface is an `isAvailable` boolean probe (the spec's "stale permission → re-pick" path).
+  - `VaultLocationCodec` — pure free functions `encodeVaultLocation` / `decodeVaultLocation`. **Single atomic blob** (one pref value, so a location can never half-persist — an improvement over iOS's two-key split), version-tagged + **length-prefixed** name (`"v1:<name.length>:<name><uri>"`) so the name needs no escaping and may contain the `:` delimiter. `decode` returns null on anything malformed (never throws): bad/absent version, missing delimiter, non-numeric/negative length, payload shorter than declared name length, **or an empty tree URI**.
+- **Real adapter (`:kit`):** `SafVaultLocationStore` — the class body holds **zero Android types**: four String-based seams (`readPref`/`writePref`/`takePermission`/`hasPermission`), exactly mirroring Slice-1's `createFn` seam, so all persist/load/clear/availability logic is host-testable with fakes. Android (`Context`/`Uri`/`ContentResolver.takePersistableUriPermission`/`persistedUriPermissions`/`Intent` flags) lives ONLY in the top-level `safVaultLocationStore(context)` factory. `persist` takes the SAF permission **before** writing the pref (never persist a URI we haven't secured). Named constants `PREFS_NAME` / `KEY_LOCATION`.
+
+**TDD throughout (subagent-driven: implementer → spec+quality review per task → whole-branch review).**
+- Host `:vault-access` — `VaultLocationCodecTest` (10 cases: round-trips incl. `:`-in-name + empty name, all decode-reject branches, empty-treeUri reject, value-equality).
+- Host `:kit` — `SafVaultLocationStoreTest` (7 cases via fake seams: take-permission-before-write **ordering** (ordered event list, genuinely falsifiable), load decodes, malformed→null, clear, replace-prior, `isAvailable` forwarding).
+- **No instrumented test this slice (documented, not silent):** a real persistable *tree* URI needs driving the system SAF picker (UiAutomator), not automatable in a unit slice → deferred to Slice 6's E2E. (Slice 1 had an instrumented test only because the FFI `.so` create *is* automatable; SAF grants are not.)
+
+**Reviews.** Per-task: Task 1 ✅ (1 Minor — empty-`treeUri` accepted by decode — **fixed**, `1e51fc22`, as a conservative-under-report guard the persisted format depends on); Task 2 ✅ (3 Minors, all non-defects: test-count verbosity / const placement matches house style / replace-test asserts via `load()` — reviewer "fine"). Whole-branch review (opus): **Ready to merge: Yes**, no Critical/Important. Two Minor KDoc nits (empty-treeUri case missing from the malformed-list; "reversible" overclaim) **fixed** in `70a5ec24`.
+
+**Branch commits** (off `main` @ `4a254e4a`):
+| SHA | What |
+|---|---|
+| `28569ec2` | docs: slice-2 plan |
+| `211e6808` | feat: pure `VaultLocationStore` port + `VaultLocation` + codec (`:vault-access`) |
+| `1e51fc22` | fix: reject empty `treeUri` in `decodeVaultLocation` (Task-1 review Minor) |
+| `e84b54e8` | feat: `SafVaultLocationStore` adapter + factory (`:kit`) |
+| `70a5ec24` | docs: align codec KDoc with empty-treeUri reject + qualify reversibility (final-review Minors) |
+| (+ handoff commit) | this baton + retargeted `NEXT_SESSION.md` symlink |
+
+### Acceptance (verified this session, in the worktree)
+```bash
+cd /Users/hherb/src/secretary/.worktrees/android-cloud-drive-locstore/android
+./gradlew :vault-access:test            # host — codec suite green (incl. empty-treeUri reject)
+./gradlew :kit:testDebugUnitTest        # host — SafVaultLocationStore suite 7/7 green
+```
+No emulator/device needed this slice.
+
+## (2) What's next
+**Slice 2 is done (PR open). Continue the epic with Slice 3.** Each slice is its own plan + PR through the review loop. Remaining slices (from the design spec):
+3. `CloudFolderPort` (list/read/write/delete over SAF) + **pure** `VaultMirrorPlanner` (which files to move, **block-first** ordering, changed-file detection — the host-testable heart) + `VaultMirror` orchestrator.
+4. Provisioning view models + `VaultSelectionScreen` / `CreateVaultWizardScreen` + `AppRoot` routing (keep the demo entry). **This is the first slice that wires `VaultCreatePort` + `VaultLocationStore` into an observable Android capability.**
+5. Working-copy lifecycle: materialize → `sync_once` → operate → **flush-after-every-commit** + pending-flush retry (push-before-pull). **`SyncState` keyed by `vault_uuid` lands here** — see the v2-codec note in (3).
+6. Instrumented E2E + offline-flush + conflict-copy-ingest tests (two working copies over one SAF tree, mirroring `cli/tests/two_instance_convergence.rs`). **Includes the deferred real-SAF `takePersistableUriPermission` round-trip for Slice 2.**
+
+**Acceptance template:** TDD (RED proven), typed-error/null surface proven not assumed on security paths, host (+ instrumented where automatable) gate green, pure logic in `:vault-access` / FFI+Android in `:kit`, no merge logic in Kotlin (the core owns CRDT).
+
+## (3) Open decisions and risks
+- **Forward-compat note for Slice 5 (`vault_uuid`):** the design-spec Slice-2 row literally lists `vault_uuid` in the location; we deliberately dropped it (unknown at persist time, `SyncState` keying is Slice 5). The codec is already **version-tagged (`v1`)** for exactly this — when Slice 5 adds `vault_uuid`, bump to a **`v2`** encoding. Because `decode` returns null for any non-`v1` blob, a `v1→v2` upgrade silently forgets the one remembered location and re-prompts a pick — acceptable for a single-vault store, but make it a *conscious* line in the Slice-5 plan, not a surprise.
+- **`isAvailable` (not iOS `beginAccess`) is the right Android shape** — SAF has no resolvable path until materialize; porting `beginAccess → path` here would have forced a fake path. Confirmed sound by the final review.
+- **Risk:** low. Two new Kotlin source files + tests, plus a factory; wraps SAF + SharedPreferences; changes no core/FFI/format. No observable byte/semantics change.
+- **README.md / ROADMAP.md unchanged** — consistent with Slice 1 (PR #320) and [[feedback_readme_style]]: Slices 1–2 are internal port plumbing with no observable Android-app capability yet. The epic earns its ROADMAP capability entry when the **create/open wizard lands (Slice 4)**.
+
+## (4) Exact commands to resume
+```bash
+cd /Users/hherb/src/secretary
+git fetch --prune origin && git checkout main && git pull --ff-only origin main
+# If this PR merged, remove the worktree + branch:
+#   git worktree remove .worktrees/android-cloud-drive-locstore && git branch -D feature/android-cloud-drive-locstore
+git worktree list && git status -s
+# Start Slice 3 from the design spec's component table (#3 row); brainstorm → plan → subagent-driven execute.
+# File work continues under issue #321 (epic).
+```
+
+## (5) Handoff file model
+`NEXT_SESSION.md` is a **relative symlink** to this file in `docs/handoffs/`. Authored once here; symlink retargeted in the same commit on the feature branch (new path → no add/add conflict; `main` updates cleanly on merge). Per [[feedback_next_session_in_pr]] / [[feedback_next_session_main_authoritative]] the baton rides inside the PR — do **not** sync to `main` during the pause window.
+
+## Closing inventory
+- **State on close:** PR opening on `feature/android-cloud-drive-locstore` (6 commits: 1 plan + 4 feat/fix/docs + handoff). Worktree `.worktrees/android-cloud-drive-locstore`. Epic issue #321.
+- **Acceptance:** host `:vault-access:test` + `:kit:testDebugUnitTest` green; whole-branch review (opus) Ready-to-merge Yes; all per-task + final Minors fixed or consciously kept.
+- **README.md / ROADMAP.md / CLAUDE.md:** unchanged (internal port slice of an in-flight epic).
+- **NEXT_SESSION.md:** symlink → `docs/handoffs/2026-06-27-android-cloud-drive-slice2-location-store-shipped.md`.

--- a/docs/superpowers/plans/2026-06-27-android-cloud-drive-slice2-location-store.md
+++ b/docs/superpowers/plans/2026-06-27-android-cloud-drive-slice2-location-store.md
@@ -1,0 +1,464 @@
+# Android Cloud-Drive Provisioning — Slice 2: VaultLocationStore Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a Kotlin `VaultLocationStore` (pure port + value type + codec in `:vault-access`) and its real `SafVaultLocationStore` adapter (in `:kit`) that remembers ONE vault location — a SAF tree URI string plus display name — in SharedPreferences, taking a durable persistable-URI permission, and reports whether that permission is still granted.
+
+**Architecture:** Mirror the existing `:vault-access` (pure, host-tested, no Android) / `:kit` (real adapter) split used by Slice 1's `VaultCreatePort` / `UniffiVaultCreatePort`. The pure layer holds the `VaultLocation` value type, the `VaultLocationStore` interface, and a reversible `VaultLocationCodec` (single-blob encode/decode). The real `SafVaultLocationStore` carries NO Android types in its own body — it takes four String-based function seams (read/write the pref, take/check the SAF permission) so all logic is host-testable with fakes; the live SAF + SharedPreferences wiring lives only in a `safVaultLocationStore(context)` factory exercised on-device.
+
+**Tech Stack:** Kotlin, JUnit 5 (Jupiter) host unit tests in `:vault-access` and `:kit`, Android Storage Access Framework (`ContentResolver.takePersistableUriPermission` / `persistedUriPermissions`), SharedPreferences.
+
+**Scope note:** This is slice 2 of 6 in the epic specified at
+`docs/superpowers/specs/2026-06-27-android-cloud-drive-provisioning-design.md`
+(epic tracking issue: #321). It deliberately does NOT touch the working-copy
+mirror, the provisioning UI, app routing, or `SyncState` keying — those are slices
+3–6. Per the brainstorm decisions: `VaultLocation` carries only `{displayName,
+treeUri}` (no `vault_uuid` — it is unknown at persist time and `SyncState` keying
+is a Slice-5 concern); the store exposes an `isAvailable` boolean probe (the honest
+Slice-2 surface for the spec's "stale permission → re-pick" path), NOT iOS's
+`beginAccess → path` (there is no real path until working-copy *materialize*, a
+later slice).
+
+## Global Constraints
+
+- **Module split discipline:** pure interface + value type + codec live in `:vault-access`; all Android/SAF I/O lives in `:kit`. (Mirrors `VaultCreatePort` in `:vault-access` vs `UniffiVaultCreatePort` in `:kit`.)
+- **Mirror iOS naming** where an analogue exists: iOS `VaultLocation` / `VaultLocationStore` (`ios/SecretaryVaultAccess/Sources/SecretaryVaultAccess/`), `BookmarkVaultLocationStore` (`ios/SecretaryKit/.../VaultAccess/BookmarkVaultLocationStore.swift`).
+- **No secrets in this surface:** a tree URI + folder name carry no key material, so `VaultLocation` is a `data class` (value equality is useful + safe), NOT the plain-class treatment secret-bearing `CreatedVault` required. Nothing here is zeroized.
+- **Injected-seam testability:** `SafVaultLocationStore`'s own body references NO Android types — it takes four String-based function seams, exactly like Slice 1's `createFn`. Android (`Context` / `Uri` / `ContentResolver` / `SharedPreferences`) appears ONLY in the `safVaultLocationStore(context)` factory.
+- **No magic strings/numbers:** prefs name, prefs key, and the codec version are named constants.
+- **Conservative decode:** `decodeVaultLocation` returns `null` for anything malformed (mirrors `FileDeviceEnrollmentMetadataStore.load`'s under-report posture) — never throws.
+- **Synchronous, no coroutines:** location ops do no crypto (no Argon2), so — like iOS and `FileDeviceEnrollmentMetadataStore` — the interface is plain `fun`, not `suspend`.
+- **No instrumented test this slice (documented, not silent):** a real persistable *tree* URI requires driving the system SAF picker (UiAutomator), not automatable in a unit slice. The live `takePersistableUriPermission` round-trip is covered by Slice 6's instrumented E2E. (Slice 1 had an instrumented test only because the FFI `.so` create is automatable; SAF grants are not.)
+- **Tests green** before each commit; Kotlin files stay focused (both new source files are well under 100 lines). **Commit per task** with a conventional-commit message.
+
+**Test commands** (run from the `android/` Gradle root in THIS worktree):
+
+```bash
+cd /Users/hherb/src/secretary/.worktrees/android-cloud-drive-locstore/android
+./gradlew :vault-access:test            # host JVM unit tests (Task 1)
+./gradlew :kit:testDebugUnitTest        # host JVM unit tests (Task 2)
+```
+
+No emulator/device is needed for either task.
+
+---
+
+### Task 1: Pure layer — `VaultLocation`, `VaultLocationStore`, `VaultLocationCodec` (`:vault-access`)
+
+**Files:**
+- Create: `android/vault-access/src/main/kotlin/org/secretary/browse/VaultLocation.kt`
+- Create: `android/vault-access/src/main/kotlin/org/secretary/browse/VaultLocationStore.kt`
+- Create: `android/vault-access/src/main/kotlin/org/secretary/browse/VaultLocationCodec.kt`
+- Test: `android/vault-access/src/test/kotlin/org/secretary/browse/VaultLocationCodecTest.kt`
+
+**Interfaces:**
+- Consumes: nothing (new pure layer).
+- Produces (Task 2 relies on these exact names/types):
+  - `data class VaultLocation(val displayName: String, val treeUri: String)`
+  - `interface VaultLocationStore { fun load(): VaultLocation?; fun persist(location: VaultLocation); fun clear(); fun isAvailable(location: VaultLocation): Boolean }`
+  - `fun encodeVaultLocation(location: VaultLocation): String`
+  - `fun decodeVaultLocation(encoded: String): VaultLocation?`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `android/vault-access/src/test/kotlin/org/secretary/browse/VaultLocationCodecTest.kt`:
+
+```kotlin
+package org.secretary.browse
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Test
+
+class VaultLocationCodecTest {
+    private val tree = "content://com.android.externalstorage.documents/tree/primary%3AVault"
+
+    @Test
+    fun `round-trips a typical location`() {
+        val loc = VaultLocation("My Vault", tree)
+        assertEquals(loc, decodeVaultLocation(encodeVaultLocation(loc)))
+    }
+
+    @Test
+    fun `round-trips a display name containing the colon delimiter`() {
+        val loc = VaultLocation("a:b:c", tree)
+        assertEquals(loc, decodeVaultLocation(encodeVaultLocation(loc)))
+    }
+
+    @Test
+    fun `round-trips an empty display name`() {
+        val loc = VaultLocation("", tree)
+        assertEquals(loc, decodeVaultLocation(encodeVaultLocation(loc)))
+    }
+
+    @Test
+    fun `decodes null for a wrong version tag`() {
+        assertNull(decodeVaultLocation("v2:3:abc$tree"))
+    }
+
+    @Test
+    fun `decodes null for a missing length delimiter`() {
+        assertNull(decodeVaultLocation("v1:abc"))
+    }
+
+    @Test
+    fun `decodes null for a non-numeric length`() {
+        assertNull(decodeVaultLocation("v1:x:abc"))
+    }
+
+    @Test
+    fun `decodes null when payload is shorter than the declared name length`() {
+        assertNull(decodeVaultLocation("v1:99:short"))
+    }
+
+    @Test
+    fun `decodes null for an empty string`() {
+        assertNull(decodeVaultLocation(""))
+    }
+
+    @Test
+    fun `VaultLocation is value-equal (deliberate data class, unlike CreatedVault)`() {
+        assertEquals(VaultLocation("n", "u"), VaultLocation("n", "u"))
+        assertNotEquals(VaultLocation("n", "u"), VaultLocation("n", "v"))
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd /Users/hherb/src/secretary/.worktrees/android-cloud-drive-locstore/android && ./gradlew :vault-access:test`
+Expected: FAIL — compilation error, `VaultLocation` / `encodeVaultLocation` / `decodeVaultLocation` unresolved.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `android/vault-access/src/main/kotlin/org/secretary/browse/VaultLocation.kt`:
+
+```kotlin
+package org.secretary.browse
+
+/**
+ * A remembered vault location: a human-readable [displayName] plus the SAF tree URI
+ * string [treeUri] returned by the Android Storage Access Framework picker.
+ *
+ * Neither field is secret — the tree URI is a path-style `content://` token with no
+ * key material, and the name is a folder label — so persisting this type (e.g. in
+ * SharedPreferences) carries no secret-residue risk. No vault key or credential ever
+ * flows through it. A plain `data class` (unlike secret-bearing `CreatedVault`)
+ * because value equality / `toString` are useful and safe here. Kotlin mirror of iOS
+ * `VaultLocation`.
+ */
+data class VaultLocation(val displayName: String, val treeUri: String)
+```
+
+Create `android/vault-access/src/main/kotlin/org/secretary/browse/VaultLocationStore.kt`:
+
+```kotlin
+package org.secretary.browse
+
+/**
+ * Persists ONE remembered vault location and reports whether its SAF permission is
+ * still granted. The port keeps the platform persistence + SAF permission machinery
+ * behind a boundary so the (later) selection view-model is host-testable against a
+ * fake. Single-vault by design (this slice): [persist] replaces any prior location.
+ *
+ * Kotlin mirror of iOS `VaultLocationStore`, minus iOS's `beginAccess`: on Android a
+ * SAF tree exposes no real filesystem path, so resolving a location to an operable
+ * path is the working-copy *materialize* step (a later slice), not this store's job.
+ */
+interface VaultLocationStore {
+    /** The remembered location, or null if none has been selected. */
+    fun load(): VaultLocation?
+
+    /** Remember [location], replacing any prior one. */
+    fun persist(location: VaultLocation)
+
+    /** Forget the remembered location. */
+    fun clear()
+
+    /**
+     * Whether the persistable SAF permission for [location] is still held (the tree has
+     * not been revoked / the granting provider uninstalled). The selection screen uses a
+     * false result to prompt a re-pick (mirrors iOS's stale-bookmark `.unavailable`).
+     */
+    fun isAvailable(location: VaultLocation): Boolean
+}
+```
+
+Create `android/vault-access/src/main/kotlin/org/secretary/browse/VaultLocationCodec.kt`:
+
+```kotlin
+package org.secretary.browse
+
+/**
+ * Pure, reversible encoding of a [VaultLocation] to/from a single persisted string
+ * (one atomic SharedPreferences value, so a location can never half-persist with a URI
+ * but no name). Free functions, no Android dependency → fully host-testable.
+ *
+ * Format: `"<VERSION>:<displayName.length>:<displayName><treeUri>"`. The display name is
+ * length-prefixed (UTF-16 code units, matching `String.length` / `String.substring`) so
+ * it needs no escaping and may contain any character — including the `:` delimiter. The
+ * only structural delimiters are the version tag and the single colon after the length
+ * digits.
+ */
+
+/** Codec format version; bump when the encoding changes so old blobs decode to null. */
+internal const val VAULT_LOCATION_CODEC_VERSION = "v1"
+
+/** Encode [location] to its persisted string form. */
+fun encodeVaultLocation(location: VaultLocation): String =
+    "$VAULT_LOCATION_CODEC_VERSION:${location.displayName.length}:${location.displayName}${location.treeUri}"
+
+/**
+ * Decode a string produced by [encodeVaultLocation]. Returns null for anything malformed
+ * — wrong/absent version tag, missing length delimiter, non-numeric or negative length, or
+ * a payload shorter than the declared name length — a conservative under-report mirroring
+ * `FileDeviceEnrollmentMetadataStore.load`. Never throws.
+ */
+fun decodeVaultLocation(encoded: String): VaultLocation? {
+    val prefix = "$VAULT_LOCATION_CODEC_VERSION:"
+    if (!encoded.startsWith(prefix)) return null
+    val rest = encoded.substring(prefix.length)
+    val colon = rest.indexOf(':')
+    if (colon < 0) return null
+    val nameLen = rest.substring(0, colon).toIntOrNull() ?: return null
+    if (nameLen < 0) return null
+    val payload = rest.substring(colon + 1)
+    if (payload.length < nameLen) return null
+    val displayName = payload.substring(0, nameLen)
+    val treeUri = payload.substring(nameLen)
+    return VaultLocation(displayName, treeUri)
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd /Users/hherb/src/secretary/.worktrees/android-cloud-drive-locstore/android && ./gradlew :vault-access:test`
+Expected: PASS — all 9 `VaultLocationCodecTest` cases green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /Users/hherb/src/secretary/.worktrees/android-cloud-drive-locstore
+git add android/vault-access/src/main/kotlin/org/secretary/browse/VaultLocation.kt \
+        android/vault-access/src/main/kotlin/org/secretary/browse/VaultLocationStore.kt \
+        android/vault-access/src/main/kotlin/org/secretary/browse/VaultLocationCodec.kt \
+        android/vault-access/src/test/kotlin/org/secretary/browse/VaultLocationCodecTest.kt
+git commit -m "feat(android): pure VaultLocationStore port + VaultLocation + codec (:vault-access)"
+```
+
+---
+
+### Task 2: Real adapter — `SafVaultLocationStore` + `safVaultLocationStore` factory (`:kit`)
+
+**Files:**
+- Create: `android/kit/src/main/kotlin/org/secretary/browse/SafVaultLocationStore.kt`
+- Test: `android/kit/src/test/kotlin/org/secretary/browse/SafVaultLocationStoreTest.kt`
+
+**Interfaces:**
+- Consumes (from Task 1): `VaultLocation`, `VaultLocationStore`, `encodeVaultLocation`, `decodeVaultLocation`.
+- Produces:
+  - `class SafVaultLocationStore(readPref: () -> String?, writePref: (String?) -> Unit, takePermission: (String) -> Unit, hasPermission: (String) -> Boolean) : VaultLocationStore`
+  - `fun safVaultLocationStore(context: Context): VaultLocationStore`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `android/kit/src/test/kotlin/org/secretary/browse/SafVaultLocationStoreTest.kt`:
+
+```kotlin
+package org.secretary.browse
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class SafVaultLocationStoreTest {
+    private val location = VaultLocation("My Vault", "content://x/tree/y")
+
+    /** In-memory seams recording interactions for ordering/forwarding assertions. */
+    private class Fakes(initialPref: String? = null) {
+        var pref: String? = initialPref
+        val events = mutableListOf<String>()
+        val permitted = mutableSetOf<String>()
+
+        fun store(): SafVaultLocationStore = SafVaultLocationStore(
+            readPref = { pref },
+            writePref = { blob -> events.add("write:$blob"); pref = blob },
+            takePermission = { uri -> events.add("take:$uri"); permitted.add(uri) },
+            hasPermission = { uri -> uri in permitted },
+        )
+    }
+
+    @Test
+    fun `persist takes the permission before writing the pref`() {
+        val f = Fakes()
+        f.store().persist(location)
+        assertEquals(
+            listOf("take:content://x/tree/y", "write:${encodeVaultLocation(location)}"),
+            f.events,
+        )
+    }
+
+    @Test
+    fun `load decodes the persisted blob`() {
+        val f = Fakes(initialPref = encodeVaultLocation(location))
+        assertEquals(location, f.store().load())
+    }
+
+    @Test
+    fun `load returns null when nothing is persisted`() {
+        assertNull(Fakes().store().load())
+    }
+
+    @Test
+    fun `load returns null for a malformed blob`() {
+        assertNull(Fakes(initialPref = "garbage").store().load())
+    }
+
+    @Test
+    fun `clear writes null and load then returns null`() {
+        val f = Fakes(initialPref = encodeVaultLocation(location))
+        val store = f.store()
+        store.clear()
+        assertNull(f.pref)
+        assertNull(store.load())
+    }
+
+    @Test
+    fun `persist replaces a prior location`() {
+        val store = Fakes().store()
+        store.persist(VaultLocation("old", "content://x/tree/old"))
+        store.persist(location)
+        assertEquals(location, store.load())
+    }
+
+    @Test
+    fun `isAvailable forwards to the permission probe`() {
+        val store = Fakes().store()
+        assertFalse(store.isAvailable(location))
+        store.persist(location)
+        assertTrue(store.isAvailable(location))
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd /Users/hherb/src/secretary/.worktrees/android-cloud-drive-locstore/android && ./gradlew :kit:testDebugUnitTest`
+Expected: FAIL — compilation error, `SafVaultLocationStore` unresolved.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `android/kit/src/main/kotlin/org/secretary/browse/SafVaultLocationStore.kt`:
+
+```kotlin
+package org.secretary.browse
+
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+
+/**
+ * The real [VaultLocationStore] over SharedPreferences + the SAF persistable-URI
+ * permission grant. Kotlin mirror of iOS `BookmarkVaultLocationStore`.
+ *
+ * The class body holds NO Android types: it is constructed from four String-based
+ * function seams so the persist/load/clear/availability logic (encode/decode plus the
+ * take-permission-before-write ordering) is host-testable with fakes, exactly like
+ * Slice 1's `createFn` seam. The live SAF + SharedPreferences wiring lives only in the
+ * [safVaultLocationStore] factory, exercised on-device.
+ *
+ * @param readPref returns the persisted blob, or null if none.
+ * @param writePref persists the blob, or clears it when given null.
+ * @param takePermission acquires a durable (persistable) read+write grant for the tree URI string.
+ * @param hasPermission reports whether a durable grant for the tree URI string is still held.
+ */
+class SafVaultLocationStore(
+    private val readPref: () -> String?,
+    private val writePref: (String?) -> Unit,
+    private val takePermission: (String) -> Unit,
+    private val hasPermission: (String) -> Boolean,
+) : VaultLocationStore {
+    override fun load(): VaultLocation? = readPref()?.let { decodeVaultLocation(it) }
+
+    override fun persist(location: VaultLocation) {
+        // Acquire the durable grant BEFORE recording the location: never persist a tree
+        // URI we have not secured persistable access to.
+        takePermission(location.treeUri)
+        writePref(encodeVaultLocation(location))
+    }
+
+    override fun clear() = writePref(null)
+
+    override fun isAvailable(location: VaultLocation): Boolean = hasPermission(location.treeUri)
+}
+
+/**
+ * Production factory wiring the real SAF + SharedPreferences seams from [context]. The
+ * only Android-bound code in this file; not host-tested (covered on-device / by Slice
+ * 6's instrumented E2E).
+ */
+fun safVaultLocationStore(context: Context): VaultLocationStore {
+    val prefs = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+    val resolver = context.contentResolver
+    val grantFlags = Intent.FLAG_GRANT_READ_URI_PERMISSION or Intent.FLAG_GRANT_WRITE_URI_PERMISSION
+    return SafVaultLocationStore(
+        readPref = { prefs.getString(KEY_LOCATION, null) },
+        writePref = { blob ->
+            val editor = prefs.edit()
+            if (blob == null) editor.remove(KEY_LOCATION) else editor.putString(KEY_LOCATION, blob)
+            editor.apply()
+        },
+        takePermission = { uri -> resolver.takePersistableUriPermission(Uri.parse(uri), grantFlags) },
+        hasPermission = { uri ->
+            val target = Uri.parse(uri)
+            resolver.persistedUriPermissions.any {
+                it.uri == target && it.isReadPermission && it.isWritePermission
+            }
+        },
+    )
+}
+
+private const val PREFS_NAME = "secretary.vault.location"
+private const val KEY_LOCATION = "location"
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd /Users/hherb/src/secretary/.worktrees/android-cloud-drive-locstore/android && ./gradlew :kit:testDebugUnitTest`
+Expected: PASS — all 7 `SafVaultLocationStoreTest` cases green. (The `safVaultLocationStore` factory is not exercised here; its Android calls run only on-device.)
+
+- [ ] **Step 5: Verify the whole module still builds and host suites are green**
+
+Run: `cd /Users/hherb/src/secretary/.worktrees/android-cloud-drive-locstore/android && ./gradlew :vault-access:test :kit:testDebugUnitTest`
+Expected: BUILD SUCCESSFUL — both host suites green (Task 1 + Task 2).
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd /Users/hherb/src/secretary/.worktrees/android-cloud-drive-locstore
+git add android/kit/src/main/kotlin/org/secretary/browse/SafVaultLocationStore.kt \
+        android/kit/src/test/kotlin/org/secretary/browse/SafVaultLocationStoreTest.kt
+git commit -m "feat(android): SafVaultLocationStore adapter + factory (:kit)"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage** (against the epic spec's Slice-2 row + brainstorm decisions):
+- `VaultLocationStore` pure port — Task 1. ✅
+- `SafVaultLocationStore` real adapter persisting tree URI + display name, `takePersistableUriPermission` — Task 2. ✅
+- iOS analogue (`BookmarkVaultLocationStore`) mirrored — both tasks. ✅
+- Brainstorm decision: value type = `{displayName, treeUri}`, no `vault_uuid` — Task 1. ✅
+- Brainstorm decision: `isAvailable` probe (not `beginAccess → path`) — Task 1 interface, Task 2 forwarding. ✅
+- Brainstorm decision: injected SAF seam + host-testable codec — Task 1 codec, Task 2 four-seam class. ✅
+- Spec testing row "location-store serialization (host)" — `VaultLocationCodecTest`. ✅
+- Spec error-handling "stale permission → Unavailable" surface — `isAvailable`. ✅
+- Instrumented coverage deferred to Slice 6 — documented in Global Constraints. ✅
+
+**Placeholder scan:** none — all code blocks are complete.
+
+**Type consistency:** `VaultLocation(displayName, treeUri)`, `encodeVaultLocation` / `decodeVaultLocation`, and the four seam signatures `(() -> String?, (String?) -> Unit, (String) -> Unit, (String) -> Boolean)` are identical across Task 1 (produced), Task 2 (consumed + tests), and the factory.


### PR DESCRIPTION
Slice **2 of 6** of the Android cloud-drive vault-provisioning epic (#321). Adds a `VaultLocationStore` that remembers ONE vault location (a SAF tree URI + display name), takes a durable persistable-URI permission, and reports whether that permission is still granted. Parity port of iOS `VaultLocation` / `VaultLocationStore` / `BookmarkVaultLocationStore`.

**Kotlin/Android only — no core `src/`, no FFI surface, no on-disk-format / spec / conformance / KAT change.**

## Pure layer (`:vault-access`, host-tested)
- `data class VaultLocation(displayName, treeUri)` — carries no secret (value-equal `data class`, unlike Slice-1's plain-class `CreatedVault`). No `vault_uuid` (unknown at persist time; `SyncState` keying is Slice 5).
- `interface VaultLocationStore { load; persist; clear; isAvailable }` — synchronous. **No `beginAccess → path`**: SAF has no real path until working-copy *materialize* (Slice 3/5), so the honest Slice-2 surface is an `isAvailable` boolean probe (the design's "stale permission → re-pick" path).
- `VaultLocationCodec` — `encodeVaultLocation` / `decodeVaultLocation`. Single atomic blob (one pref value → never half-persists; improves on iOS's two-key split), version-tagged + length-prefixed name (`"v1:<len>:<name><uri>"`, needs no escaping, may contain `:`). `decode` returns null on anything malformed (never throws), including an empty tree URI.

## Real adapter (`:kit`)
- `SafVaultLocationStore` — class body holds **zero Android types**: four String-based seams (`readPref`/`writePref`/`takePermission`/`hasPermission`), mirroring Slice-1's `createFn` seam, so all logic is host-testable with fakes. Android (`Context`/`Uri`/`ContentResolver.takePersistableUriPermission`/`persistedUriPermissions`) lives only in the `safVaultLocationStore(context)` factory. `persist` takes the SAF permission **before** writing the pref. Named constants (`PREFS_NAME`/`KEY_LOCATION`).

## Testing
- Host `:vault-access` `VaultLocationCodecTest` (10) + `:kit` `SafVaultLocationStoreTest` (7, incl. a genuinely-falsifiable take-permission-before-write ordering assertion).
- **No instrumented test this slice (deferred to Slice 6):** a real persistable *tree* URI needs driving the system SAF picker (UiAutomator), not automatable in a unit slice.

```
cd android
./gradlew :vault-access:test :kit:testDebugUnitTest   # both host suites green
```

## Reviews
Subagent-driven TDD (implementer → spec+quality review per task → whole-branch review). Per-task + final-review Minors all fixed or consciously kept (see handoff). Whole-branch review (opus): **Ready to merge: Yes**, no Critical/Important.

Baton: `docs/handoffs/2026-06-27-android-cloud-drive-slice2-location-store-shipped.md` (via `NEXT_SESSION.md` symlink).

🤖 Generated with [Claude Code](https://claude.com/claude-code)