### PR TITLE
docs: refresh developer manual to current state of development

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,14 +4,14 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## What this project is
 
-**Secretary** is a multi-platform, client-only secrets manager. The repository is currently in **Sub-project A** — the Rust cryptographic core and on-disk vault format. There is no usable application yet. The FFI bindings (Sub-project B), sync orchestration (Sub-project C), and platform UIs (Sub-project D) are downstream phases; their directories (`ffi/*`, `desktop/`, `ios/`, `android/`) currently hold stubs or README placeholders.
+**Secretary** is a multi-platform, client-only secrets manager. The Rust cryptographic core and on-disk vault format (**Sub-project A**) are feature-complete and frozen for v1, and all three downstream phases are substantially built on top of it: **Sub-project B** (FFI bindings — the `secretary-ffi-bridge` crate projected onto PyO3 + uniffi) is complete through B.6 v2 and beyond (device-slot ops, record-edit + block-CRUD primitives, sync surface); **Sub-project C** (sync orchestration) is complete through C.4; and **Sub-project D** (platform UIs) ships working apps — a Tauri 2 desktop client (`desktop/`), a native SwiftUI iOS app (`ios/`), and a native Jetpack Compose Android app (`android/`). See [README.md](README.md) "Project status" and [ROADMAP.md](ROADMAP.md) for the authoritative per-slice state. The Rust core remains the single source of truth for everything security-relevant; the platform code consumes it, never reimplements it.
 
 The cryptographic design and on-disk format are **frozen for v1** because vaults written today must remain readable by clients written decades from now. Treat anything in `docs/crypto-design.md`, `docs/vault-format.md`, and `docs/threat-model.md` as the source of truth — the Rust code implements those, not the other way around.
 
 ## Layout
 
 ```
-core/                Rust crate `secretary-core` — the only thing that matters today
+core/                Rust crate `secretary-core` — the security-critical source of truth
 core/src/{crypto,identity,unlock,vault}/   — module per spec section
 core/tests/          — integration tests; tests/data/ holds KATs and fuzz regressions
 core/tests/python/conformance.py           — clean-room verifier (generic crypto primitives via
@@ -19,8 +19,12 @@ core/tests/python/conformance.py           — clean-room verifier (generic cryp
                                              the spec is implementable from `docs/` alone
 core/fuzz/           — `cargo-fuzz` harness, EXCLUDED from the workspace; nightly toolchain
 docs/                — normative specs (see "Spec is normative" below)
-docs/adr/            — architecture decision records, numbered 0001..0006
-ffi/secretary-ffi-py, ffi/secretary-ffi-uniffi  — placeholder PyO3 / uniffi binding crates
+docs/adr/            — architecture decision records, numbered 0001..0010
+ffi/secretary-ffi-bridge                        — the single source of FFI code truth (pure-safe Rust)
+ffi/secretary-ffi-py, ffi/secretary-ffi-uniffi  — PyO3 / uniffi (Swift + Kotlin) binding crates over the bridge
+desktop/             — Tauri 2 desktop client (Rust backend + Svelte/TypeScript frontend)
+ios/                 — native SwiftUI app + Swift packages (SecretaryKit / SecretaryVaultAccess / SecretaryDeviceUnlock)
+android/             — native Jetpack Compose app + Gradle modules (:app, :kit, :vault-access, :sync-ui, :browse-ui)
 ```
 
 ## Working directory discipline

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ A *block* is the unit of both encryption and sharing. A block contains 1 or more
 | [docs/threat-model.md](docs/threat-model.md) | Adversaries, attacks, defenses, explicit non-goals |
 | [docs/crypto-design.md](docs/crypto-design.md) | Cryptographic constructions in spec-level detail |
 | [docs/vault-format.md](docs/vault-format.md) | Byte-level on-disk format (v1) |
-| [docs/adr/](docs/adr/) | Architecture decision records — six in total |
+| [docs/adr/](docs/adr/) | Architecture decision records — ten in total |
 
 **User and contributor manual** — informal companions to the specs.
 

--- a/core/tests/python/spec_freshness_allowlist.txt
+++ b/core/tests/python/spec_freshness_allowlist.txt
@@ -80,3 +80,28 @@ docs/manual/contributors/ffi-secret-handling-internal.md::uniffi_core
 
 # reason: upstream uniffi-generated RustBuffer-free scaffolding symbol, not a project symbol
 docs/manual/contributors/ffi-secret-handling-internal.md::uniffi_rustbuffer_free
+
+# --- contributor-index "Where the project is" FFI-surface citations. The
+# --- freshness check only scans core/; these bridge/uniffi-projected fns live
+# --- under ffi/, so they register as bare-unresolved when the index names them.
+
+# reason: ffi/secretary-ffi-uniffi/src/namespace/mod.rs::create_vault_in_folder — uniffi-projected fn, not in core/
+docs/manual/contributors/index.md::create_vault_in_folder
+
+# reason: ffi/secretary-ffi-uniffi/src/namespace/block_crud.rs::create_block — uniffi-projected fn, not in core/
+docs/manual/contributors/index.md::create_block
+
+# reason: ffi/secretary-ffi-uniffi/src/namespace/block_crud.rs::rename_block — uniffi-projected fn, not in core/
+docs/manual/contributors/index.md::rename_block
+
+# reason: ffi/secretary-ffi-uniffi/src/namespace/block_crud.rs::move_record — uniffi-projected fn, not in core/
+docs/manual/contributors/index.md::move_record
+
+# reason: ffi/secretary-ffi-uniffi/src/namespace/sync.rs::sync_status — uniffi-projected fn, not in core/
+docs/manual/contributors/index.md::sync_status
+
+# reason: ffi/secretary-ffi-uniffi/src/namespace/sync.rs::sync_vault — uniffi-projected fn, not in core/
+docs/manual/contributors/index.md::sync_vault
+
+# reason: ffi/secretary-ffi-uniffi/src/namespace/sync.rs::sync_commit_decisions — uniffi-projected fn, not in core/
+docs/manual/contributors/index.md::sync_commit_decisions

--- a/docs/manual/contributors/ffi-secret-handling-internal.md
+++ b/docs/manual/contributors/ffi-secret-handling-internal.md
@@ -417,14 +417,21 @@ for the full investigation record.
 
 ### Sub-project D platform concerns (carved out)
 
-When the platform UI (Sub-project D, currently in flight as the
-Tauri 2 desktop walking skeleton — ADR 0007 + `desktop/`) copies a
+When a platform UI (Sub-project D — now shipping real reveal/copy
+surfaces across the Tauri 2 desktop app, the native iOS app, and the
+native Android app; see [ADR 0007](../../adr/0007-d-row-tauri.md) +
+[ADR 0008](../../adr/0008-native-mobile-via-uniffi.md)) copies a
 secret to the system clipboard, that's a Sub-project D concern that
 the bridge cannot reach. The bridge gives the UI the **secret bytes**
 via `expose_text` / `expose_bytes`; what the UI does with them
 between read and clipboard-clear is Sub-project D's responsibility.
+The three UIs already implement reveal-on-demand with auto-hide,
+copy-with-auto-clear, and lock-on-background session wipe, but this
+memo is bridge-scoped — the consolidated cross-platform hygiene memo
+is still an outstanding contributor-doc gap (see
+[`index.md`](index.md) → "Where the project is").
 
-The Tauri 2 desktop scaffold's IPC layer (`desktop/src-tauri/src/`)
+The Tauri 2 desktop's IPC layer (`desktop/src-tauri/src/`)
 re-bridges through `secretary-ffi-py` for the live UI; the same
 `expose_*` discipline applies at every IPC `tauri::command` boundary
 that returns secret bytes. Contributors adding such commands should

--- a/docs/manual/contributors/index.md
+++ b/docs/manual/contributors/index.md
@@ -120,29 +120,67 @@ external track.
 ## Where the project is, vs. where the original memos were written
 
 The four audit memos were written in May 2026 against
-Sub-project A (Rust core) only. Since then:
+Sub-project A (Rust core) only. Since then (state as of 2026-07-01;
+[`ROADMAP.md`](../../../ROADMAP.md) and the README "Project status"
+table carry the authoritative per-slice detail):
 
-- **Sub-project B** (FFI bindings) — complete through B.6 v2. The
-  bridge crate + PyO3 + uniffi (Swift, Kotlin) expose unlock / open /
-  read / save / share / trash / restore. Cross-language conformance
-  KAT replays Rust ↔ Swift ↔ Kotlin parity. See
+- **Sub-project B** (FFI bindings) — complete through B.6 v2 and
+  extended well past it. The bridge crate + PyO3 + uniffi (Swift,
+  Kotlin) expose unlock / open / read / save / share / trash /
+  restore, plus the per-device wrap-slot ops (B.1 format + crypto,
+  B.2 FFI projection — `add_device_slot` / `open_with_device_secret`
+  / `remove_device_slot`, [ADR 0009](../../adr/0009-per-device-wrap-slot.md)),
+  the folder-writing `create_vault_in_folder`, the record-edit
+  primitives (`append` / `edit` / `tombstone` / `resurrect`), the
+  block-CRUD tier (`create_block` / `rename_block` / `move_record`),
+  and the sync surface (`sync_status` / `sync_vault` /
+  `sync_commit_decisions`, [#187](https://github.com/hherb/secretary/issues/187)).
+  Cross-language conformance KAT (27/27: 26 vectors + a device-secret
+  enrol round-trip) replays Rust ↔ Swift ↔ Kotlin parity. See
   [`ROADMAP.md`](../../../ROADMAP.md) → Sub-project B for the per-
   phase summary.
-- **Sub-project C** (sync orchestration) — C.1 (sync detection),
-  C.1.1a (conflict-copy ingestion), C.1.1b (merge layer), C.2 (the
-  headless `secretary-sync` CLI) all ✅ complete. C.3 (mobile
-  adapters) + C.4 (cross-device convergence conformance) pending.
-- **Sub-project D** (platform UIs) — pivoted to Tauri 2 per
-  [ADR 0007](../../adr/0007-d-row-tauri.md); D.1.1 (walking-skeleton
-  desktop client) in flight.
+- **Sub-project C** (sync orchestration) — **all four phases ✅
+  complete.** C.1 (sync detection), C.1.1a (conflict-copy ingestion),
+  C.1.1b (merge layer), C.2 (the headless `secretary-sync` CLI), C.3
+  (mobile adapters — the full iOS *and* Android sync stacks), and C.4
+  (cross-device convergence conformance, ✅ 2026-06-15 —
+  `core/tests/convergence.rs`, mirrored in the stdlib-only
+  clean-room `conformance.py`).
+- **Sub-project D** (platform UIs) — **far past the walking-skeleton
+  phase; the platform surface where most current work lands.** Desktop
+  is a single Tauri 2 codebase ([ADR 0007](../../adr/0007-d-row-tauri.md))
+  shipped through D.1.15 (unlock, browse, create, edit, delete/trash,
+  share/contacts, per-block + per-contact recipient views, revoke,
+  sync UI + interactive conflict resolution) plus a block-CRUD UI and
+  password re-auth before writes. Mobile stayed native over uniffi
+  ([ADR 0008](../../adr/0008-native-mobile-via-uniffi.md)): the **iOS**
+  app does Secure-Enclave/Face-ID device unlock (on-device proof ✅ on
+  an iPhone 13 Pro Max, [#202](https://github.com/hherb/secretary/issues/202)),
+  password/recovery unlock, vault selection, browse-with-reveal, record
+  + block CRUD, vault create/import, sync UI, and biometric write
+  re-auth; the **Android** app (Jetpack Compose) does password /
+  recovery / biometric-Keystore device unlock (on-device proof ✅ on an
+  NX809J), browse-with-reveal, record + block CRUD, sync-on-browse, and
+  a full cloud-drive working-copy lifecycle over Storage Access
+  Framework (instrumented-proven end-to-end, epic
+  [#321](https://github.com/hherb/secretary/issues/321)).
 
 The Rust core's *normative* behaviour is unchanged across these
 sub-projects (the spec is frozen for v1, see
 [`CLAUDE.md`](../../../CLAUDE.md) → "Spec is normative"). The memos'
 findings remain valid for the core; the FFI memo extends the
 discipline coverage to the bridge layer; sub-project C's sync code
-follows the established patterns; sub-project D's platform-UI hygiene
-will need its own memo when D matures past the walking-skeleton phase.
+follows the established patterns. **Sub-project D has now matured well
+past the walking-skeleton phase, so its platform-UI secret-hygiene
+concerns are live rather than hypothetical** — reveal-on-demand with
+auto-hide, copy-with-auto-clear, lock-on-background session wipe, and
+re-auth-before-write are already implemented across desktop / iOS /
+Android, but a consolidated platform-UI hygiene memo (clipboard
+lifetime, reveal lifetime, IPC-plaintext handling) covering all three
+platforms is the outstanding contributor-doc gap for this layer. Until
+it exists, the per-platform discipline is documented in the shipped
+UIs and the FFI memo's "Sub-project D platform concerns (carved out)"
+section is the closest standing reference.
 
 ## When updating these memos
 


### PR DESCRIPTION
## Why

The contributor-facing developer manual's project-state summary had drifted far behind the code. Its "Where the project is" section still described Sub-project C's mobile adapters (C.3) and cross-device convergence (C.4) as *pending* and Sub-project D as a *walking skeleton in flight* — when in fact C is complete through C.4 and D ships working desktop, iOS, and Android apps. The most-read orientation doc (`CLAUDE.md`) still opened with "the repository is currently in Sub-project A … there is no usable application yet … directories hold stubs or placeholders."

## What changed

- **`docs/manual/contributors/index.md`** — rewrote the "Where the project is, vs. where the original memos were written" section:
  - **Sub-project B**: complete through B.6 v2 *and beyond* — per-device wrap-slot ops (ADR 0009), folder-writing `create_vault_in_folder`, record-edit + block-CRUD primitives, and the sync surface (#187). Conformance KAT now 27/27.
  - **Sub-project C**: all four phases ✅ complete (C.3 iOS + Android stacks; C.4 cross-device convergence, 2026-06-15) — was "C.3/C.4 pending".
  - **Sub-project D**: far past the walking skeleton — desktop through D.1.15 + block-CRUD UI + write re-auth; native iOS app (SE/Face ID device unlock, unlock/browse/CRUD/create/import/sync); native Android app (biometric-Keystore unlock, browse/CRUD/sync, full SAF cloud-drive lifecycle).
  - Reframed the closing note: the platform-UI hygiene concern is now *live* (reveal/copy UIs shipped on all three platforms), and a consolidated cross-platform hygiene memo is the outstanding contributor-doc gap.
- **`docs/manual/contributors/ffi-secret-handling-internal.md`** — corrected the stale "Sub-project D currently in flight as the Tauri 2 desktop walking skeleton" claim; the reveal/copy surfaces now ship across desktop / iOS / Android.
- **`CLAUDE.md`** — fixed the stale opening ("currently in Sub-project A / no usable application yet / stubs or placeholders") and the Layout block (ADR count `0001..0010`, added the `secretary-ffi-bridge` crate and the real `desktop/` / `ios/` / `android/` directories). The rest of `CLAUDE.md` was already current.
- **`README.md`** — ADR count "six in total" → "ten in total".
- **`core/tests/python/spec_freshness_allowlist.txt`** — allowlisted the seven new FFI-surface symbol citations added to the index (bridge/uniffi fns that live under `ffi/`, not `core/`, so the freshness check flags them), matching the existing FFI-memo entries.

## Verification

`uv run core/tests/python/spec_test_name_freshness.py` returns to the same 3 pre-existing unresolved citations that already fail on `main` (browser-autofill terms in `docs/threat-model.md`, unrelated to this change) — the seven citations added here are fully allowlisted, so this change does not worsen the check.

Docs-only; no code, on-disk format, or crypto change.

## Notes / not done

- The **ROADMAP.md** header still reads `## Where we are: 2026-06-14` while its body runs to ~2026-06-28; I left it untouched because bumping only the date would overstate the body. Refreshing ROADMAP's body is a larger, separate pass.
- The 3 pre-existing `threat-model.md` freshness failures (ADR 0010 origin-matching concepts) are out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FEmA3RNUN47Na36b6vt1gN)_