### PR TITLE
test(bridge): preview_repair recovery + device-secret arm coverage (#388)

### DIFF
--- a/NEXT_SESSION.md
+++ b/NEXT_SESSION.md
@@ -1,1 +1,1 @@
-docs/handoffs/2026-07-06-audit-quickxml-triage-383-shipped.md
+docs/handoffs/2026-07-07-preview-repair-arm-tests-388-shipped.md

--- a/docs/handoffs/2026-07-07-preview-repair-arm-tests-388-shipped.md
+++ b/docs/handoffs/2026-07-07-preview-repair-arm-tests-388-shipped.md
@@ -1,0 +1,61 @@
+# NEXT_SESSION.md — #388 preview_repair arm-parity tests ✅ SHIPPED (PR opening)
+
+**Session date:** 2026-07-07. A short test-coverage session: closed the #374 follow-up **#388** by adding happy-path bridge tests for the recovery-phrase and device-secret arms of `preview_repair`. Also housekept the merged #383 re-triage (PR #392): removed worktree `.worktrees/audit-quickxml-383` + branch `feature/audit-quickxml-triage-383`. Branch `feature/preview-repair-arm-tests-388` cut from `main` @ `143f778`.
+
+## (1) What we shipped this session
+
+**Housekeeping:** confirmed PR #392 (#383 quick-xml re-triage) MERGED into `main` @ `143f778`; removed the stale `audit-quickxml-383` worktree + branch (remote branch was already deleted). `main` clean.
+
+**#388 test coverage** (commit `3e81b34`, test-only — no production code touched). The password unlock arm of `preview_repair` already had full happy-path coverage in the bridge crate ([ffi/secretary-ffi-bridge/src/repair/tests/preview.rs](ffi/secretary-ffi-bridge/src/repair/tests/preview.rs)); the recovery and device-secret arms funnel through the same `project_preview` projection but had NO happy-path execution test of their own — leaving an arm-specific FFI-projection wiring mistake able to go unnoticed (the risk #388 called out). Added:
+
+- `preview_with_recovery_reports_widening` — unlocks via the golden 24-word mnemonic (`VAULT_001_PHRASE`).
+- `preview_with_device_secret_reports_widening` — unlocks via a freshly-enrolled device slot (`add_device_slot` → extract uuid/secret; mirrors the device-slot setup in `consent.rs`).
+
+Each mirrors `preview_with_password_reports_widening`: stage the canonical crashed-`share_block` widening residue, assert the read-only preview reports the identical single `FfiWideningReport` (block name/UUID, round-tripped BLAKE3 `file_fingerprint_hex`, one added recipient with verified display name + 16-byte card fingerprint), and assert the manifest is byte-untouched. Added the two `preview_repair_with_*` fns to the test-module imports in [tests/mod.rs](ffi/secretary-ffi-bridge/src/repair/tests/mod.rs). Distinct RNG/UUID/mint seeds (`0xba`–`0xc0`) disjoint from existing tests and from the golden-vault mint seeds. **#388 closes on merge** (`Closes #388` in the commit).
+
+### Branch commits (off `main` @ `143f778`)
+`3e81b34` test(bridge): preview_repair recovery + device-secret arm happy-path coverage (#388) → then this docs/handoff commit.
+
+### Acceptance (verified this session, from the main repo on the feature branch)
+```bash
+cd /Users/hherb/src/secretary   # on feature/preview-repair-arm-tests-388
+cargo test --release -p secretary-ffi-bridge repair::tests::preview 2>&1 \
+  | grep -E "preview_with|test result"
+# → 5 passed; 0 failed  (incl. preview_with_recovery_reports_widening + preview_with_device_secret_reports_widening)
+cargo clippy --release -p secretary-ffi-bridge --tests -- -D warnings   # clean
+```
+
+## (2) What's next
+
+Same menu as last session, minus #388 (now shipped):
+
+1. **Manual GUI smoke of the #374 consent flow** (human-only, still carried): `pnpm tauri dev` against a **temp copy** ([[feedback_smoke_test_temp_copy_golden_vault]]) of a vault with staged crashed-share residue (`core/tests/crash_recovery.rs::stage_crashed_share`). Confirm unlock → "Repair now?" → consent dialog renders the added recipient + grouped fingerprint → Cancel leaves vault untouched → Grant adopts the widened set.
+2. **#389** — desktop dialog accessibility parity: `aria-labelledby`/`role` wiring across `ConfirmDialog` + `RepairConsentDialog`. Small, self-contained; last remaining #374 follow-up. (Recommended next — cheap, and it finishes the #374 epic's loose ends.)
+3. **#376 remainder** — `trash_block` secure-overwrite fallback + legacy `fingerprint == None` trash-entry migration decisions (design-heavy → brainstorm first, no code).
+4. **Housekeeping:** #387 (`:kit` NewApi lint on `StrongBoxUnavailableException`, min SDK 26 / API 28), #379 (desktop `errors.rs` 726-line split — enum / `map_ffi_error` / serde tests), #290 (`spec_test_name_freshness.py` 3 pre-existing D.4 design-concept false-positives — Python, your strong area).
+5. **Carried mobile (on-device / human-only):** iOS Face ID spot-check; Android #338 on-device biometric cloud-open, #331 SAF custom-ROM, #334 native cloud-provider epic (ADR + threat-model first).
+
+## (3) Open decisions and risks
+
+- **None introduced this session.** Pure additive test coverage; no production code, no spec, no error surface changed. The three `preview_repair` arms are now all execution-tested on the happy path.
+- **#383 stays OPEN** (unchanged from last session): drop RUSTSEC-2026-0194/0195 from `.cargo/audit.toml` only when `cargo tree -i quick-xml --target all` shows a single quick-xml ≥0.41 (both plist AND wayland-scanner moved). Re-check on every Tauri upgrade / any `cargo update` touching plist or the arboard/wayland clipboard chain. Do NOT `cargo update -p plist` in isolation (resolves a duplicate quick-xml with no audit benefit).
+
+## (4) Exact commands to resume
+```bash
+cd /Users/hherb/src/secretary
+git fetch --prune origin && git checkout main && git pull --ff-only origin main
+# After this PR merges, remove the worktree/branch if any lingered:
+#   git branch -D feature/preview-repair-arm-tests-388   # (no worktree used this session)
+git worktree list && git status -s
+# Re-run the new tests any time:
+cargo test --release -p secretary-ffi-bridge repair::tests::preview
+```
+
+## (5) Handoff file model
+`NEXT_SESSION.md` is a **relative symlink** to this file in `docs/handoffs/`. Authored once here; the symlink is retargeted in the same commit on the feature branch (new path → no add/add conflict; `main` updates cleanly on merge). Per the baton convention the handoff rides inside the PR — do **not** sync to `main` during the pause window.
+
+## Closing inventory
+- **State on close:** PR opening on `feature/preview-repair-arm-tests-388` (2 commits: `3e81b34` test code + this docs/handoff commit). No worktree used (small test-only change, edited on a branch in the main checkout off current `main` @ `143f778`). #388 closes on merge. Merged #383 worktree/branch cleaned up.
+- **Acceptance:** `cargo test --release -p secretary-ffi-bridge repair::tests::preview` → 5 passed; `cargo clippy --release -p secretary-ffi-bridge --tests -- -D warnings` clean.
+- **README / ROADMAP:** no update needed — pure test coverage for the already-documented #374 follow-up; nothing user-facing (verified by grep for `#388` / `preview_repair` / `#374`).
+- **NEXT_SESSION.md:** symlink → `docs/handoffs/2026-07-07-preview-repair-arm-tests-388-shipped.md`.

--- a/ffi/secretary-ffi-bridge/src/repair/tests/mod.rs
+++ b/ffi/secretary-ffi-bridge/src/repair/tests/mod.rs
@@ -32,8 +32,8 @@ use super::orchestration::{
 };
 use super::preview::preview_repair_with_password_in;
 use super::{
-    preview_repair_with_password, repair_vault_with_device_secret, repair_vault_with_password,
-    repair_vault_with_recovery,
+    preview_repair_with_device_secret, preview_repair_with_password, preview_repair_with_recovery,
+    repair_vault_with_device_secret, repair_vault_with_password, repair_vault_with_recovery,
 };
 
 // ── fixture helpers (mirrors `device.rs`'s `tmp_golden_vault`) ─────────────

--- a/ffi/secretary-ffi-bridge/src/repair/tests/preview.rs
+++ b/ffi/secretary-ffi-bridge/src/repair/tests/preview.rs
@@ -62,6 +62,136 @@ fn preview_with_password_reports_widening() {
     );
 }
 
+/// Arm parity (recovery): `preview_repair_with_recovery` on the same
+/// crashed-`share_block` widening residue must report the identical single
+/// `FfiWideningReport` the password arm does — same block name/UUID, a
+/// round-tripped `file_fingerprint_hex`, and the one added recipient's
+/// UUID + verified display name. The three arms funnel through the same
+/// `project_preview` projection, so this guards specifically against an
+/// FFI-projection wiring mistake in the recovery arm (the risk #388
+/// calls out). Staging opens with the password; the preview unlocks with
+/// the 24-word mnemonic — both are valid unlock paths for the same vault.
+#[test]
+fn preview_with_recovery_reports_widening() {
+    let (_tmp, folder) = tmp_golden_vault();
+    let pw = golden_password();
+    let pw_secret = SecretBytes::new(pw.clone());
+    let mut rng = ChaCha20Rng::from_seed([0xba; 32]);
+    let open = open_vault(&folder, Unlocker::Password(&pw_secret), None).unwrap();
+    let (device_uuid, block_uuid) = ([0xbb; 16], [0xbc; 16]);
+    let card_c = mint_external_card(0xbd, "Dee");
+    let staged = stage_crashed_share(&folder, open, block_uuid, device_uuid, &card_c, &mut rng);
+
+    let manifest_before_preview = std::fs::read(folder.join("manifest.cbor.enc")).unwrap();
+
+    let preview = preview_repair_with_recovery(&folder, VAULT_001_PHRASE)
+        .expect("preview must succeed on consent-eligible widening residue via the recovery arm");
+
+    assert_eq!(preview.widenings.len(), 1, "exactly one widened block");
+    let report = &preview.widenings[0];
+    assert_eq!(report.block_uuid_hex, format_uuid_hyphenated(&block_uuid));
+    assert_eq!(report.block_name, "mine");
+    assert_eq!(
+        report.file_fingerprint_hex,
+        hex::encode(staged.file_fingerprint),
+        "file_fingerprint_hex must round-trip the on-disk BLAKE3 fingerprint"
+    );
+    assert_eq!(report.added.len(), 1, "exactly one added recipient");
+    let added = &report.added[0];
+    assert_eq!(
+        added.uuid_hex,
+        format_uuid_hyphenated(&staged.added_contact_uuid)
+    );
+    assert_eq!(added.display_name, "Dee");
+    assert_eq!(
+        added.card_fingerprint_hex.len(),
+        32,
+        "card_fingerprint_hex must be 32 lowercase hex chars (16-byte identity fingerprint)"
+    );
+
+    // Read-only: preview must not write anything, including the manifest.
+    assert_eq!(
+        std::fs::read(folder.join("manifest.cbor.enc")).unwrap(),
+        manifest_before_preview,
+        "preview_repair must not mutate the manifest"
+    );
+}
+
+/// Arm parity (device-secret): `preview_repair_with_device_secret`,
+/// unlocking via a freshly-enrolled device slot (ADR 0009), must report
+/// the identical single `FfiWideningReport` on the same crashed-`share`
+/// residue. Guards the device-secret FFI-projection wiring. Mirrors the
+/// device-slot setup in `consent.rs::repair_with_device_secret_adopts_with_exact_approval`.
+#[test]
+fn preview_with_device_secret_reports_widening() {
+    let (_tmp, folder) = tmp_golden_vault();
+    let pw = golden_password();
+    let mut rng = ChaCha20Rng::from_seed([0xbe; 32]);
+
+    let enrolled = add_device_slot(&folder, &pw).expect("add_device_slot must succeed");
+    let device_uuid: [u8; 16] = enrolled
+        .device_uuid
+        .as_slice()
+        .try_into()
+        .expect("device_uuid must be 16 bytes");
+    let device_secret_bytes = enrolled
+        .device_secret
+        .take_secret()
+        .expect("first take_secret must return Some");
+    let device_secret: [u8; 32] = device_secret_bytes
+        .as_slice()
+        .try_into()
+        .expect("device secret must be 32 bytes");
+
+    let device_secret_sb = SecretBytes::new(device_secret.to_vec());
+    let open = open_vault(
+        &folder,
+        Unlocker::DeviceSecret {
+            device_uuid: &device_uuid,
+            secret: &device_secret_sb,
+        },
+        None,
+    )
+    .unwrap();
+    let block_uuid = [0xbf; 16];
+    let card_c = mint_external_card(0xc0, "Eff");
+    let staged = stage_crashed_share(&folder, open, block_uuid, device_uuid, &card_c, &mut rng);
+
+    let manifest_before_preview = std::fs::read(folder.join("manifest.cbor.enc")).unwrap();
+
+    let preview = preview_repair_with_device_secret(&folder, &device_uuid, &device_secret)
+        .expect("preview must succeed on widening residue via the device-secret arm");
+
+    assert_eq!(preview.widenings.len(), 1, "exactly one widened block");
+    let report = &preview.widenings[0];
+    assert_eq!(report.block_uuid_hex, format_uuid_hyphenated(&block_uuid));
+    assert_eq!(report.block_name, "mine");
+    assert_eq!(
+        report.file_fingerprint_hex,
+        hex::encode(staged.file_fingerprint),
+        "file_fingerprint_hex must round-trip the on-disk BLAKE3 fingerprint"
+    );
+    assert_eq!(report.added.len(), 1, "exactly one added recipient");
+    let added = &report.added[0];
+    assert_eq!(
+        added.uuid_hex,
+        format_uuid_hyphenated(&staged.added_contact_uuid)
+    );
+    assert_eq!(added.display_name, "Eff");
+    assert_eq!(
+        added.card_fingerprint_hex.len(),
+        32,
+        "card_fingerprint_hex must be 32 lowercase hex chars (16-byte identity fingerprint)"
+    );
+
+    // Read-only: preview must not write anything, including the manifest.
+    assert_eq!(
+        std::fs::read(folder.join("manifest.cbor.enc")).unwrap(),
+        manifest_before_preview,
+        "preview_repair must not mutate the manifest"
+    );
+}
+
 /// A crashed `save_block` (interrupted content save, not a widening) is
 /// exactly what `repair_vault` adopts unconditionally — there is nothing
 /// to consent to. `preview_repair_with_password` must report zero


### PR DESCRIPTION
Closes #388.

## What

Adds happy-path bridge tests for the **recovery-phrase** and **device-secret** arms of `preview_repair`. The password arm already had full happy-path coverage in the bridge crate; the other two arms funnel through the same `project_preview` projection but had no happy-path execution test of their own — leaving an arm-specific FFI-projection wiring mistake able to go unnoticed (the exact risk #388 flags).

Two new tests in `ffi/secretary-ffi-bridge/src/repair/tests/preview.rs`, each mirroring `preview_with_password_reports_widening`:

- `preview_with_recovery_reports_widening` — unlocks via the golden 24-word mnemonic (`VAULT_001_PHRASE`).
- `preview_with_device_secret_reports_widening` — unlocks via a freshly-enrolled device slot (`add_device_slot`; mirrors the device-slot setup in `consent.rs`).

Each stages the canonical crashed-`share_block` widening residue, asserts the read-only preview reports the identical single `FfiWideningReport` (block name/UUID, round-tripped BLAKE3 `file_fingerprint_hex`, one added recipient with verified display name + 16-byte card fingerprint), and asserts the manifest is byte-untouched.

**Test-only change** — no production code touched. A #374 follow-up.

## Verification

```
cargo test --release -p secretary-ffi-bridge repair::tests::preview   # 5 passed; 0 failed
cargo clippy --release -p secretary-ffi-bridge --tests -- -D warnings  # clean
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)