### PR TITLE
fix(ios): make runOffMainActor's result handoff TSan-visible (flaky iOS TSan failure on PR #372)

### DIFF
--- a/ios/SecretaryKit/Sources/SecretaryKit/VaultAccess/RunOffMainActor.swift
+++ b/ios/SecretaryKit/Sources/SecretaryKit/VaultAccess/RunOffMainActor.swift
@@ -1,24 +1,32 @@
-import Foundation
-
 /// Run a synchronous, CPU-bound (Argon2id) throwing closure off the calling
-/// actor on a user-initiated global queue, *suspending* the caller rather than
+/// actor on the global concurrent executor, *suspending* the caller rather than
 /// blocking it. Used by the real vault open/create adapters so a `@MainActor`
 /// caller's UI stays responsive during the KDF.
 ///
-/// Implemented with `withCheckedThrowingContinuation` (not `Task.detached`) on
-/// purpose: `Task<Success, _>` constrains `Success: Sendable`, but the open
-/// adapter returns `any VaultSession` (a non-`Sendable` `AnyObject`), which would
-/// emit a Swift-5.9 Sendable warning. `CheckedContinuation`'s result type is
-/// unconstrained, so the freshly-built session transfers back across the
-/// suspension cleanly. (The create adapter returns the `Sendable` `CreatedVault`
-/// and shares this helper purely for consistency.) `work` is `@Sendable` and
-/// captures only `Sendable` inputs (`Data` / `[UInt8]` / `URL` / `String`);
-/// neither adapter captures `self`.
-func runOffMainActor<T>(_ work: @escaping @Sendable () throws -> T) async throws -> T {
-    try await withCheckedThrowingContinuation { continuation in
-        DispatchQueue.global(qos: .userInitiated).async {
-            do { continuation.resume(returning: try work()) }
-            catch { continuation.resume(throwing: error) }
-        }
-    }
+/// Implemented as a `nonisolated` async function on purpose: per SE-0338 it
+/// hops off the caller's actor onto the global concurrent executor, runs `work`
+/// there, and hops back at the return. The `sending` result is what lets the
+/// non-`Sendable` return (`any VaultSession`, a non-`Sendable` `AnyObject`)
+/// transfer back across the isolation boundary — `Task.detached` would
+/// constrain `Success: Sendable`, and `work` being `@Sendable` means its fresh
+/// result is always in a disconnected region, so the transfer is safe. (The
+/// create adapter returns the `Sendable` `CreatedVault` and shares this helper
+/// purely for consistency.) `work` captures only `Sendable` inputs (`Data` /
+/// `[UInt8]` / `URL` / `String`); neither adapter captures `self`.
+///
+/// This replaced a `withCheckedThrowingContinuation` +
+/// `DispatchQueue.global().async` implementation: ThreadSanitizer does not
+/// model the happens-before edge that `continuation.resume` establishes between
+/// a GCD worker and the resumed task (a known TSan/Swift-concurrency
+/// instrumentation gap), so the returned value was flakily reported as a data
+/// race by the iOS TSan CI job. Plain executor hops are ordinary
+/// TSan-intercepted dispatch enqueues, so this shape carries a visible edge.
+/// The handoff was always correctly synchronized; only TSan's view changed.
+///
+/// If this package ever adopts Swift 6.2's `NonisolatedNonsendingByDefault`
+/// upcoming feature, nonisolated async functions run on the *caller's* actor by
+/// default — this helper must then be marked `@concurrent` to keep the KDF off
+/// the main actor.
+nonisolated func runOffMainActor<T>(_ work: @Sendable () throws -> T) async throws -> sending T {
+    try work()
 }

--- a/ios/SecretaryKit/Tests/SecretaryKitTests/RunOffMainActorTests.swift
+++ b/ios/SecretaryKit/Tests/SecretaryKitTests/RunOffMainActorTests.swift
@@ -5,8 +5,9 @@ import XCTest
 /// of the FFI integration paths that also use it.
 final class RunOffMainActorTests: XCTestCase {
     /// A non-`Sendable` reference type — proves the helper transfers such a return
-    /// back across the suspension (the reason it uses `CheckedContinuation`
-    /// instead of `Task.detached`, whose `Success` must be `Sendable`).
+    /// back across the suspension (the reason it returns `sending T` from a
+    /// `nonisolated` async function instead of using `Task.detached`, whose
+    /// `Success` must be `Sendable`).
     private final class Box {
         let value: Int
         init(_ value: Int) { self.value = value }


### PR DESCRIPTION
## Summary

The **SecretaryKit ThreadSanitizer** CI job failed on PR #372 with a data race in `RunOffMainActorTests.testReturnsNonSendableValue` — even though that PR doesn't touch this code. The race report is on the `runOffMainActor` helper's result handoff: the value is written on the GCD worker inside the dispatched block (thread T2) and read after `continuation.resume` in the resumed task (thread T4). The handoff was **correctly synchronized** (`continuation.resume` establishes a real happens-before edge via the concurrency runtime), but ThreadSanitizer does not model that edge when the resume comes from a raw GCD thread — a known TSan / Swift-concurrency instrumentation gap — so the report is a false positive that any `ios/**` PR could flake on.

## What changed

`ios/SecretaryKit/Sources/SecretaryKit/VaultAccess/RunOffMainActor.swift` — replaced the `withCheckedThrowingContinuation` + `DispatchQueue.global(qos: .userInitiated).async` implementation with a `nonisolated` async function returning `sending T`:

```swift
nonisolated func runOffMainActor<T>(_ work: @Sendable () throws -> T) async throws -> sending T {
    try work()
}
```

- Per SE-0338, the nonisolated async function hops off the caller's actor onto the global concurrent executor, so a `@MainActor` caller still suspends (UI stays responsive during Argon2id) exactly as before.
- The `sending` result carries the non-`Sendable` return (`any VaultSession`) back across the isolation boundary — the constraint that originally motivated the continuation, since `Task.detached` requires `Success: Sendable`.
- Executor hops are ordinary TSan-intercepted dispatch enqueues, so the handoff edge is now natively visible to the checker instead of relying on runtime annotations it misses. No suppression, no weakening of the TSan gate.
- No call-site changes (all six adapter call sites in `UniffiVaultOpenPort` / `UniffiVaultCreatePort` / `UniffiVaultSyncPort` compile unchanged); test doc comment updated to describe the new design.
- A future-proofing note is documented in the helper: if the package ever adopts Swift 6.2's `NonisolatedNonsendingByDefault`, this helper must be marked `@concurrent`.

Deliberately **not** touched: the inlined copy of the old pattern in `ios/SecretaryApp/Sources/SecretaryApp.swift` (device-enroll offload). It only passes `Void` across the handoff (nothing non-`Sendable` to race on), the app target isn't part of the TSan-instrumented SecretaryKit suite, and PR #372 rewrites that exact region — touching it here would just create merge conflicts.

## Relation to PR #372

PR #372's TSan failure is unrelated to its diff. Once this lands on `main`, re-running that PR's `SecretaryKit ThreadSanitizer` check (or rebasing it) should clear it — and the flake is removed for every future `ios/**` PR.

## Testing

- No Swift toolchain in this environment; the path-gated **iOS TSan** workflow runs the full SecretaryKit suite under `-enableThreadSanitizer` on this PR (it triggers on `ios/**` changes) and is the acceptance gate, along with the `swift conformance` job for compile coverage.
- iOS-only; no Rust / FFI / on-disk-format / spec change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HfXNvFSH3fFSKQqHvDXQnx

---
_Generated by [Claude Code](https://claude.ai/code/session_01HfXNvFSH3fFSKQqHvDXQnx)_