### PR TITLE
refactor(core): extract shared manifest re-sign + owner-secret-rewrap helper (#377)

### DIFF
--- a/core/src/vault/orchestrators.rs
+++ b/core/src/vault/orchestrators.rs
@@ -920,6 +920,81 @@ pub(crate) fn tick_clock(
     Ok(())
 }
 
+/// Re-sign the manifest with the owner's hybrid signing keys and
+/// atomically write it — the single source of truth for the
+/// security-sensitive re-sign tail shared by [`save_block`],
+/// [`trash_block`], [`restore_block`], and
+/// [`crate::vault::repair_vault`] (#377).
+///
+/// The sequence, in order:
+/// 1. Rebuild the manifest [`ManifestHeader`] preserving `vault_uuid` and
+///    `created_at_ms` from `prev_header`; only `last_mod_ms` advances.
+/// 2. Re-wrap the owner Ed25519 secret into a fresh [`Sensitive`] holder
+///    and **zeroize the intermediate stack copy** (the move over `[u8; 32]`
+///    copies — see CLAUDE.md "Memory hygiene: zeroize discipline").
+/// 3. Rebuild the ML-DSA-65 secret, draw a **fresh** AEAD nonce, and
+///    hybrid-sign (`sign_manifest` emits both halves of the §8 signature).
+/// 4. Encode and [`io::write_atomic`] the manifest under `io_context`.
+///
+/// Returns the freshly-signed [`ManifestFile`]; the caller swaps it into
+/// its in-memory `OpenVault.manifest_file` envelope.
+///
+/// # Security invariant
+///
+/// A change to nonce generation, the Ed25519 stack-copy zeroize, the §8
+/// hybrid-signature construction, or the atomic-write must land **here**
+/// so every mutating orchestrator inherits it in lockstep. A fix applied
+/// at only one former call site would silently leave the others weaker —
+/// that divergence risk is exactly why this was extracted (#377).
+// The manifest re-sign inputs (folder, body, owner identity, IBK, prior
+// header, timestamp, author fingerprint, rng, error context) are inherent
+// to the operation; bundling them into a struct would only relocate the
+// argument list without reducing it.
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn resign_and_write_manifest(
+    folder: &Path,
+    manifest: &Manifest,
+    identity: &IdentityBundle,
+    ibk: &aead::AeadKey,
+    prev_header: &ManifestHeader,
+    last_mod_ms: u64,
+    author_fingerprint: Fingerprint,
+    rng: &mut (impl RngCore + CryptoRng),
+    io_context: &'static str,
+) -> Result<ManifestFile, VaultError> {
+    // Preserve the on-disk envelope's vault_uuid + created_at_ms; only
+    // last_mod_ms moves forward.
+    let new_header = ManifestHeader {
+        vault_uuid: prev_header.vault_uuid,
+        created_at_ms: prev_header.created_at_ms,
+        last_mod_ms,
+    };
+
+    // Re-wrap the owner Ed25519 secret and zeroize the stack copy.
+    let mut ed_sk_bytes = *identity.ed25519_sk.expose();
+    let owner_ed_sk: Ed25519Secret = Sensitive::new(ed_sk_bytes);
+    ed_sk_bytes.zeroize();
+    let owner_pq_sk = MlDsa65Secret::from_bytes(identity.ml_dsa_65_sk.expose())?;
+
+    let aead_nonce = aead::random_nonce(rng);
+    let new_manifest_file = manifest::sign_manifest(
+        new_header,
+        manifest,
+        ibk,
+        &aead_nonce,
+        author_fingerprint,
+        &owner_ed_sk,
+        &owner_pq_sk,
+    )?;
+    let manifest_bytes = manifest::encode_manifest_file(&new_manifest_file)?;
+    let manifest_path = folder.join(MANIFEST_FILENAME);
+    io::write_atomic(&manifest_path, &manifest_bytes).map_err(|e| VaultError::Io {
+        context: io_context,
+        source: e,
+    })?;
+    Ok(new_manifest_file)
+}
+
 /// Encrypt and persist a new (or updated) block in the vault.
 ///
 /// Updates the in-memory `OpenVault.manifest` and `OpenVault.manifest_file`,
@@ -1102,37 +1177,24 @@ pub fn save_block(
     // Step 10: tick the manifest-level (vault-level) vector clock.
     tick_clock(&mut open.manifest.vector_clock, &device_uuid)?;
 
-    // Step 11: refresh the manifest header — vault_uuid and created_at_ms
-    // are preserved from the existing on-disk envelope; only last_mod_ms
-    // moves forward.
-    let new_header = ManifestHeader {
-        vault_uuid: open.manifest_file.header.vault_uuid,
-        created_at_ms: open.manifest_file.header.created_at_ms,
-        last_mod_ms: now_ms,
-    };
-
-    // Step 12: fresh AEAD nonce + re-sign the manifest. `sign_manifest`
-    // canonical-encodes the body, AEAD-encrypts with the IBK (header AAD),
-    // and produces both halves of the §8 hybrid signature.
-    let aead_nonce = aead::random_nonce(rng);
-    let new_manifest_file = manifest::sign_manifest(
-        new_header,
+    // Steps 11-13: refresh the manifest header (vault_uuid + created_at_ms
+    // preserved; last_mod_ms advances), draw a fresh AEAD nonce, hybrid-sign
+    // over the updated body, and atomic-write — the shared re-sign tail
+    // (#377). Block-first-then-manifest ordering is preserved by step 7 →
+    // this write. The owner keys are re-wrapped from `open.identity` inside
+    // the helper; the `owner_ed_sk` bound above for `encrypt_block` is not
+    // reused here.
+    let new_manifest_file = resign_and_write_manifest(
+        folder,
         &open.manifest,
+        &open.identity,
         &open.identity_block_key,
-        &aead_nonce,
+        &open.manifest_file.header,
+        now_ms,
         owner_fp,
-        &owner_ed_sk,
-        &owner_pq_sk,
+        rng,
+        "failed to write manifest.cbor.enc",
     )?;
-    let manifest_bytes = manifest::encode_manifest_file(&new_manifest_file)?;
-
-    // Step 13: atomic-write the manifest. Block-first-then-manifest
-    // ordering is preserved by step 7 → step 13.
-    let manifest_path = folder.join(MANIFEST_FILENAME);
-    io::write_atomic(&manifest_path, &manifest_bytes).map_err(|e| VaultError::Io {
-        context: "failed to write manifest.cbor.enc",
-        source: e,
-    })?;
 
     // Step 14: refresh the in-memory manifest envelope so subsequent
     // saves chain off the new clock and the new author signature.
@@ -2045,35 +2107,19 @@ pub fn trash_block(
 
     // Step 4: refresh manifest header → fresh AEAD nonce → re-sign (over
     // `&staged`, not `&open.manifest`) → atomic-write. **Commit point.**
-    // Mirrors `save_block` steps 11-13. Owner secret keys are re-wrapped
-    // from the bundle's raw seeds into the typed Ed25519Secret /
-    // MlDsa65Secret holders that `sign_manifest` expects; the
-    // intermediate stack copy is zeroized before sign.
-    let new_header = ManifestHeader {
-        vault_uuid: open.manifest_file.header.vault_uuid,
-        created_at_ms: open.manifest_file.header.created_at_ms,
-        last_mod_ms: now_ms,
-    };
-    let mut ed_sk_bytes = *open.identity.ed25519_sk.expose();
-    let owner_ed_sk: Ed25519Secret = Sensitive::new(ed_sk_bytes);
-    ed_sk_bytes.zeroize();
-    let owner_pq_sk = MlDsa65Secret::from_bytes(open.identity.ml_dsa_65_sk.expose())?;
-    let aead_nonce = aead::random_nonce(rng);
-    let new_manifest_file = manifest::sign_manifest(
-        new_header,
+    // Shared re-sign tail (#377): the helper re-wraps the owner secret keys
+    // from `open.identity` and zeroizes the intermediate stack copy.
+    let new_manifest_file = resign_and_write_manifest(
+        folder,
         &staged,
+        &open.identity,
         &open.identity_block_key,
-        &aead_nonce,
+        &open.manifest_file.header,
+        now_ms,
         open.manifest_file.author_fingerprint,
-        &owner_ed_sk,
-        &owner_pq_sk,
+        rng,
+        "trash_block: failed to write manifest.cbor.enc",
     )?;
-    let manifest_bytes = manifest::encode_manifest_file(&new_manifest_file)?;
-    let manifest_path = folder.join(MANIFEST_FILENAME);
-    io::write_atomic(&manifest_path, &manifest_bytes).map_err(|e| VaultError::Io {
-        context: "trash_block: failed to write manifest.cbor.enc",
-        source: e,
-    })?;
 
     // Step 5: swap the staged state into `open`. From here the trash has
     // happened; nothing below may fail the call.
@@ -2523,32 +2569,18 @@ pub fn restore_block(
     tick_clock(&mut open.manifest.vector_clock, &device_uuid)?;
 
     // Step 11: re-sign manifest with fresh AEAD nonce + atomic-write.
-    // Mirrors trash_block / save_block.
-    let new_header = ManifestHeader {
-        vault_uuid: open.manifest_file.header.vault_uuid,
-        created_at_ms: open.manifest_file.header.created_at_ms,
-        last_mod_ms: now_ms,
-    };
-    let mut ed_sk_bytes = *open.identity.ed25519_sk.expose();
-    let owner_ed_sk: Ed25519Secret = Sensitive::new(ed_sk_bytes);
-    ed_sk_bytes.zeroize();
-    let owner_pq_sk = MlDsa65Secret::from_bytes(open.identity.ml_dsa_65_sk.expose())?;
-    let aead_nonce = aead::random_nonce(rng);
-    let new_manifest_file = manifest::sign_manifest(
-        new_header,
+    // Shared re-sign tail (#377); mirrors trash_block / save_block.
+    let new_manifest_file = resign_and_write_manifest(
+        folder,
         &open.manifest,
+        &open.identity,
         &open.identity_block_key,
-        &aead_nonce,
+        &open.manifest_file.header,
+        now_ms,
         open.manifest_file.author_fingerprint,
-        &owner_ed_sk,
-        &owner_pq_sk,
+        rng,
+        "restore_block: failed to write manifest.cbor.enc",
     )?;
-    let manifest_bytes = manifest::encode_manifest_file(&new_manifest_file)?;
-    let manifest_path = folder.join(MANIFEST_FILENAME);
-    io::write_atomic(&manifest_path, &manifest_bytes).map_err(|e| VaultError::Io {
-        context: "restore_block: failed to write manifest.cbor.enc",
-        source: e,
-    })?;
 
     // Step 12: refresh in-memory envelope.
     open.manifest_file = new_manifest_file;

--- a/core/src/vault/repair.rs
+++ b/core/src/vault/repair.rs
@@ -13,21 +13,20 @@ use rand_core::{CryptoRng, RngCore};
 
 use zeroize::Zeroize as _;
 
-use crate::crypto::aead;
 use crate::crypto::hash::hash as blake3_hash;
 use crate::crypto::kem::{self, MlKem768Secret};
 use crate::crypto::secret::Sensitive;
-use crate::crypto::sig::{Ed25519Secret, MlDsa65Public, MlDsa65Secret};
+use crate::crypto::sig::MlDsa65Public;
 use crate::identity::fingerprint::fingerprint;
 
+use super::block;
 use super::conflict::{clock_relation, ClockRelation};
-use super::manifest::{self, BlockEntry, Manifest, ManifestHeader};
+use super::manifest::{BlockEntry, Manifest};
 use super::orchestrators::{
-    format_uuid_hyphenated, read_and_verify_manifest, resolve_recipient_uuids, tick_clock,
-    unlock_vault_identity, OpenVault, Unlocker, BLOCKS_SUBDIR, BLOCK_FILE_EXTENSION,
-    MANIFEST_FILENAME, TRASH_SUBDIR,
+    format_uuid_hyphenated, read_and_verify_manifest, resign_and_write_manifest,
+    resolve_recipient_uuids, tick_clock, unlock_vault_identity, OpenVault, Unlocker, BLOCKS_SUBDIR,
+    BLOCK_FILE_EXTENSION, TRASH_SUBDIR,
 };
-use super::{block, io};
 use super::{VaultError, VectorClockEntry};
 
 /// Best-effort completion of trash renames interrupted between
@@ -397,33 +396,21 @@ pub fn repair_vault(
     }
     tick_clock(&mut manifest.vector_clock, &device_uuid)?;
 
-    // Re-sign + atomic-write — same key-rewrap shape as trash_block
-    // step 7 (zeroize the ed25519 stack copy).
-    let new_header = ManifestHeader {
-        vault_uuid: manifest_file.header.vault_uuid,
-        created_at_ms: manifest_file.header.created_at_ms,
-        last_mod_ms: now_ms,
-    };
-    let mut ed_sk_bytes = *unlocked.identity.ed25519_sk.expose();
-    let owner_ed_sk: Ed25519Secret = Sensitive::new(ed_sk_bytes);
-    ed_sk_bytes.zeroize();
-    let owner_pq_sk = MlDsa65Secret::from_bytes(unlocked.identity.ml_dsa_65_sk.expose())?;
-    let aead_nonce = aead::random_nonce(rng);
-    let new_manifest_file = manifest::sign_manifest(
-        new_header,
+    // Re-sign + atomic-write — the shared re-sign tail (#377): re-wrap the
+    // owner Ed25519 secret + zeroize the stack copy, fresh AEAD nonce,
+    // hybrid-sign, atomic-write. Same manifest verify-before-decrypt open
+    // guarantees the rewritten envelope.
+    let new_manifest_file = resign_and_write_manifest(
+        folder,
         &manifest,
+        &unlocked.identity,
         &unlocked.identity_block_key,
-        &aead_nonce,
+        &manifest_file.header,
+        now_ms,
         manifest_file.author_fingerprint,
-        &owner_ed_sk,
-        &owner_pq_sk,
+        rng,
+        "repair_vault: failed to write manifest.cbor.enc",
     )?;
-    let manifest_bytes = manifest::encode_manifest_file(&new_manifest_file)?;
-    let manifest_path = folder.join(MANIFEST_FILENAME);
-    io::write_atomic(&manifest_path, &manifest_bytes).map_err(|e| VaultError::Io {
-        context: "repair_vault: failed to write manifest.cbor.enc",
-        source: e,
-    })?;
 
     complete_pending_trash_renames(folder, &manifest);
     Ok(OpenVault {


### PR DESCRIPTION
Closes #377.

## Problem

The manifest re-sign tail — build `ManifestHeader` → re-wrap the owner Ed25519 secret into a `Sensitive` holder + `zeroize()` the stack copy → `MlDsa65Secret::from_bytes` → fresh `aead::random_nonce` → `sign_manifest` → `encode_manifest_file` → `io::write_atomic` — was copy-pasted across four orchestrator sites:

- `core/src/vault/orchestrators.rs::save_block`
- `core/src/vault/orchestrators.rs::trash_block`
- `core/src/vault/orchestrators.rs::restore_block`
- `core/src/vault/repair.rs::repair_vault`

This is a **security-sensitive** path: it touches owner signing-key material and the `Sensitive::new(x); x.zeroize()` stack-residue discipline (CLAUDE.md "Memory hygiene: zeroize discipline"). A future fix landing at only one site — a missed `ml_dsa_65_sk` zeroize, a nonce-generation change, a write-ordering fix — silently leaves the other sites weaker. A divergence here is a security regression, not a cosmetic one.

## Change

Extract `pub(crate) fn resign_and_write_manifest(folder, manifest, identity, ibk, prev_header, last_mod_ms, author_fingerprint, rng, io_context)` as the single source of truth for the re-sign tail, and route all four call sites through it. The helper carries a `# Security invariant` doc block stating that any change to nonce generation, the Ed25519 stack-copy zeroize, the §8 hybrid-signature construction, or the atomic-write must land there so every mutating orchestrator inherits it in lockstep.

Each call site keeps its own `io_context` error string and its own `author_fingerprint` source (`save_block` passes the freshly-computed owner fingerprint; the others pass `manifest_file.author_fingerprint`). Behaviour is preserved — the header is rebuilt with the same field-preservation rule (`vault_uuid` + `created_at_ms` preserved, only `last_mod_ms` advances), the same rewrap+zeroize, the same fresh nonce, and the same block-first-then-manifest ordering.

`rewrite_block_with_recipients` (share/revoke) is intentionally **not** folded in: it signs with pre-wrapped author keys passed as parameters rather than re-wrapping from the identity bundle, so it does not share this tail's shape.

## Verification

- `cargo build --release -p secretary-core` — clean
- `cargo clippy --release -p secretary-core --tests -- -D warnings` — clean (the helper carries a justified `#[allow(clippy::too_many_arguments)]`, matching the crate's existing pattern for inherent-input signing functions)
- `cargo test --release -p secretary-core` — 330 lib tests + all integration suites green. Two `trash_restore` tests that force a write/rename failure via `chmod 0o555` fail **only** because this CI runs as root (root bypasses the DAC read-only bit); they fail identically on the unmodified base commit and are unrelated to this change.
- `uv run core/tests/python/conformance.py` — **PASS** (confirms no on-disk byte-format or merge-semantics drift; this is a behaviour-preserving refactor)
- `cargo fmt` — the two touched files are clean

Desktop/Tauri clippy was not run here (the environment lacks `gdk-3.0`); this change is core-only and does not touch `ffi/`, the on-disk format, KATs, or conformance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KbSLh3stgDa1NUyZJtx31a)_