### PR TITLE
docs(audit): re-triage #383 quick-xml — correct exit criteria + document wayland path

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -16,13 +16,33 @@
 # FFI bridge, and mobile clients.
 [advisories]
 ignore = [
-  # --- quick-xml DoS via malicious XML, transitive via tauri -> plist (desktop) ---
-  # HIGH (7.5) but NOT reachable here: `plist` only parses the app's own
-  # trusted macOS Info.plist bundle metadata; no secretary crate uses
-  # plist/quick-xml, and vault data is CBOR/TOML, never XML. Not fixable yet —
-  # the latest plist (1.9.0) still pins quick-xml ^0.39.2, so 0.41 cannot
-  # resolve in. Drop both once plist adopts quick-xml >=0.41 and Tauri adopts
-  # that plist. Tracked in #383.
+  # --- quick-xml DoS via malicious XML, transitive via Tauri (desktop only) ---
+  # HIGH (7.5), fixed in quick-xml >=0.41.0, but NOT reachable here. quick-xml
+  # 0.39.4 enters the tree via TWO Tauri-only paths, neither attacker-facing
+  # (no secretary crate uses quick-xml; vault data is CBOR/TOML, never XML):
+  #   1. plist -> tauri (macOS): `plist` parses only the app's own trusted,
+  #      signed Info.plist bundle metadata. `cargo tree -i quick-xml` shows this.
+  #   2. wayland-scanner -> wl-clipboard-rs -> arboard ->
+  #      tauri-plugin-clipboard-manager (Linux): a BUILD-TIME proc-macro that
+  #      parses static Wayland protocol XML during compilation. Trusted,
+  #      compile-time input; only visible in `cargo tree -i quick-xml --target
+  #      all` or on a Linux host. This second path is why the fix is not simply
+  #      "bump plist" (see below).
+  #
+  # Exit criteria (BOTH must hold before dropping these two ids; verified
+  # 2026-07-06, #383): the vulnerable quick-xml 0.39.x must be gone from
+  # Cargo.lock entirely.
+  #   - plist: DONE upstream. plist 1.10.0 requires quick-xml ^0.41 and Tauri
+  #     accepts it (`plist ^1`). But `cargo update -p plist` alone does NOT
+  #     clear the advisory: it ADDS quick-xml 0.41.0 while wayland-scanner keeps
+  #     0.39.4 in the lock (two copies), so 0194/0195 still fire and we gain a
+  #     duplicate dep for no audit benefit. Deferred until path 2 also moves, so
+  #     a single quick-xml 0.41 resolves and both ids drop in one step.
+  #   - wayland-scanner: PENDING. Latest (0.31.10) still pins quick-xml ^0.39.
+  #     Clears when a wayland-scanner adopting >=0.41 resolves via a
+  #     wl-clipboard-rs/arboard/tauri-plugin-clipboard-manager bump.
+  # Re-check on every Tauri upgrade and whenever `cargo update` touches plist or
+  # the arboard/wayland-* clipboard chain.
   "RUSTSEC-2026-0194", # quick-xml quadratic duplicate-attribute-name check
   "RUSTSEC-2026-0195", # quick-xml unbounded NsReader namespace allocation
 

--- a/NEXT_SESSION.md
+++ b/NEXT_SESSION.md
@@ -1,1 +1,1 @@
-docs/handoffs/2026-07-06-repair-consent-widening-374-shipped.md
+docs/handoffs/2026-07-06-audit-quickxml-triage-383-shipped.md

--- a/docs/handoffs/2026-07-06-audit-quickxml-triage-383-shipped.md
+++ b/docs/handoffs/2026-07-06-audit-quickxml-triage-383-shipped.md
@@ -1,0 +1,62 @@
+# NEXT_SESSION.md — #383 quick-xml audit re-triage ✅ SHIPPED (PR opening)
+
+**Session date:** 2026-07-06. A short security-triage session: re-triaged the `#383` quick-xml DoS advisories (RUSTSEC-2026-0194/0195) that the `#354` `cargo audit --deny warnings` gate accepts. Also opened by cleaning up the merged `#374` slice (PR #390): removed worktree `.worktrees/repair-consent-374` + branch `feature/repair-consent-374`. Worktree `.worktrees/audit-quickxml-383`, branch `feature/audit-quickxml-triage-383` (cut from `main` @ `09ad4e9`).
+
+## (1) What we shipped this session
+
+**Housekeeping:** confirmed PR #390 (final #374 slice) MERGED; removed the stale `repair-consent-374` worktree + branch. `main` clean @ `09ad4e9`.
+
+**#383 re-triage** (commit `fd7a9f5`, single `.cargo/audit.toml` rationale change — ignore IDs unchanged, audit gate stays green). The re-triage produced two evidence-backed findings that invalidated the original acceptance note:
+
+- **Second consumer found.** quick-xml 0.39.4 enters the lock via TWO Tauri-only paths, not just plist. `cargo tree -i quick-xml` (macOS) shows only `plist → tauri`; `--target all` reveals `wayland-scanner v0.31.10` (build-time proc-macro) `→ wl-clipboard-rs → arboard → tauri-plugin-clipboard-manager` (Linux clipboard). It parses static Wayland protocol XML at compile time — trusted, still not attacker-reachable, but the rationale named only plist.
+- **Exit criteria were insufficient.** plist **1.10.0** now requires quick-xml `^0.41` and Tauri accepts it (`plist ^1`) — so the original "drop once plist adopts >=0.41" condition is met, yet empirically `cargo update -p plist` ADDS quick-xml 0.41.0 while wayland-scanner keeps 0.39.4 (two copies verified in `Cargo.lock`, then reverted), so 0194/0195 still fire. Bumping plist alone = duplicate dep, zero audit benefit → deferred.
+- **Corrected exit criteria** (now in `audit.toml`): drop both ids only when quick-xml 0.39.x is gone from `Cargo.lock` entirely — BOTH plist ≥0.41 (done upstream) AND wayland-scanner ≥0.41 (**pending**; 0.31.10 still pins `^0.39`). Then a single quick-xml 0.41 resolves and both ids drop in one step.
+- Posted the full triage to #383 (comment) with the corrected checklist; **issue stays OPEN** pending the wayland-scanner side.
+
+### Branch commits (off `main` @ `09ad4e9`)
+`fd7a9f5` audit.toml re-triage → this docs/handoff commit.
+
+### Acceptance (verified this session, from the worktree)
+```bash
+cd /Users/hherb/src/secretary/.worktrees/audit-quickxml-383
+python3 -c "import tomllib; tomllib.load(open('.cargo/audit.toml','rb'))"   # TOML valid
+cargo audit --deny warnings                                                 # exit 0, clean
+# Proof the ignores are load-bearing (probe a copy without the config):
+cp Cargo.lock /tmp/lock.probe && (cd /tmp && cargo audit --file lock.probe) # flags exactly 0194/0195
+```
+
+## (2) What's next
+
+1. **Manual GUI smoke of the #374 consent flow** (human-only, carried from last session): `pnpm tauri dev` against a **temp copy** ([[feedback_smoke_test_temp_copy_golden_vault]]) of a vault with staged crashed-share residue (`core/tests/crash_recovery.rs::stage_crashed_share`). Confirm unlock → "Repair now?" → consent dialog renders the added recipient + grouped fingerprint → Cancel leaves vault untouched → Grant adopts the widened set.
+2. **#376 remainder** — `trash_block` secure-overwrite fallback + legacy `fingerprint == None` trash-entry migration decisions (design-heavy).
+3. **#388** — bridge `preview_repair` recovery/device-secret arm happy-path tests (cheap, mechanical). **#389** — desktop dialog aria-labelledby parity. Both #374 follow-ups.
+4. **Housekeeping:** #387 (`:kit` NewApi lint), #379 (desktop `errors.rs` 726-line split), #290 (`spec_test_name_freshness.py` 3 pre-existing threat-model false-positives).
+5. **Carried mobile:** iOS on-device Face ID spot-check; Android #338 on-device biometric cloud-open, #331 SAF custom-ROM, #334 native cloud-provider epic (ADR + threat-model first).
+
+**#383 acceptance to fully close (future):** when `cargo tree -i quick-xml --target all` shows a single quick-xml ≥0.41 (both plist and wayland-scanner moved), drop RUSTSEC-2026-0194/0195 from `.cargo/audit.toml` and confirm `cargo audit --deny warnings` stays green. Re-check on every Tauri upgrade / any `cargo update` touching plist or the arboard/wayland clipboard chain.
+
+## (3) Open decisions and risks
+
+- **Do NOT `cargo update -p plist` in isolation.** It resolves in a second quick-xml (0.41 alongside 0.39.4) with no audit-gate benefit until wayland-scanner also moves. The audit.toml comment now spells this out; honor it.
+- **The wayland-scanner quick-xml path is Linux/build-time only** and invisible to a macOS `cargo tree -i quick-xml` — use `--target all` when re-checking, or the next auditor will miss it again (as this issue's original note did).
+- Both advisories remain **consciously accepted, not fixed** — trusted-input, desktop-only, outside the crypto core / FFI bridge / mobile clients. Enforcement is intact: `cargo audit --deny warnings` fails on any *new* advisory; these two are the only vulnerability-class entries in the ignore list.
+
+## (4) Exact commands to resume
+```bash
+cd /Users/hherb/src/secretary
+git fetch --prune origin && git checkout main && git pull --ff-only origin main
+# After this PR merges, remove the worktree + branch:
+#   git worktree remove .worktrees/audit-quickxml-383 && \
+#   git branch -D feature/audit-quickxml-triage-383
+git worktree list && git status -s
+# Re-check the audit gate any time: cargo audit --deny warnings
+```
+
+## (5) Handoff file model
+`NEXT_SESSION.md` is a **relative symlink** to this file in `docs/handoffs/`. Authored once here; the symlink is retargeted in the same commit on the feature branch (new path → no add/add conflict; `main` updates cleanly on merge). Per the baton convention the handoff rides inside the PR — do **not** sync to `main` during the pause window.
+
+## Closing inventory
+- **State on close:** PR opening on `feature/audit-quickxml-triage-383` (2 commits: `fd7a9f5` + this docs/handoff commit). Worktree `.worktrees/audit-quickxml-383`. #383 stays OPEN (exit criteria corrected, pending wayland-scanner ≥0.41 upstream). Merged #374 worktree/branch cleaned up.
+- **Acceptance:** `.cargo/audit.toml` valid TOML; `cargo audit --deny warnings` exit 0; probe without the config flags exactly RUSTSEC-2026-0194/0195.
+- **README / ROADMAP:** no update needed (neither references the audit gate, quick-xml, or #383 — verified by grep).
+- **NEXT_SESSION.md:** symlink → `docs/handoffs/2026-07-06-audit-quickxml-triage-383-shipped.md`.


### PR DESCRIPTION
## Summary

Security re-triage of the `#383` quick-xml DoS advisories (RUSTSEC-2026-0194/0195) that the `#354` `cargo audit --deny warnings` gate consciously accepts. **Doc/config only** — the two ignore IDs are unchanged and the audit gate stays green; what changed is the *rationale*, which the re-triage found to be incomplete and its exit criteria wrong.

## Findings

1. **Second consumer, not just plist.** quick-xml 0.39.4 enters via TWO Tauri-only paths. `cargo tree -i quick-xml` (macOS) shows only `plist → tauri`; `--target all` reveals `wayland-scanner v0.31.10` (build-time proc-macro) `→ wl-clipboard-rs → arboard → tauri-plugin-clipboard-manager` (Linux clipboard), parsing static Wayland protocol XML at compile time. Trusted / compile-time input → still not attacker-reachable, but the original note named only plist.

2. **Exit criteria were insufficient.** plist **1.10.0** now requires quick-xml `^0.41` and Tauri accepts it (`plist ^1`) — the original "drop once plist adopts >=0.41" condition is *met*. But empirically `cargo update -p plist` **adds** quick-xml 0.41.0 while wayland-scanner keeps 0.39.4 (two copies verified in `Cargo.lock`, then reverted), so 0194/0195 still fire. Bumping plist alone = duplicate dep, zero audit benefit → deferred.

3. **Corrected exit criteria** (now in `.cargo/audit.toml`): drop both ids only when quick-xml 0.39.x is gone from `Cargo.lock` entirely — BOTH plist ≥0.41 (done upstream) AND wayland-scanner ≥0.41 (**pending**; 0.31.10 still pins `^0.39`). Then a single quick-xml 0.41 resolves and both drop in one step.

`#383` stays **open** pending the wayland-scanner side; findings posted there.

## Verification

- `.cargo/audit.toml` is valid TOML.
- `cargo audit --deny warnings` → exit 0, clean.
- Probe without the config (`cargo audit --file <copy>` from a dir with no `audit.toml`) flags **exactly** RUSTSEC-2026-0194/0195 on quick-xml 0.39.4 (patched ≥0.41.0) — proving the ignores are load-bearing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)