### PR TITLE
Security tech debt: split desktop create/unlock path approvals (#378) + surface lingering trashed ciphertext (#376)

### DIFF
--- a/desktop/src-tauri/src/commands/create.rs
+++ b/desktop/src-tauri/src/commands/create.rs
@@ -68,10 +68,13 @@ pub fn create_vault_impl(
     rng: &mut (impl RngCore + CryptoRng),
 ) -> Result<CreateVaultDto, AppError> {
     let folder = Path::new(folder_path);
-    // #353: the target must be the approved vault folder or a subfolder of it.
+    // #353/#378: the target must be the folder the user picked FOR CREATION
+    // (via `pick_create_folder` → the `CreateParent` slot) or a subfolder of
+    // it. Deliberately not the `VaultFolder` slot: an unlock pick must never
+    // authorize a create.
     {
         let session = lock_session(state)?;
-        if !session.is_path_approved(PathPurpose::VaultFolder, folder, MatchMode::Containment) {
+        if !session.is_path_approved(PathPurpose::CreateParent, folder, MatchMode::Containment) {
             return Err(AppError::PathNotApproved {
                 path: folder_path.to_string(),
             });
@@ -109,15 +112,16 @@ pub fn create_vault_impl(
         }
     })?;
 
-    // #353: bind the just-created folder as the approved VaultFolder so the
-    // follow-on unlock passes its `Exact`-match gate. The create wizard
-    // auto-navigates to Unlock pre-filled with THIS path; when the user created
-    // inside a typed *subfolder* of the picked folder, the slot still held the
-    // parent, so an `Exact` unlock of the subfolder would fail `PathNotApproved`.
-    // Re-approving the created folder also NARROWS the slot from the picked
-    // parent to the actual vault (least-privilege) until the session locks.
-    // `folder` now exists (create succeeded) and the top-of-fn Containment gate
-    // already proved it canonicalizes, so `Some` is guaranteed here.
+    // #353/#378: bind the just-created folder as the approved VaultFolder so
+    // the follow-on unlock passes its `Exact`-match gate. The create wizard
+    // auto-navigates to Unlock pre-filled with THIS path; since #378 the
+    // create pick lives in the separate `CreateParent` slot, so without this
+    // backend-initiated approval the `Exact` unlock of the created folder
+    // would fail `PathNotApproved`. Approving exactly the created vault (not
+    // the picked parent) keeps the unlock slot least-privilege until the
+    // session locks. `folder` now exists (create succeeded) and the
+    // top-of-fn Containment gate already proved it canonicalizes, so `Some`
+    // is guaranteed here.
     if let Some(canonical) = canonicalize_for_auth(folder) {
         lock_session(state)?.approve_path(PathPurpose::VaultFolder, canonical);
     }
@@ -145,10 +149,11 @@ pub fn probe_create_target_impl(
     folder_path: &str,
 ) -> Result<CreateTargetProbeDto, AppError> {
     let folder = Path::new(folder_path);
-    // #353: only probe a path the user picked (or a subfolder of it).
+    // #353/#378: only probe a path the user picked for creation (or a
+    // subfolder of it). Same `CreateParent` gate as `create_vault_impl`.
     {
         let session = lock_session(state)?;
-        if !session.is_path_approved(PathPurpose::VaultFolder, folder, MatchMode::Containment) {
+        if !session.is_path_approved(PathPurpose::CreateParent, folder, MatchMode::Containment) {
             return Err(AppError::PathNotApproved {
                 path: folder_path.to_string(),
             });
@@ -198,11 +203,49 @@ mod tests {
         let temp = tempdir().unwrap();
         let state = Mutex::new(VaultSession::new(std::env::temp_dir()));
         state.lock().unwrap().approve_path(
-            PathPurpose::VaultFolder,
+            PathPurpose::CreateParent,
             canonicalize_for_auth(temp.path()).unwrap(),
         );
         let dto = probe_create_target_impl(&state, temp.path().to_str().unwrap()).unwrap();
         assert!(dto.exists && dto.is_empty);
+    }
+
+    /// #378 regression: an *unlock* pick (`VaultFolder` slot) must not
+    /// authorize create/probe — they consult the `CreateParent` slot only.
+    #[test]
+    fn unlock_approval_does_not_authorize_create_or_probe() {
+        let temp = tempdir().unwrap();
+        let target = temp.path().join("sub-vault");
+        let state = Mutex::new(VaultSession::new(std::env::temp_dir()));
+        state.lock().unwrap().approve_path(
+            PathPurpose::VaultFolder,
+            canonicalize_for_auth(temp.path()).unwrap(),
+        );
+
+        let err = probe_create_target_impl(&state, target.to_str().unwrap())
+            .expect_err("probe must not ride an unlock approval");
+        assert!(
+            matches!(err, AppError::PathNotApproved { .. }),
+            "got {err:?}"
+        );
+
+        let err = create_vault_impl(
+            &state,
+            target.to_str().unwrap(),
+            "My Vault",
+            &secretary_core::crypto::secret::SecretBytes::from(any_password().to_vec()),
+            0,
+            &mut rand_core::OsRng,
+        )
+        .expect_err("create must not ride an unlock approval");
+        assert!(
+            matches!(err, AppError::PathNotApproved { .. }),
+            "got {err:?}"
+        );
+        assert!(
+            !target.exists(),
+            "must not create the folder for an unapproved path"
+        );
     }
 
     #[test]
@@ -244,7 +287,7 @@ mod tests {
 
         let state = Mutex::new(VaultSession::new(std::env::temp_dir()));
         state.lock().unwrap().approve_path(
-            PathPurpose::VaultFolder,
+            PathPurpose::CreateParent,
             canonicalize_for_auth(parent.path()).unwrap(),
         );
 

--- a/desktop/src-tauri/src/commands/delete.rs
+++ b/desktop/src-tauri/src/commands/delete.rs
@@ -14,6 +14,7 @@
 //!   routes the trash-precondition variants (`BlockUuidAlreadyLive` →
 //!   `BlockRestoreConflict`, `BlockNotInTrash` → `TrashEntryNotFound`).
 
+use std::path::{Path, PathBuf};
 use std::sync::Mutex;
 
 use tauri::State;
@@ -142,8 +143,44 @@ pub fn trash_block_impl(state: &Mutex<VaultSession>, block_uuid_hex: &str) -> Re
             now_ms(),
         )
         .map_err(map_ffi_error)?;
+        // #376 operator signal: core `trash_block` is manifest-first — the
+        // physical `blocks/ → trash/` rename is best-effort and ALL its
+        // failures (EXDEV cross-filesystem trash dir, permissions) are
+        // swallowed inside core, so a "deleted" secret's ciphertext can
+        // linger in `blocks/`, still wrapped to its recipients, with no
+        // indication anywhere. Surface that state here, where a logging
+        // runtime exists.
+        if let Some(residue) = lingering_trash_residue(&u.vault_folder, &block_uuid) {
+            tracing::warn!(
+                path = %residue.display(),
+                "trashed block ciphertext is still resident in blocks/: the \
+                 best-effort rename to trash/ failed (cross-filesystem trash \
+                 dir or permissions); the secret remains decryptable on disk \
+                 until an open-time sweep, a restore, or manual relocation \
+                 moves it"
+            );
+        }
         Ok(())
     })
+}
+
+/// #376: path of a trashed block's ciphertext if it is still resident in
+/// `blocks/` — i.e. the best-effort physical rename inside core
+/// `trash_block` (or the open-time sweep) failed. The manifest-first commit
+/// already lists the block as trashed, so this is NOT a consistency fault;
+/// but the logically-deleted ciphertext remains decryptable on disk until
+/// something relocates it. The filename is reconstructed from core's
+/// canonical formatting helpers, so this stays pinned to the on-disk layout's
+/// single source of truth.
+pub fn lingering_trash_residue(vault_folder: &Path, block_uuid: &[u8; 16]) -> Option<PathBuf> {
+    use secretary_core::vault::{format_uuid_hyphenated, BLOCKS_SUBDIR, BLOCK_FILE_EXTENSION};
+    let file = format!(
+        "{}{}",
+        format_uuid_hyphenated(block_uuid),
+        BLOCK_FILE_EXTENSION
+    );
+    let path = vault_folder.join(BLOCKS_SUBDIR).join(file);
+    path.exists().then_some(path)
 }
 
 #[tauri::command]

--- a/desktop/src-tauri/src/commands/pick.rs
+++ b/desktop/src-tauri/src/commands/pick.rs
@@ -38,8 +38,9 @@ pub fn pick_into_slot_impl(
     Ok(Some(display))
 }
 
-/// Native folder picker for the vault folder (unlock + create). Stores the
-/// choice in the `VaultFolder` slot.
+/// Native folder picker for the vault folder (unlock). Stores the choice in
+/// the `VaultFolder` slot. Vault creation uses [`pick_create_folder`] — a
+/// distinct purpose, so an unlock pick never authorizes a create (#378).
 #[tauri::command]
 pub async fn pick_vault_folder(
     app: tauri::AppHandle,
@@ -52,6 +53,25 @@ pub async fn pick_vault_folder(
         .blocking_pick_folder()
         .and_then(|fp| fp.into_path().ok());
     pick_into_slot_impl(state.inner(), PathPurpose::VaultFolder, picked)
+}
+
+/// Native folder picker for the create wizard (#378). Stores the choice in
+/// the `CreateParent` slot, which `create_vault` / `probe_create_target`
+/// consult with `Containment` (the wizard may create a subfolder inside it).
+/// Deliberately NOT the `VaultFolder` slot: sharing it would let a pick made
+/// to *unlock* a vault authorize a *create* in one of its subfolders.
+#[tauri::command]
+pub async fn pick_create_folder(
+    app: tauri::AppHandle,
+    state: State<'_, Mutex<VaultSession>>,
+) -> Result<Option<String>, AppError> {
+    let picked = app
+        .dialog()
+        .file()
+        .set_title("Choose a folder to create your vault in")
+        .blocking_pick_folder()
+        .and_then(|fp| fp.into_path().ok());
+    pick_into_slot_impl(state.inner(), PathPurpose::CreateParent, picked)
 }
 
 /// Native file picker (`.card` filter) for contact-card import. Stores the

--- a/desktop/src-tauri/src/main.rs
+++ b/desktop/src-tauri/src/main.rs
@@ -86,6 +86,7 @@ fn main() {
             create::create_vault,
             create::probe_create_target,
             pick::pick_vault_folder,
+            pick::pick_create_folder,
             pick::pick_contact_card,
             pick::pick_export_dir,
             edit::create_block,

--- a/desktop/src-tauri/src/path_auth.rs
+++ b/desktop/src-tauri/src/path_auth.rs
@@ -17,6 +17,11 @@ use std::path::{Component, Path, PathBuf};
 #[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
 pub enum PathPurpose {
     VaultFolder,
+    /// Parent folder for vault creation (#378). Kept separate from
+    /// `VaultFolder` so an unlock pick (matched `Exact`) can never authorize
+    /// a `Containment`-matched `create_vault` / `probe_create_target` in a
+    /// subfolder of the unlocked vault's folder.
+    CreateParent,
     ContactCard,
     ExportDir,
 }
@@ -167,6 +172,26 @@ mod tests {
         let dir = tempdir().unwrap();
         let approvals = PathApprovals::default();
         assert!(!approvals.is_authorized(PathPurpose::VaultFolder, dir.path(), MatchMode::Exact));
+    }
+
+    /// #378 regression: an unlock pick (`VaultFolder`) must never authorize a
+    /// create in a subfolder — create/probe consult the `CreateParent` slot,
+    /// which only `pick_create_folder` populates.
+    #[test]
+    fn vault_folder_approval_never_authorizes_create_parent() {
+        let dir = tempdir().unwrap();
+        let sub = dir.path().join("sub");
+        let mut approvals = PathApprovals::default();
+        approvals.approve(
+            PathPurpose::VaultFolder,
+            canonicalize_for_auth(dir.path()).unwrap(),
+        );
+        assert!(!approvals.is_authorized(PathPurpose::CreateParent, &sub, MatchMode::Containment));
+        assert!(!approvals.is_authorized(
+            PathPurpose::CreateParent,
+            dir.path(),
+            MatchMode::Containment
+        ));
     }
 
     #[test]

--- a/desktop/src-tauri/src/session.rs
+++ b/desktop/src-tauri/src/session.rs
@@ -263,6 +263,23 @@ impl VaultSession {
                 }
             };
 
+        // #376 operator signal: flag ciphertext lingering in blocks/ that the
+        // signed manifest no longer lists — a trashed block whose best-effort
+        // rename (and every subsequent open-time sweep) failed, a legacy
+        // pre-#293 trash entry the sweep can never touch, or crash residue of
+        // an uncommitted save. Log-only: `open_vault` ignores unlisted files,
+        // so this is not a consistency fault, but the bytes remain
+        // decryptable on disk and were previously invisible.
+        for orphan in unlisted_block_files(folder, &output.manifest) {
+            tracing::warn!(
+                path = %orphan.display(),
+                "block ciphertext on disk is not listed in the verified \
+                 manifest: likely a trashed block whose physical move to \
+                 trash/ failed, or crash residue of an uncommitted save; it \
+                 remains decryptable until relocated (#376)"
+            );
+        }
+
         self.inner = Some(UnlockedSession {
             identity: output.identity,
             manifest: output.manifest,
@@ -347,6 +364,50 @@ impl VaultSession {
     pub fn force_expire_idle_tracker_for_test(&mut self) {
         self.idle.last_activity_ms = 0;
     }
+}
+
+/// #376: block-ciphertext files sitting in `blocks/` that the freshly-opened
+/// (verified) manifest does not list as live blocks. Each is logically
+/// deleted (or never committed) but physically present — still wrapped to
+/// its recipients, i.e. decryptable — because the best-effort
+/// `blocks/ → trash/` rename in core `trash_block` / the open-time sweep
+/// failed (EXDEV cross-filesystem trash dir, permissions), because it is a
+/// legacy pre-#293 trash entry the sweep never attempts, or because a
+/// crashed save never reached its manifest commit. Pure scan (no logging) so
+/// it is unit-testable; `populate_unlocked` logs each returned path.
+///
+/// Filenames are reconstructed from core's canonical formatting helpers, so
+/// the comparison stays pinned to the on-disk layout's single source of
+/// truth. Non-block files (e.g. atomic-write temp files) are ignored. A
+/// missing/unreadable `blocks/` dir yields an empty list — a fresh vault has
+/// no blocks dir and nothing to report.
+pub fn unlisted_block_files(vault_folder: &Path, manifest: &OpenVaultManifest) -> Vec<PathBuf> {
+    use secretary_core::vault::{format_uuid_hyphenated, BLOCKS_SUBDIR, BLOCK_FILE_EXTENSION};
+    let blocks_dir = vault_folder.join(BLOCKS_SUBDIR);
+    let Ok(entries) = std::fs::read_dir(&blocks_dir) else {
+        return Vec::new();
+    };
+    let live: std::collections::HashSet<String> = manifest
+        .block_summaries()
+        .iter()
+        .map(|b| {
+            format!(
+                "{}{}",
+                format_uuid_hyphenated(&b.block_uuid),
+                BLOCK_FILE_EXTENSION
+            )
+        })
+        .collect();
+    let mut orphans: Vec<PathBuf> = entries
+        .flatten()
+        .filter_map(|entry| {
+            let name = entry.file_name().into_string().ok()?;
+            (name.ends_with(BLOCK_FILE_EXTENSION) && !live.contains(&name))
+                .then(|| blocks_dir.join(name))
+        })
+        .collect();
+    orphans.sort();
+    orphans
 }
 
 #[cfg(test)]

--- a/desktop/src-tauri/src/session.rs
+++ b/desktop/src-tauri/src/session.rs
@@ -267,16 +267,22 @@ impl VaultSession {
         // signed manifest no longer lists — a trashed block whose best-effort
         // rename (and every subsequent open-time sweep) failed, a legacy
         // pre-#293 trash entry the sweep can never touch, or crash residue of
-        // an uncommitted save. Log-only: `open_vault` ignores unlisted files,
-        // so this is not a consistency fault, but the bytes remain
-        // decryptable on disk and were previously invisible.
+        // an uncommitted save. NOTE: with a file-sync backend
+        // (Dropbox/iCloud/Syncthing) an incoming block can also propagate
+        // ahead of the updated manifest, so an unlisted file is not always
+        // deletion/crash residue — the wording is deliberately non-committal.
+        // Log-only: `open_vault` ignores unlisted files, so this is not a
+        // consistency fault, but the bytes are on disk and were previously
+        // invisible.
         for orphan in unlisted_block_files(folder, &output.manifest) {
             tracing::warn!(
                 path = %orphan.display(),
                 "block ciphertext on disk is not listed in the verified \
-                 manifest: likely a trashed block whose physical move to \
-                 trash/ failed, or crash residue of an uncommitted save; it \
-                 remains decryptable until relocated (#376)"
+                 manifest: a trashed block whose physical move to trash/ \
+                 failed, crash residue of an uncommitted save, or an incoming \
+                 block from a file-sync backend not yet reflected in this \
+                 manifest; if it is a deleted block it remains decryptable \
+                 until relocated (#376)"
             );
         }
 
@@ -367,14 +373,18 @@ impl VaultSession {
 }
 
 /// #376: block-ciphertext files sitting in `blocks/` that the freshly-opened
-/// (verified) manifest does not list as live blocks. Each is logically
-/// deleted (or never committed) but physically present — still wrapped to
-/// its recipients, i.e. decryptable — because the best-effort
+/// (verified) manifest does not list as live blocks. Typically each is
+/// logically deleted (or never committed) but physically present — still
+/// wrapped to its recipients, i.e. decryptable — because the best-effort
 /// `blocks/ → trash/` rename in core `trash_block` / the open-time sweep
 /// failed (EXDEV cross-filesystem trash dir, permissions), because it is a
 /// legacy pre-#293 trash entry the sweep never attempts, or because a
-/// crashed save never reached its manifest commit. Pure scan (no logging) so
-/// it is unit-testable; `populate_unlocked` logs each returned path.
+/// crashed save never reached its manifest commit. It can ALSO be a benign
+/// incoming block that a file-sync backend (Dropbox/iCloud/Syncthing)
+/// propagated ahead of the updated manifest — the scan cannot distinguish
+/// the two, so callers must treat a hit as "worth a look", not proof of
+/// residue. Pure scan (no logging) so it is unit-testable;
+/// `populate_unlocked` logs each returned path.
 ///
 /// Filenames are reconstructed from core's canonical formatting helpers, so
 /// the comparison stays pinned to the on-disk layout's single source of

--- a/desktop/src-tauri/tests/ipc_integration.rs
+++ b/desktop/src-tauri/tests/ipc_integration.rs
@@ -773,7 +773,7 @@ mod create_path {
 
         let (state, _device_dir) = fresh_state();
         state.lock().unwrap().approve_path(
-            PathPurpose::VaultFolder,
+            PathPurpose::CreateParent,
             canonicalize_for_auth(dir.path()).unwrap(),
         );
         let dto = create::create_vault_impl(
@@ -806,7 +806,7 @@ mod create_path {
 
         let (state, _device_dir) = fresh_state();
         state.lock().unwrap().approve_path(
-            PathPurpose::VaultFolder,
+            PathPurpose::CreateParent,
             canonicalize_for_auth(dir.path()).unwrap(),
         );
         create::create_vault_impl(
@@ -824,12 +824,14 @@ mod create_path {
         assert_eq!(manifest.block_count, 0, "a new vault has no blocks");
     }
 
-    /// #353: creating into a typed SUBFOLDER of the picked folder (the wizard's
-    /// non-empty-folder offer) must still let the auto-navigated unlock through.
-    /// The picker only ever approves the PARENT (Containment authorizes the
-    /// subfolder create); `create_vault_impl` then re-approves the created
-    /// subfolder so the follow-on `Exact` unlock of that exact path succeeds.
-    /// Without that re-approval the unlock would fail `PathNotApproved`.
+    /// #353/#378: creating into a typed SUBFOLDER of the picked folder (the
+    /// wizard's non-empty-folder offer) must still let the auto-navigated
+    /// unlock through. The create picker (`pick_create_folder`) only ever
+    /// approves the PARENT in the `CreateParent` slot (Containment authorizes
+    /// the subfolder create); `create_vault_impl` then approves the created
+    /// subfolder in the `VaultFolder` slot so the follow-on `Exact` unlock of
+    /// that exact path succeeds. Without that approval the unlock would fail
+    /// `PathNotApproved`.
     #[test]
     fn created_subfolder_vault_reopens_via_exact_unlock() {
         let parent = tempfile::tempdir().expect("parent tempdir");
@@ -838,10 +840,10 @@ mod create_path {
         let pw = random_password();
 
         let (state, _device_dir) = fresh_state();
-        // Only the PARENT is approved (mirrors `pick_vault_folder`); the
+        // Only the PARENT is approved (mirrors `pick_create_folder`); the
         // subfolder is never picked — the wizard constructs it.
         state.lock().unwrap().approve_path(
-            PathPurpose::VaultFolder,
+            PathPurpose::CreateParent,
             canonicalize_for_auth(parent.path()).unwrap(),
         );
         create::create_vault_impl(
@@ -870,7 +872,7 @@ mod create_path {
 
         let (state, _device_dir) = fresh_state();
         state.lock().unwrap().approve_path(
-            PathPurpose::VaultFolder,
+            PathPurpose::CreateParent,
             canonicalize_for_auth(dir.path()).unwrap(),
         );
         let err = create::create_vault_impl(
@@ -897,7 +899,7 @@ mod create_path {
 
         let (state, _device_dir) = fresh_state();
         state.lock().unwrap().approve_path(
-            PathPurpose::VaultFolder,
+            PathPurpose::CreateParent,
             canonicalize_for_auth(dir.path()).unwrap(),
         );
         create::create_vault_impl(
@@ -919,7 +921,7 @@ mod create_path {
 
         let (state, _device_dir) = fresh_state();
         state.lock().unwrap().approve_path(
-            PathPurpose::VaultFolder,
+            PathPurpose::CreateParent,
             canonicalize_for_auth(dir.path()).unwrap(),
         );
 
@@ -974,7 +976,7 @@ mod edit_path {
 
         let (state, _device_dir) = fresh_state();
         state.lock().unwrap().approve_path(
-            PathPurpose::VaultFolder,
+            PathPurpose::CreateParent,
             canonicalize_for_auth(vault_dir.path()).unwrap(),
         );
         create::create_vault_impl(
@@ -1294,7 +1296,7 @@ mod delete_path {
 
         let (state, _device_dir) = fresh_state();
         state.lock().unwrap().approve_path(
-            PathPurpose::VaultFolder,
+            PathPurpose::CreateParent,
             canonicalize_for_auth(vault_dir.path()).unwrap(),
         );
         create::create_vault_impl(
@@ -1489,7 +1491,7 @@ mod contacts_path {
 
         let (peer_state, _device_dir) = fresh_state();
         peer_state.lock().unwrap().approve_path(
-            PathPurpose::VaultFolder,
+            PathPurpose::CreateParent,
             canonicalize_for_auth(dir.path()).unwrap(),
         );
         create::create_vault_impl(

--- a/desktop/src-tauri/tests/ipc_integration.rs
+++ b/desktop/src-tauri/tests/ipc_integration.rs
@@ -1408,6 +1408,79 @@ mod delete_path {
         );
     }
 
+    /// #376: a failed physical `blocks/ → trash/` rename must not fail the
+    /// trash (the manifest write is the commit point) but must be detectable
+    /// as lingering residue afterwards. The rename failure is forced
+    /// deterministically by planting a regular FILE named `trash` at the
+    /// vault root: core's `create_dir_all("trash")` fails on it, so the
+    /// rename is never attempted and the ciphertext stays in `blocks/`.
+    #[test]
+    fn trash_rename_failure_leaves_detectable_residue_without_failing() {
+        let (state, dir, _pw) = unlocked_session_over_new_vault();
+        let block = edit::create_block_impl(&state, "Bank logins").expect("create_block");
+        let block_hex = block.block_uuid_hex.clone();
+        add_one_record(&state, &block_hex);
+
+        std::fs::write(dir.path().join("trash"), b"obstruction").expect("plant trash file");
+
+        delete::trash_block_impl(&state, &block_hex)
+            .expect("manifest-first trash must succeed despite the physical rename failing");
+
+        let uuid: [u8; 16] = hex::decode(&block_hex)
+            .expect("hex")
+            .try_into()
+            .expect("16 bytes");
+        let residue = delete::lingering_trash_residue(dir.path(), &uuid)
+            .expect("ciphertext must be detected as still resident in blocks/");
+        assert!(residue.exists(), "residue path exists on disk");
+
+        // The manifest no longer lists the block, so the unlock-time orphan
+        // scan reports exactly this file.
+        let session = state.lock().unwrap();
+        session
+            .with_unlocked(|u| {
+                let orphans =
+                    secretary_desktop::session::unlisted_block_files(dir.path(), &u.manifest);
+                assert_eq!(
+                    orphans,
+                    vec![residue.clone()],
+                    "orphan scan finds the residue"
+                );
+                Ok(())
+            })
+            .expect("session unlocked");
+    }
+
+    /// #376 counterpart: on the happy path the physical rename succeeds, so
+    /// neither the per-event residue check nor the orphan scan fires.
+    #[test]
+    fn trash_happy_path_leaves_no_residue_and_no_orphans() {
+        let (state, dir, _pw) = unlocked_session_over_new_vault();
+        let block = edit::create_block_impl(&state, "Bank logins").expect("create_block");
+        let block_hex = block.block_uuid_hex.clone();
+        add_one_record(&state, &block_hex);
+
+        delete::trash_block_impl(&state, &block_hex).expect("trash_block");
+
+        let uuid: [u8; 16] = hex::decode(&block_hex)
+            .expect("hex")
+            .try_into()
+            .expect("16 bytes");
+        assert!(
+            delete::lingering_trash_residue(dir.path(), &uuid).is_none(),
+            "no residue after a successful physical move"
+        );
+        let session = state.lock().unwrap();
+        session
+            .with_unlocked(|u| {
+                let orphans =
+                    secretary_desktop::session::unlisted_block_files(dir.path(), &u.manifest);
+                assert!(orphans.is_empty(), "no orphans, got {orphans:?}");
+                Ok(())
+            })
+            .expect("session unlocked");
+    }
+
     #[test]
     fn restore_never_trashed_block_is_trash_entry_not_found() {
         // A UUID that is neither live nor in trash. Core checks the live

--- a/desktop/src/components/PathPicker.svelte
+++ b/desktop/src/components/PathPicker.svelte
@@ -8,7 +8,7 @@
   type Props = {
     value: string;
     onSelect: (path: string) => void;
-    command: 'pick_vault_folder' | 'pick_contact_card' | 'pick_export_dir';
+    command: 'pick_vault_folder' | 'pick_create_folder' | 'pick_contact_card' | 'pick_export_dir';
     disabled?: boolean;
     label?: string;
     placeholder?: string;

--- a/desktop/src/components/create/FolderStep.svelte
+++ b/desktop/src/components/create/FolderStep.svelte
@@ -2,6 +2,7 @@
   import PathPicker from '../PathPicker.svelte';
   import { probeCreateTarget } from '../../lib/ipc';
   import { joinSubfolder } from '../../lib/create';
+  import type { AppError } from '../../lib/errors';
 
   let {
     seedPath = '',
@@ -17,12 +18,18 @@
   let probed = $state<{ exists: boolean; isEmpty: boolean } | null>(null);
   let subfolderName = $state('');
   let probing = $state(false);
+  // #378: create has its own approval slot (CreateParent), populated only by
+  // the pick_create_folder dialog. A seed path carried over from the Unlock
+  // screen is NOT approved for creation, so probing it rejects with
+  // path_not_approved — the user must confirm the folder via the picker.
+  let needsPick = $state(false);
 
   let probeGeneration = 0;
 
   async function probe(path: string): Promise<void> {
     if (path.length === 0) {
       probed = null;
+      needsPick = false;
       return;
     }
     const gen = ++probeGeneration;
@@ -31,6 +38,12 @@
       const result = await probeCreateTarget(path);
       if (gen === probeGeneration) {
         probed = result;
+        needsPick = false;
+      }
+    } catch (err) {
+      if (gen === probeGeneration) {
+        probed = null;
+        needsPick = (err as AppError).code === 'path_not_approved';
       }
     } finally {
       if (gen === probeGeneration) {
@@ -49,7 +62,10 @@
     needsSubfolder ? joinSubfolder(picked, subfolderName) : picked.length > 0 ? picked : null
   );
 
-  const canContinue = $derived(!probing && finalPath !== null);
+  // A successful probe (probed !== null) is required: it proves the backend
+  // holds a CreateParent approval covering `picked`, so create_vault won't
+  // bounce with path_not_approved after the credentials step.
+  const canContinue = $derived(!probing && probed !== null && finalPath !== null);
 
   function onPick(p: string): void {
     picked = p;
@@ -61,9 +77,11 @@
   <h2 class="wizard-step__title">Choose a folder</h2>
   <p class="wizard-step__hint">Pick an empty folder, or a folder to create your vault inside.</p>
 
-  <PathPicker value={picked} command="pick_vault_folder" onSelect={onPick} disabled={probing} />
+  <PathPicker value={picked} command="pick_create_folder" onSelect={onPick} disabled={probing} />
 
-  {#if needsSubfolder}
+  {#if needsPick}
+    <p class="wizard-step__warn">Confirm the folder with the Choose… button to continue.</p>
+  {:else if needsSubfolder}
     <p class="wizard-step__warn">{picked} already contains files.</p>
     <label class="wizard-step__field" for="subfolder-name">
       <span>Subfolder name</span>

--- a/desktop/src/components/create/FolderStep.svelte
+++ b/desktop/src/components/create/FolderStep.svelte
@@ -2,7 +2,7 @@
   import PathPicker from '../PathPicker.svelte';
   import { probeCreateTarget } from '../../lib/ipc';
   import { joinSubfolder } from '../../lib/create';
-  import type { AppError } from '../../lib/errors';
+  import { userMessageFor, type AppError } from '../../lib/errors';
 
   let {
     seedPath = '',
@@ -23,27 +23,40 @@
   // screen is NOT approved for creation, so probing it rejects with
   // path_not_approved — the user must confirm the folder via the picker.
   let needsPick = $state(false);
+  // A non-approval probe failure (io, internal, …). Surfaced inline so the
+  // step never dead-ends silently with Continue disabled and no explanation.
+  let probeError = $state<string | null>(null);
 
   let probeGeneration = 0;
 
   async function probe(path: string): Promise<void> {
+    const gen = ++probeGeneration;
+    // Clear the previous verdict up front so a slow probe never leaves the
+    // prior folder's "Ready to create"/subfolder guidance on screen while the
+    // new path is still being checked.
+    probed = null;
+    needsPick = false;
+    probeError = null;
     if (path.length === 0) {
-      probed = null;
-      needsPick = false;
+      probing = false;
       return;
     }
-    const gen = ++probeGeneration;
     probing = true;
     try {
       const result = await probeCreateTarget(path);
       if (gen === probeGeneration) {
         probed = result;
-        needsPick = false;
       }
     } catch (err) {
       if (gen === probeGeneration) {
-        probed = null;
-        needsPick = (err as AppError).code === 'path_not_approved';
+        const code = (err as Partial<AppError>).code;
+        if (code === 'path_not_approved') {
+          needsPick = true;
+        } else {
+          // io/internal/etc: show a concrete reason instead of a silent
+          // greyed-out Continue with no explanation.
+          probeError = userMessageFor(err as AppError).title;
+        }
       }
     } finally {
       if (gen === probeGeneration) {
@@ -52,8 +65,16 @@
     }
   }
 
+  // Probe the seed once on mount (a carried-over Unlock path is not approved
+  // for creation, so this surfaces `needsPick`). Every subsequent pick
+  // re-probes explicitly in `onPick` rather than through a `picked`-tracking
+  // effect: re-picking the SAME folder as the rejected seed yields an
+  // identical string, and Svelte skips the reactive update on an unchanged
+  // primitive, so an effect would never re-fire — stranding the step with
+  // Continue disabled even though `pick_create_folder` just approved the
+  // path (#378).
   $effect(() => {
-    void probe(picked);
+    void probe(seedPath);
   });
 
   const needsSubfolder = $derived(probed !== null && probed.exists && !probed.isEmpty);
@@ -70,6 +91,11 @@
   function onPick(p: string): void {
     picked = p;
     subfolderName = '';
+    // Re-probe explicitly. We can't rely on `picked` changing to drive this:
+    // re-picking the same folder as the rejected seed is a no-op for Svelte
+    // reactivity, but it must still re-probe now that `pick_create_folder`
+    // has approved the path (see the mount effect's note).
+    void probe(p);
   }
 </script>
 
@@ -81,6 +107,8 @@
 
   {#if needsPick}
     <p class="wizard-step__warn">Confirm the folder with the Choose… button to continue.</p>
+  {:else if probeError}
+    <p class="wizard-step__warn">{probeError}</p>
   {:else if needsSubfolder}
     <p class="wizard-step__warn">{picked} already contains files.</p>
     <label class="wizard-step__field" for="subfolder-name">

--- a/desktop/src/lib/ipc.ts
+++ b/desktop/src/lib/ipc.ts
@@ -176,6 +176,10 @@ export async function pickVaultFolder(): Promise<string | null> {
   return call<string | null>('pick_vault_folder', {});
 }
 
+export async function pickCreateFolder(): Promise<string | null> {
+  return call<string | null>('pick_create_folder', {});
+}
+
 export async function pickContactCard(): Promise<string | null> {
   return call<string | null>('pick_contact_card', {});
 }

--- a/desktop/src/lib/writeCommands.ts
+++ b/desktop/src/lib/writeCommands.ts
@@ -75,6 +75,13 @@ export const COMMAND_CLASSIFICATION: Record<string, CommandClass> = {
     reason:
       'opens a native dialog and records the chosen path in a backend PathPurpose slot (#353); performs no vault mutation',
   },
+  pick_create_folder: {
+    kind: 'write',
+    gate: 'exempt',
+    wrapper: 'pickCreateFolder',
+    reason:
+      'opens a native dialog and records the chosen path in the backend CreateParent slot (#378); performs no vault mutation — kept separate from pick_vault_folder so an unlock pick never authorizes a create',
+  },
   pick_contact_card: {
     kind: 'write',
     gate: 'exempt',

--- a/desktop/tests/FolderStep.test.ts
+++ b/desktop/tests/FolderStep.test.ts
@@ -7,8 +7,8 @@ vi.mock('../src/lib/ipc', () => ({
 }));
 import { probeCreateTarget } from '../src/lib/ipc';
 
-// PathPicker invokes `pick_vault_folder` directly via `@tauri-apps/api/core`
-// (#353); these tests seed the picker via `seedPath` and never click the
+// PathPicker invokes `pick_create_folder` directly via `@tauri-apps/api/core`
+// (#353/#378); these tests seed the picker via `seedPath` and never click the
 // Choose… button, so the mock only needs to exist to satisfy the import.
 vi.mock('@tauri-apps/api/core', () => ({
   invoke: vi.fn().mockResolvedValue('/Users/h/Docs')
@@ -56,6 +56,23 @@ describe('FolderStep', () => {
     });
     await fireEvent.click(getByRole('button', { name: /cancel/i }));
     expect(onCancel).toHaveBeenCalled();
+  });
+
+  // #378: a seed path carried over from the Unlock screen has no CreateParent
+  // approval — the probe rejects with path_not_approved. The step must keep
+  // Continue disabled and ask the user to confirm the folder via the picker.
+  it('unapproved seed path disables Continue and asks for a fresh pick', async () => {
+    (probeCreateTarget as ReturnType<typeof vi.fn>).mockRejectedValueOnce({
+      code: 'path_not_approved',
+      path: '/Users/h/Docs'
+    });
+    const onNext = vi.fn();
+    const { findByText, findByRole } = render(FolderStep, {
+      props: { seedPath: '/Users/h/Docs', onNext, onCancel: vi.fn() }
+    });
+    expect(await findByText(/confirm the folder/i)).toBeTruthy();
+    const cont = (await findByRole('button', { name: /continue/i })) as HTMLButtonElement;
+    expect(cont.disabled).toBe(true);
   });
 
   it('subfolder path: typing a name yields the joined path on Continue', async () => {

--- a/desktop/tests/FolderStep.test.ts
+++ b/desktop/tests/FolderStep.test.ts
@@ -75,6 +75,43 @@ describe('FolderStep', () => {
     expect(cont.disabled).toBe(true);
   });
 
+  // #378 regression: re-picking the SAME folder as the rejected seed must
+  // re-probe. The pick returns a string identical to the seed, so `picked`
+  // never changes — a `picked`-tracking effect would not re-fire and the step
+  // would strand with Continue disabled even though `pick_create_folder` just
+  // approved the path. The explicit re-probe in `onPick` fixes it.
+  it('re-picking the same folder as the rejected seed re-probes and enables Continue', async () => {
+    (probeCreateTarget as ReturnType<typeof vi.fn>)
+      .mockRejectedValueOnce({ code: 'path_not_approved', path: '/Users/h/Docs' })
+      .mockResolvedValueOnce({ exists: true, isEmpty: true });
+    const onNext = vi.fn();
+    const { findByText, findByRole, getByRole } = render(FolderStep, {
+      props: { seedPath: '/Users/h/Docs', onNext, onCancel: vi.fn() }
+    });
+    // Seed probe rejected → the "confirm the folder" prompt is shown.
+    expect(await findByText(/confirm the folder/i)).toBeTruthy();
+    // The picker (mocked invoke) returns '/Users/h/Docs' — the SAME string.
+    await fireEvent.click(getByRole('button', { name: /choose/i }));
+    // The explicit re-probe resolves empty → Continue enables and works.
+    expect(await findByText(/ready to create/i)).toBeTruthy();
+    const cont = (await findByRole('button', { name: /continue/i })) as HTMLButtonElement;
+    expect(cont.disabled).toBe(false);
+    await fireEvent.click(cont);
+    expect(onNext).toHaveBeenCalledWith('/Users/h/Docs');
+  });
+
+  // A non-approval probe failure (e.g. io) must surface a concrete message
+  // rather than silently greying out Continue with no explanation.
+  it('a non-approval probe error is shown inline and keeps Continue disabled', async () => {
+    (probeCreateTarget as ReturnType<typeof vi.fn>).mockRejectedValueOnce({ code: 'io' });
+    const { findByText, findByRole } = render(FolderStep, {
+      props: { seedPath: '/Users/h/Docs', onNext: vi.fn(), onCancel: vi.fn() }
+    });
+    expect(await findByText(/filesystem error/i)).toBeTruthy();
+    const cont = (await findByRole('button', { name: /continue/i })) as HTMLButtonElement;
+    expect(cont.disabled).toBe(true);
+  });
+
   it('subfolder path: typing a name yields the joined path on Continue', async () => {
     (probeCreateTarget as ReturnType<typeof vi.fn>).mockResolvedValue({
       exists: true,

--- a/desktop/tests/writeCommands.test.ts
+++ b/desktop/tests/writeCommands.test.ts
@@ -7,8 +7,8 @@ import {
 } from '../src/lib/writeCommands';
 
 describe('writeCommands registry', () => {
-  it('classifies exactly the 38 registered commands', () => {
-    expect(classifiedCommandNames().size).toBe(38);
+  it('classifies exactly the 39 registered commands', () => {
+    expect(classifiedCommandNames().size).toBe(39);
   });
 
   it('lists the gated write wrappers (14)', () => {


### PR DESCRIPTION
Works off the two open `security`-labelled issues that are fixable now without a spec decision.

## #378 — an unlock pick can no longer authorize a create

`create_vault` / `probe_create_target` shared the `VaultFolder` approval slot with `unlock_with_password` (matched with `Containment`), so after an unlock pick a compromised webview could create a vault in an empty subfolder of the approved folder without a distinct user pick. Implemented the hardening proposed in the issue:

- New `PathPurpose::CreateParent`, populated only by the new backend `pick_create_folder` dialog command.
- `create_vault` / `probe_create_target` gate on `CreateParent` (`Containment`, preserving the wizard's "create a subfolder" offer); an unlock pick (`VaultFolder`, `Exact`) can no longer authorize either.
- `create_vault` still approves the just-created folder in the `VaultFolder` slot so the wizard's auto-navigated `Exact` unlock passes (least-privilege: exactly the created vault, not the picked parent).
- FolderStep uses the new picker; a seed path carried over from the Unlock screen is no longer pre-authorized, so the step treats `path_not_approved` on the seeded probe as "confirm the folder via the picker" and keeps Continue disabled until a real pick lands (the one-extra-click cost the issue accepted).

Regression tests: slot isolation in `path_auth`, create/probe rejection of a `VaultFolder`-only approval, and the FolderStep unapproved-seed flow.

Closes #378.

## #376 — operator signal for lingering trashed-block ciphertext (observability slice)

Core `trash_block` is manifest-first (#350); the physical `blocks/ → trash/` rename is best-effort with all failures swallowed, so a "deleted" secret's ciphertext could stay in `blocks/` — still decryptable — with zero indication. Added the signal at the desktop layer (where a logging runtime exists), leaving core/bridge surfaces and crash-consistency semantics untouched:

- `trash_block_impl` checks for the block's ciphertext in `blocks/` after the committed trash and logs a `tracing::warn!` naming the resident path.
- `populate_unlocked` (unlock + repair) scans for `*.cbor.enc` files the verified manifest doesn't list and logs each — covering sweep failures and the legacy pre-#293 entries the sweep can never relocate.
- Filenames are reconstructed from core's re-exported canonical helpers (`format_uuid_hyphenated` / `BLOCKS_SUBDIR` / `BLOCK_FILE_EXTENSION`), pinned to the on-disk layout's single source of truth.

Integration tests force the rename failure deterministically (a regular file named `trash` at the vault root) and assert the trash still commits, the residue is detected, and the orphan scan reports exactly that file — plus the happy-path counterpart.

The deeper #376 directions (secure-overwrite fallback, legacy-entry migration, UI surfacing) stay open on the issue — they need spec-level decisions.

## Triage notes on the remaining security issues

- **#374 item 4** (device-secret crash-recovery test): already covered — `repair_vault_adopts_interrupted_save_via_device_secret` landed with the #382 slice; verified passing.
- **#307**: now **unblocked** — uniffi **0.32.0** (2026-06-30) contains #2878 (zero-copy `&[u8]` inbound args). Not attempted here because the migration requires the Swift + Kotlin conformance gates, and those toolchains aren't available in this environment. Noted on the issue.
- **#384**: deliberately not touched — the issue calls for spec treatment, not a drive-by edit on the frozen crash-recovery path.
- **#383**: still blocked upstream (`plist`/`tauri` pin `quick-xml 0.39`); already risk-accepted in `.cargo/audit.toml`.

## Verification

- `cargo test --release -p secretary-desktop` — 162 unit + 62 IPC-integration + 18 session tests pass (includes the new #378/#376 tests).
- `cargo test --release -p secretary-core --test crash_recovery` — 16 pass.
- `cargo clippy --release -p secretary-desktop --tests -- -D warnings` clean; `cargo fmt` clean.
- Frontend: 579 vitest tests pass; eslint, svelte-check, `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017spAjMMm46YFSaZahzeXQ5

---
_Generated by [Claude Code](https://claude.ai/code/session_017spAjMMm46YFSaZahzeXQ5)_