### PR TITLE
feat(desktop): dialog aria-labelledby parity across all native <dialog> components (#389)

### DIFF
--- a/NEXT_SESSION.md
+++ b/NEXT_SESSION.md
@@ -1,1 +1,1 @@
-docs/handoffs/2026-07-07-preview-repair-arm-tests-388-shipped.md
+docs/handoffs/2026-07-07-dialog-aria-labelledby-389-shipped.md

--- a/desktop/src/components/ConflictResolutionDialog.svelte
+++ b/desktop/src/components/ConflictResolutionDialog.svelte
@@ -83,9 +83,14 @@
   }
 </script>
 
-<dialog bind:this={dialogEl} class="conflict-dialog" oncancel={onNativeCancel}>
+<dialog
+  bind:this={dialogEl}
+  class="conflict-dialog"
+  aria-labelledby="conflict-dialog-title"
+  oncancel={onNativeCancel}
+>
   <form class="conflict-dialog__form" onsubmit={apply}>
-    <h2 class="conflict-dialog__title">Resolve sync conflicts</h2>
+    <h2 id="conflict-dialog-title" class="conflict-dialog__title">Resolve sync conflicts</h2>
     <p class="conflict-dialog__subtitle">
       These records were deleted on another device but you still have them. Choose what to keep —
       nothing is written until you click Apply.

--- a/desktop/src/components/ReauthPasswordDialog.svelte
+++ b/desktop/src/components/ReauthPasswordDialog.svelte
@@ -62,9 +62,14 @@
   }
 </script>
 
-<dialog bind:this={dialogEl} class="reauth-dialog" onclose={onNativeClose}>
+<dialog
+  bind:this={dialogEl}
+  class="reauth-dialog"
+  aria-labelledby="reauth-dialog-title"
+  onclose={onNativeClose}
+>
   {#if prompt}
-    <h2 class="reauth-dialog__title">Confirm with your password</h2>
+    <h2 id="reauth-dialog-title" class="reauth-dialog__title">Confirm with your password</h2>
     <p class="reauth-dialog__reason">{prompt.reason}</p>
     <label class="reauth-dialog__field">
       <span class="reauth-dialog__label">Password</span>

--- a/desktop/src/components/RepairConsentDialog.svelte
+++ b/desktop/src/components/RepairConsentDialog.svelte
@@ -66,8 +66,13 @@
   }
 </script>
 
-<dialog bind:this={dialogEl} class="repair-consent" oncancel={onNativeCancel}>
-  <h2 class="repair-consent__title">An interrupted share was found.</h2>
+<dialog
+  bind:this={dialogEl}
+  class="repair-consent"
+  aria-labelledby="repair-consent-title"
+  oncancel={onNativeCancel}
+>
+  <h2 id="repair-consent-title" class="repair-consent__title">An interrupted share was found.</h2>
   <p class="repair-consent__body">
     Adopting this repair will give these contacts access to this block. If you don't recognize
     this, choose Cancel — the vault stays unchanged.

--- a/desktop/src/components/SettingsDialog.svelte
+++ b/desktop/src/components/SettingsDialog.svelte
@@ -209,8 +209,13 @@
   }
 </script>
 
-<dialog bind:this={dialogEl} class="settings-dialog" onclose={onNativeClose}>
-  <h2 class="settings-dialog__title">Settings</h2>
+<dialog
+  bind:this={dialogEl}
+  class="settings-dialog"
+  aria-labelledby="settings-dialog-title"
+  onclose={onNativeClose}
+>
+  <h2 id="settings-dialog-title" class="settings-dialog__title">Settings</h2>
 
   <label class="settings-dialog__field">
     <span class="settings-dialog__label">Auto-lock after</span>

--- a/desktop/src/components/SyncPasswordDialog.svelte
+++ b/desktop/src/components/SyncPasswordDialog.svelte
@@ -64,9 +64,14 @@
   }
 </script>
 
-<dialog bind:this={dialogEl} class="sync-dialog" oncancel={onNativeCancel}>
+<dialog
+  bind:this={dialogEl}
+  class="sync-dialog"
+  aria-labelledby="sync-dialog-title"
+  oncancel={onNativeCancel}
+>
   <form class="sync-dialog__form" onsubmit={submit}>
-    <h2 class="sync-dialog__title">Confirm your password</h2>
+    <h2 id="sync-dialog-title" class="sync-dialog__title">Confirm your password</h2>
     <p class="sync-dialog__subtitle">Needed to sync this vault.</p>
 
     <label class="sync-dialog__label" for="sync-password">Password</label>

--- a/desktop/src/components/delete/ConfirmDialog.svelte
+++ b/desktop/src/components/delete/ConfirmDialog.svelte
@@ -39,8 +39,13 @@
   }
 </script>
 
-<dialog bind:this={dialogEl} class="confirm-dialog" oncancel={onNativeCancel}>
-  <h2 class="confirm-dialog__title">{title}</h2>
+<dialog
+  bind:this={dialogEl}
+  class="confirm-dialog"
+  aria-labelledby="confirm-dialog-title"
+  oncancel={onNativeCancel}
+>
+  <h2 id="confirm-dialog-title" class="confirm-dialog__title">{title}</h2>
   <p class="confirm-dialog__body">{body}</p>
 
   <div class="confirm-dialog__actions">

--- a/desktop/src/components/edit/MoveTargetPicker.svelte
+++ b/desktop/src/components/edit/MoveTargetPicker.svelte
@@ -26,8 +26,8 @@
   });
 </script>
 
-<dialog class="move-picker" open>
-  <h3 class="move-picker__title">Move to which block?</h3>
+<dialog class="move-picker" aria-labelledby="move-picker-title" open>
+  <h3 id="move-picker-title" class="move-picker__title">Move to which block?</h3>
   {#if error}
     {@const msg = userMessageFor(error)}
     <p class="move-picker__error" role="alert">{msg.title}</p>

--- a/desktop/src/components/share/ShareDialog.svelte
+++ b/desktop/src/components/share/ShareDialog.svelte
@@ -123,8 +123,13 @@
   }
 </script>
 
-<dialog bind:this={dialogEl} class="share-dialog" oncancel={onNativeCancel}>
-  <h2 class="share-dialog__title">Share “{block.blockName}”</h2>
+<dialog
+  bind:this={dialogEl}
+  class="share-dialog"
+  aria-labelledby="share-dialog-title"
+  oncancel={onNativeCancel}
+>
+  <h2 id="share-dialog-title" class="share-dialog__title">Share “{block.blockName}”</h2>
 
   {#if unreadable > 0}
     <p class="share-dialog__warn" role="status">

--- a/desktop/tests/ConfirmDialog.test.ts
+++ b/desktop/tests/ConfirmDialog.test.ts
@@ -70,4 +70,18 @@ describe('ConfirmDialog.svelte', () => {
     expect(getByRole('button', { name: 'Delete' }).getAttribute('type')).toBe('button');
     expect(getByRole('button', { name: /cancel/i }).getAttribute('type')).toBe('button');
   });
+
+  // #389: screen readers should announce the dialog's title on open. Native
+  // <dialog> gives an implicit role="dialog" but no accessible name unless the
+  // title is wired via aria-labelledby.
+  it('labels the dialog with its title via aria-labelledby (#389)', () => {
+    const { container } = renderDialog();
+    const dialog = container.querySelector('dialog') as HTMLDialogElement;
+    const labelId = dialog.getAttribute('aria-labelledby');
+    expect(labelId).toBeTruthy();
+    const title = container.querySelector(`#${labelId}`);
+    expect(title).not.toBeNull();
+    expect(dialog.contains(title)).toBe(true);
+    expect(title?.textContent).toBe('Delete this record?');
+  });
 });

--- a/desktop/tests/ConflictResolutionDialog.test.ts
+++ b/desktop/tests/ConflictResolutionDialog.test.ts
@@ -86,4 +86,16 @@ describe('ConflictResolutionDialog.svelte', () => {
     });
     expect(getByText(/auto-merged/i)).toBeTruthy();
   });
+
+  // #389: announce the dialog's title to screen readers on open.
+  it('labels the dialog with its title via aria-labelledby (#389)', () => {
+    const { container } = renderDialog();
+    const dialog = container.querySelector('dialog') as HTMLDialogElement;
+    const labelId = dialog.getAttribute('aria-labelledby');
+    expect(labelId).toBeTruthy();
+    const title = container.querySelector(`#${labelId}`);
+    expect(title).not.toBeNull();
+    expect(dialog.contains(title)).toBe(true);
+    expect(title?.textContent).toBe('Resolve sync conflicts');
+  });
 });

--- a/desktop/tests/MoveTargetPicker.test.ts
+++ b/desktop/tests/MoveTargetPicker.test.ts
@@ -23,4 +23,19 @@ describe('MoveTargetPicker', () => {
     await fireEvent.click(getByRole('button', { name: /Target/ }));
     expect(onSelect).toHaveBeenCalledWith(blocks[1]);
   });
+
+  // #389: announce the picker's title to screen readers on open.
+  it('labels the dialog with its title via aria-labelledby (#389)', () => {
+    invokeMock.mockResolvedValueOnce(blocks); // list_blocks
+    const { container } = render(MoveTargetPicker, {
+      props: { sourceBlockUuidHex: 'src', onSelect: vi.fn(), onCancel: vi.fn() }
+    });
+    const dialog = container.querySelector('dialog') as HTMLDialogElement;
+    const labelId = dialog.getAttribute('aria-labelledby');
+    expect(labelId).toBeTruthy();
+    const title = container.querySelector(`#${labelId}`);
+    expect(title).not.toBeNull();
+    expect(dialog.contains(title)).toBe(true);
+    expect(title?.textContent).toBe('Move to which block?');
+  });
 });

--- a/desktop/tests/ReauthPasswordDialog.test.ts
+++ b/desktop/tests/ReauthPasswordDialog.test.ts
@@ -75,7 +75,7 @@ describe('ReauthPasswordDialog.svelte — confirm happy path', () => {
     const { getByText, getByLabelText } = render(ReauthPasswordDialog);
     openReauthPrompt('Confirm deleting this entry');
     await waitFor(() => getByText('Confirm deleting this entry'));
-    await fireEvent.input(getByLabelText(/password/i), { target: { value: 'pw' } });
+    await fireEvent.input(getByLabelText(/^password$/i), { target: { value: 'pw' } });
     await fireEvent.click(getByText('Confirm'));
     await waitFor(() => {
       expect(verifyPassword).toHaveBeenCalledWith('pw');
@@ -87,7 +87,7 @@ describe('ReauthPasswordDialog.svelte — confirm happy path', () => {
     const { getByText, getByLabelText } = render(ReauthPasswordDialog);
     openReauthPrompt('Confirm saving');
     await waitFor(() => getByText('Confirm saving'));
-    await fireEvent.input(getByLabelText(/password/i), { target: { value: 'correct-pw' } });
+    await fireEvent.input(getByLabelText(/^password$/i), { target: { value: 'correct-pw' } });
     await fireEvent.click(getByText('Confirm'));
     await waitFor(() => {
       expect(resolveReauthMock).toHaveBeenCalledTimes(1);
@@ -102,7 +102,7 @@ describe('ReauthPasswordDialog.svelte — wrong password stays open', () => {
     const { getByText, getByLabelText, queryByRole } = render(ReauthPasswordDialog);
     openReauthPrompt('Confirm saving this entry');
     await waitFor(() => getByText('Confirm saving this entry'));
-    await fireEvent.input(getByLabelText(/password/i), { target: { value: 'bad' } });
+    await fireEvent.input(getByLabelText(/^password$/i), { target: { value: 'bad' } });
     await fireEvent.click(getByText('Confirm'));
     await waitFor(() => {
       expect(queryByRole('alert')).toBeTruthy();
@@ -114,7 +114,7 @@ describe('ReauthPasswordDialog.svelte — wrong password stays open', () => {
     const { getByText, getByLabelText, queryByRole } = render(ReauthPasswordDialog);
     openReauthPrompt('Confirm saving this entry');
     await waitFor(() => getByText('Confirm saving this entry'));
-    await fireEvent.input(getByLabelText(/password/i), { target: { value: 'bad' } });
+    await fireEvent.input(getByLabelText(/^password$/i), { target: { value: 'bad' } });
     await fireEvent.click(getByText('Confirm'));
     // Wait for the error alert to appear (means verify settled), then assert no resolve.
     await waitFor(() => expect(queryByRole('alert')).toBeTruthy());
@@ -141,5 +141,21 @@ describe('ReauthPasswordDialog.svelte — cancel', () => {
     await waitFor(() => {
       expect(resolveReauthMock).not.toHaveBeenCalled();
     });
+  });
+});
+
+describe('ReauthPasswordDialog.svelte — accessibility', () => {
+  // #389: when open, the dialog's accessible name is its title heading.
+  it('labels the dialog with its title via aria-labelledby (#389)', async () => {
+    const { container, getByText } = render(ReauthPasswordDialog);
+    openReauthPrompt('Confirm something');
+    await waitFor(() => getByText('Confirm something'));
+    const dialog = container.querySelector('dialog') as HTMLDialogElement;
+    const labelId = dialog.getAttribute('aria-labelledby');
+    expect(labelId).toBeTruthy();
+    const title = container.querySelector(`#${labelId}`);
+    expect(title).not.toBeNull();
+    expect(dialog.contains(title)).toBe(true);
+    expect(title?.textContent).toBe('Confirm with your password');
   });
 });

--- a/desktop/tests/RepairConsentDialog.test.ts
+++ b/desktop/tests/RepairConsentDialog.test.ts
@@ -138,4 +138,16 @@ describe('RepairConsentDialog.svelte', () => {
       'button'
     );
   });
+
+  // #389: the consent modal must announce its title to screen readers on open.
+  it('labels the dialog with its title via aria-labelledby (#389)', () => {
+    const { container } = renderDialog();
+    const dialog = container.querySelector('dialog') as HTMLDialogElement;
+    const labelId = dialog.getAttribute('aria-labelledby');
+    expect(labelId).toBeTruthy();
+    const title = container.querySelector(`#${labelId}`);
+    expect(title).not.toBeNull();
+    expect(dialog.contains(title)).toBe(true);
+    expect(title?.textContent).toBe('An interrupted share was found.');
+  });
 });

--- a/desktop/tests/SettingsDialog.test.ts
+++ b/desktop/tests/SettingsDialog.test.ts
@@ -546,4 +546,17 @@ describe('SettingsDialog.svelte — accessibility', () => {
     const { getByRole } = renderOpen();
     expect(getByRole('heading', { name: /settings/i })).toBeTruthy();
   });
+
+  // #389: wire the heading to the dialog so its accessible name is the title.
+  it('labels the dialog with its title via aria-labelledby (#389)', () => {
+    unlockWith();
+    const { container } = renderOpen();
+    const dialog = container.querySelector('dialog') as HTMLDialogElement;
+    const labelId = dialog.getAttribute('aria-labelledby');
+    expect(labelId).toBeTruthy();
+    const title = container.querySelector(`#${labelId}`);
+    expect(title).not.toBeNull();
+    expect(dialog.contains(title)).toBe(true);
+    expect(title?.textContent).toBe('Settings');
+  });
 });

--- a/desktop/tests/ShareDialog.test.ts
+++ b/desktop/tests/ShareDialog.test.ts
@@ -105,6 +105,19 @@ describe('ShareDialog.svelte', () => {
     // The dialog stays open on error (onClose only fires on success).
     expect(onClose).not.toHaveBeenCalled();
   });
+
+  // #389: announce the dialog's title (which names the block) on open.
+  it('labels the dialog with its title via aria-labelledby (#389)', async () => {
+    invokeMock.mockResolvedValueOnce({ contacts: [], unreadableCount: 0 }); // list_contacts
+    const { container } = render(ShareDialog, { props: { block: BLOCK, onClose: vi.fn() } });
+    const dialog = container.querySelector('dialog') as HTMLDialogElement;
+    const labelId = dialog.getAttribute('aria-labelledby');
+    expect(labelId).toBeTruthy();
+    const title = container.querySelector(`#${labelId}`);
+    expect(title).not.toBeNull();
+    expect(dialog.contains(title)).toBe(true);
+    expect(title?.textContent).toMatch(/Share.*Logins/);
+  });
 });
 
 describe('ShareDialog — write-reauth gate', () => {

--- a/desktop/tests/SyncPasswordDialog.test.ts
+++ b/desktop/tests/SyncPasswordDialog.test.ts
@@ -28,14 +28,14 @@ describe('SyncPasswordDialog.svelte', () => {
       const dialog = container.querySelector('dialog') as HTMLDialogElement;
       expect(dialog.hasAttribute('open')).toBe(true);
     });
-    expect(getByLabelText(/password/i)).toBeTruthy();
+    expect(getByLabelText(/^password$/i)).toBeTruthy();
     expect(getByRole('button', { name: /sync/i })).toBeTruthy();
   });
 
   it('calls syncNow with the typed password and onSynced with the outcome', async () => {
     mockSyncNow.mockResolvedValue({ kind: 'nothingToDo' });
     const { getByLabelText, getByRole, onSynced } = renderDialog();
-    await fireEvent.input(getByLabelText(/password/i), { target: { value: 'hunter2' } });
+    await fireEvent.input(getByLabelText(/^password$/i), { target: { value: 'hunter2' } });
     await fireEvent.click(getByRole('button', { name: /^sync$/i }));
     await waitFor(() => expect(mockSyncNow).toHaveBeenCalledWith('hunter2'));
     expect(onSynced).toHaveBeenCalledWith({ kind: 'nothingToDo' });
@@ -46,7 +46,7 @@ describe('SyncPasswordDialog.svelte', () => {
     // unhandled-rejection that fails this test even though it is caught.
     mockSyncNow.mockRejectedValueOnce({ code: 'wrong_password' });
     const { getByLabelText, getByRole, findByRole, onSynced } = renderDialog();
-    await fireEvent.input(getByLabelText(/password/i), { target: { value: 'bad' } });
+    await fireEvent.input(getByLabelText(/^password$/i), { target: { value: 'bad' } });
     await fireEvent.click(getByRole('button', { name: /^sync$/i }));
     const alert = await findByRole('alert');
     expect(alert.textContent).toMatch(/wrong password/i);
@@ -72,7 +72,7 @@ describe('SyncPasswordDialog.svelte', () => {
     };
     mockSyncNow.mockResolvedValueOnce(outcome);
     const { getByLabelText, getByRole, onConflicts, onSynced } = renderDialog();
-    await fireEvent.input(getByLabelText(/password/i), { target: { value: 'thepassword' } });
+    await fireEvent.input(getByLabelText(/^password$/i), { target: { value: 'thepassword' } });
     await fireEvent.click(getByRole('button', { name: /^sync$/i }));
     await waitFor(() => expect(onConflicts).toHaveBeenCalledWith(outcome, 'thepassword'));
     expect(onSynced).not.toHaveBeenCalled();
@@ -83,5 +83,17 @@ describe('SyncPasswordDialog.svelte', () => {
     await fireEvent.click(getByRole('button', { name: /cancel/i }));
     expect(onCancel).toHaveBeenCalledTimes(1);
     expect(mockSyncNow).not.toHaveBeenCalled();
+  });
+
+  // #389: announce the dialog's title to screen readers on open.
+  it('labels the dialog with its title via aria-labelledby (#389)', () => {
+    const { container } = renderDialog();
+    const dialog = container.querySelector('dialog') as HTMLDialogElement;
+    const labelId = dialog.getAttribute('aria-labelledby');
+    expect(labelId).toBeTruthy();
+    const title = container.querySelector(`#${labelId}`);
+    expect(title).not.toBeNull();
+    expect(dialog.contains(title)).toBe(true);
+    expect(title?.textContent).toBe('Confirm your password');
   });
 });

--- a/desktop/tests/SyncPill.test.ts
+++ b/desktop/tests/SyncPill.test.ts
@@ -50,7 +50,7 @@ describe('SyncPill.svelte', () => {
     const { findByRole, getByLabelText, findByText } = render(SyncPill);
 
     await fireEvent.click(await findByRole('button', { name: /sync/i }));
-    await fireEvent.input(getByLabelText(/password/i), { target: { value: 'pw' } });
+    await fireEvent.input(getByLabelText(/^password$/i), { target: { value: 'pw' } });
     await fireEvent.click(await findByRole('button', { name: /^sync$/i }));
 
     expect(await findByText(/your vault is up to date/i)).toBeTruthy();
@@ -65,7 +65,7 @@ describe('SyncPill.svelte', () => {
     mockSyncNow.mockResolvedValue({ kind: 'nothingToDo' });
     const { findByRole, getByLabelText, findByText } = render(SyncPill);
     await fireEvent.click(await findByRole('button', { name: /sync/i }));
-    await fireEvent.input(getByLabelText(/password/i), { target: { value: 'pw' } });
+    await fireEvent.input(getByLabelText(/^password$/i), { target: { value: 'pw' } });
     await fireEvent.click(await findByRole('button', { name: /^sync$/i }));
     expect(await findByText(/already up to date/i)).toBeTruthy();
     expect(mockRefresh).not.toHaveBeenCalled();
@@ -98,7 +98,7 @@ describe('SyncPill.svelte', () => {
 
     // Open password dialog, enter password, sync → conflictsPending.
     await fireEvent.click(await findByRole('button', { name: /sync/i }));
-    await fireEvent.input(getByLabelText(/password/i), { target: { value: 'pw' } });
+    await fireEvent.input(getByLabelText(/^password$/i), { target: { value: 'pw' } });
     await fireEvent.click(await findByRole('button', { name: /^sync$/i }));
 
     // The resolution dialog renders.
@@ -125,7 +125,7 @@ describe('SyncPill.svelte', () => {
 
       // Trigger a sync so a notice appears.
       await fireEvent.click(await findByRole('button', { name: /sync/i }));
-      await fireEvent.input(getByLabelText(/password/i), { target: { value: 'pw' } });
+      await fireEvent.input(getByLabelText(/^password$/i), { target: { value: 'pw' } });
       await fireEvent.click(await findByRole('button', { name: /^sync$/i }));
 
       // Drain only microtasks (Promise resolutions) without advancing timers,

--- a/docs/handoffs/2026-07-07-dialog-aria-labelledby-389-shipped.md
+++ b/docs/handoffs/2026-07-07-dialog-aria-labelledby-389-shipped.md
@@ -1,0 +1,74 @@
+# NEXT_SESSION.md — #389 desktop dialog aria-labelledby parity ✅ SHIPPED (PR opening)
+
+**Session date:** 2026-07-07. A small desktop-accessibility session that closed the last remaining #374 follow-up, **#389**: wired `aria-labelledby` across **all eight** native `<dialog>` components so screen readers announce each dialog's title on open. Branch `feature/dialog-aria-labelledby-389` cut from `main` @ `7870595`. First, housekept the merged #388 (PR #393): removed the stale local `feature/preview-repair-arm-tests-388` branch (remote already pruned; verified its code was fully in `main` before force-deleting the leftover handoff commit).
+
+## (1) What we shipped this session
+
+**#389 aria-labelledby parity** (commit `7511315`). Native `<dialog>` gives an implicit `role="dialog"` but **no accessible name** unless its title is wired via `aria-labelledby` — so no dialog announced its title on open. Gave each dialog's title heading a stable `id` (matching its BEM prefix, e.g. `confirm-dialog-title`) and referenced it from the `<dialog>`, consistently across all eight modals rather than fixing the two named ones in isolation (the #374 review's ask):
+
+| Component | id / title |
+|---|---|
+| [delete/ConfirmDialog.svelte](desktop/src/components/delete/ConfirmDialog.svelte) | `confirm-dialog-title` (dynamic `{title}`) |
+| [RepairConsentDialog.svelte](desktop/src/components/RepairConsentDialog.svelte) | `repair-consent-title` — "An interrupted share was found." |
+| [SettingsDialog.svelte](desktop/src/components/SettingsDialog.svelte) | `settings-dialog-title` — "Settings" |
+| [ConflictResolutionDialog.svelte](desktop/src/components/ConflictResolutionDialog.svelte) | `conflict-dialog-title` — "Resolve sync conflicts" |
+| [SyncPasswordDialog.svelte](desktop/src/components/SyncPasswordDialog.svelte) | `sync-dialog-title` — "Confirm your password" |
+| [ReauthPasswordDialog.svelte](desktop/src/components/ReauthPasswordDialog.svelte) | `reauth-dialog-title` — "Confirm with your password" (inside `{#if prompt}`; id present only while open, which is correct) |
+| [share/ShareDialog.svelte](desktop/src/components/share/ShareDialog.svelte) | `share-dialog-title` — `Share "{blockName}"` |
+| [edit/MoveTargetPicker.svelte](desktop/src/components/edit/MoveTargetPicker.svelte) | `move-picker-title` — "Move to which block?" (`<h3>`; `open` not `showModal`) |
+
+**TDD** — added one happy-path assertion per dialog test (8 total): the `<dialog>`'s `aria-labelledby` resolves to an in-dialog title element with the expected text. Confirmed all 8 **red** before wiring, then **green** after. Assertions check the wiring resolves (id → title element inside the dialog) rather than pinning the literal id string, so an id rename stays green while the a11y contract is enforced.
+
+**Collateral fix (same commit):** three pre-existing tests located the password **input** via a loose `getByLabelText(/password/i)`. Once the dialog gained an accessible name containing "password" ("Confirm your password" / "Confirm with your password"), that query became ambiguous (`Found multiple elements`). Anchored those to `getByLabelText(/^password$/i)` in [SyncPill.test.ts](desktop/tests/SyncPill.test.ts), [SyncPasswordDialog.test.ts](desktop/tests/SyncPasswordDialog.test.ts), [ReauthPasswordDialog.test.ts](desktop/tests/ReauthPasswordDialog.test.ts) — the input's own label is exactly "Password", so the anchor matches the input and not the dialog name.
+
+**Scope note:** `edit/BlockNameDialog.svelte` is a `<section>` inline editor, **not** a native `<dialog>` — correctly out of scope.
+
+**Filed [#394](https://github.com/hherb/secretary/issues/394)** (incidental, pre-existing): `pnpm typecheck` (bare `tsc --noEmit`) fails on a Svelte `<script module>` named export (`groupHex` from `RepairConsentDialog.svelte`). `tsc` can't resolve Svelte module exports; `pnpm svelte-check` (the correct tool) passes 0-errors, and desktop CI runs only `pnpm test`/vitest. Not a regression, not a CI gate — filed so the failing script isn't mistaken for one later.
+
+### Branch commits (off `main` @ `7870595`)
+`7511315` feat(desktop): wire aria-labelledby across all native `<dialog>` components (#389) → then this docs/handoff commit.
+
+### Acceptance (verified this session, from `desktop/`)
+```bash
+cd /Users/hherb/src/secretary/desktop
+pnpm test            # → Test Files 76 passed (76); Tests 604 passed (604)
+pnpm run svelte-check # → 0 ERRORS 0 WARNINGS
+pnpm run lint         # → clean
+```
+
+## (2) What's next
+
+Menu (unchanged minus #389, now shipped):
+
+1. **Manual GUI smoke of the #374 consent flow** (human-only, still carried): `pnpm tauri dev` against a **temp copy** ([[feedback_smoke_test_temp_copy_golden_vault]]) of a vault with staged crashed-share residue (`core/tests/crash_recovery.rs::stage_crashed_share`). Confirm unlock → "Repair now?" → consent dialog renders the added recipient + grouped fingerprint → Cancel leaves vault untouched → Grant adopts the widened set. With #389 done you can also spot-check VoiceOver announces each dialog's title on open.
+2. **#376 remainder** — `trash_block` secure-overwrite fallback + legacy `fingerprint == None` trash-entry migration decisions (design-heavy → brainstorm first, no code). (Recommended next if you want a meaty core slice.)
+3. **#379** — desktop `errors.rs` 726-line split (enum / `map_ffi_error` / serde tests). Pure refactor, under the 500-line guideline.
+4. **#394** (new, tiny) — decide the fate of the desktop `typecheck` script (drop / make svelte-aware / narrow includes).
+5. **Housekeeping:** #387 (`:kit` NewApi lint on `StrongBoxUnavailableException`, min SDK 26 / API 28), #290 (`spec_test_name_freshness.py` 3 pre-existing D.4 design-concept false-positives — Python, your strong area).
+6. **Carried mobile (on-device / human-only):** iOS Face ID spot-check; Android #338 on-device biometric cloud-open, #331 SAF custom-ROM, #334 native cloud-provider epic (ADR + threat-model first).
+
+## (3) Open decisions and risks
+
+- **None introduced this session.** Additive a11y attributes + test coverage; no `core`, no FFI surface, no spec, no error type touched. Static ids are safe: no two instances of the same dialog component mount simultaneously (parents mount one-at-a-time), matching the existing convention (`BlockNameDialog` already uses a static `id="block-name"`).
+- **#394** filed (see above) — pre-existing `typecheck`-script limitation, no impact.
+- **#383 stays OPEN** (unchanged): drop RUSTSEC-2026-0194/0195 from `.cargo/audit.toml` only when `cargo tree -i quick-xml --target all` shows a single quick-xml ≥0.41 (both plist AND wayland-scanner moved). Re-check on every Tauri upgrade / any `cargo update` touching plist or the arboard/wayland clipboard chain. Do NOT `cargo update -p plist` in isolation.
+
+## (4) Exact commands to resume
+```bash
+cd /Users/hherb/src/secretary
+git fetch --prune origin && git checkout main && git pull --ff-only origin main
+# After this PR merges, drop the merged branch (squash-merge leaves it "not fully merged"):
+#   git branch -D feature/dialog-aria-labelledby-389
+git worktree list && git status -s
+# Re-run the desktop suite any time:
+cd desktop && pnpm test && pnpm run svelte-check && pnpm run lint
+```
+
+## (5) Handoff file model
+`NEXT_SESSION.md` is a **relative symlink** to this file in `docs/handoffs/`. Authored once here; the symlink is retargeted in the same commit on the feature branch (new path → no add/add conflict; `main` updates cleanly on merge). Per the baton convention the handoff rides inside the PR — do **not** sync to `main` during the pause window.
+
+## Closing inventory
+- **State on close:** PR opening on `feature/dialog-aria-labelledby-389` (2 commits: `7511315` code + this docs/handoff commit). No worktree used (small desktop-only change, edited on a branch in the main checkout off `main` @ `7870595`). #389 closes on merge. Merged-#388 local branch cleaned up. #394 filed.
+- **Acceptance:** `pnpm test` → 604 passed; `pnpm run svelte-check` → 0 errors; `pnpm run lint` → clean.
+- **README / ROADMAP:** no update needed — #389 is a low-priority a11y polish follow-up to the already-documented #374 epic (ROADMAP line 68), finer-grained than the per-slice/milestone granularity those docs track (same call as test-only #388).
+- **NEXT_SESSION.md:** symlink → `docs/handoffs/2026-07-07-dialog-aria-labelledby-389-shipped.md`.


### PR DESCRIPTION
Closes #389 (the last remaining #374 follow-up).

## What & why

Native `<dialog>` gives an implicit `role="dialog"` but **no accessible name** unless its title is wired via `aria-labelledby`, so screen readers didn't announce a dialog's title on open. This wires each dialog's title heading (stable `id` matching its BEM prefix) to its `<dialog>` consistently across **all eight** modal components — not just the two named in the issue — which was the #374 review's explicit ask (fix the whole convention, not one dialog in isolation):

`ConfirmDialog` · `RepairConsentDialog` · `SettingsDialog` · `ConflictResolutionDialog` · `SyncPasswordDialog` · `ReauthPasswordDialog` · `ShareDialog` · `MoveTargetPicker`.

`edit/BlockNameDialog` is a `<section>` inline editor (not a native `<dialog>`) → correctly out of scope.

## TDD

Each dialog's test gains a happy-path assertion that the `<dialog>`'s `aria-labelledby` resolves to an in-dialog title element with the expected text. All 8 were confirmed **red** before wiring, **green** after. The assertion checks the wiring *resolves* (id → title element inside the dialog) rather than pinning the literal id string.

**Collateral:** three pre-existing tests found the password **input** via a loose `getByLabelText(/password/i)`; once the dialog gained an accessible name containing "password", that query became ambiguous. Anchored them to `/^password$/i` (the input's label is exactly "Password") in `SyncPill`, `SyncPasswordDialog`, `ReauthPasswordDialog` tests.

## Verification

```
pnpm test            → 76 files, 604 tests passed
pnpm run svelte-check → 0 errors, 0 warnings
pnpm run lint         → clean
```

No `core` / FFI / bridge / spec / error-type change — desktop-only additive a11y attributes + tests.

## Incidental

Filed #394: `pnpm typecheck` (bare `tsc`) fails on a Svelte `<script module>` named export — pre-existing, not a CI gate (`svelte-check` covers it and passes), filed so it isn't mistaken for a regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)