### PR TITLE
chore(desktop): drop redundant `tsc --noEmit` typecheck script (#394)

### DIFF
--- a/NEXT_SESSION.md
+++ b/NEXT_SESSION.md
@@ -1,1 +1,1 @@
-docs/handoffs/2026-07-07-dialog-aria-labelledby-389-shipped.md
+docs/handoffs/2026-07-07-drop-desktop-typecheck-script-394-shipped.md

--- a/desktop/README.md
+++ b/desktop/README.md
@@ -54,8 +54,7 @@ pnpm tauri dev                          # launches Vite dev server + Tauri windo
 
 ```bash
 pnpm test                               # Vitest — pure TS module unit tests
-pnpm tsc --noEmit                       # TypeScript type-check
-pnpm svelte-check                       # Svelte type-check
+pnpm svelte-check                       # Type-check (Svelte + .ts); understands component module exports
 pnpm lint                               # ESLint
 # From repo root:
 cargo test --release --workspace        # Rust backend unit + integration tests

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -12,8 +12,7 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "lint": "eslint src tests",
-    "svelte-check": "svelte-check --tsconfig ./tsconfig.json",
-    "typecheck": "tsc --noEmit"
+    "svelte-check": "svelte-check --tsconfig ./tsconfig.json"
   },
   "dependencies": {
     "@tauri-apps/api": "^2",

--- a/docs/handoffs/2026-07-07-drop-desktop-typecheck-script-394-shipped.md
+++ b/docs/handoffs/2026-07-07-drop-desktop-typecheck-script-394-shipped.md
@@ -1,0 +1,68 @@
+# NEXT_SESSION.md — #394 drop redundant desktop `typecheck` script ✅ SHIPPED (PR opening)
+
+**Session date:** 2026-07-07. A tiny desktop dev-tooling cleanup that closes **#394**: removed the broken, redundant `typecheck` script (`tsc --noEmit`) from `desktop/package.json`. Branch `feature/drop-desktop-typecheck-script-394` cut from `main` @ `e99982d` (which already carries #389 / PR #395, merged 2026-07-06). Housekeeping first: confirmed #389 merged, pulled `main`, force-deleted the stale merged local branch `feature/dialog-aria-labelledby-389`.
+
+## (1) What we shipped this session
+
+**#394 — drop the `typecheck` script** (commit `c709194`). Bare `tsc --noEmit` cannot resolve a Svelte component's `<script module lang="ts">` named exports (e.g. `groupHex` from [RepairConsentDialog.svelte](desktop/src/components/RepairConsentDialog.svelte), imported by its test), so `pnpm typecheck` failed with `TS2614` — a false alarm, not a real type error.
+
+**Decision: drop it** (option 1 of the three the issue offered). Empirically verified `svelte-check` is a **strict superset** of what bare `tsc` provided before removing anything:
+
+- it type-checks the `.ts` test files — planted a `const x: number = "s"` in a `*.test.ts` and `svelte-check` caught `Type 'string' is not assignable to type 'number'`;
+- it enforces the same strict tsconfig — the same probe also tripped `noUnusedLocals` (`'x' is declared but its value is never read`);
+- it understands component module-context exports, which bare `tsc` cannot (that's the whole `groupHex` failure).
+
+So bare `tsc` was strictly worse and 100% redundant. Files touched (2):
+- [desktop/package.json](desktop/package.json) — removed the `"typecheck": "tsc --noEmit"` line (fixed the trailing comma on the now-last `svelte-check` entry).
+- [desktop/README.md](desktop/README.md) — the "Test layers" block dropped the `pnpm tsc --noEmit` line; the `svelte-check` line is now labelled as **the** type-check (`Type-check (Svelte + .ts); understands component module exports`).
+
+**Retained:** `desktop/tsconfig.json` is unchanged — it is the config that `svelte-check --tsconfig ./tsconfig.json` and the IDE both consume; only the redundant `tsc` *entry point* is gone.
+
+**No CI / no user impact:** desktop CI runs only `pnpm test` (vitest); `typecheck` was never a gate. Confirmed no `.github/` workflow, root README, or ROADMAP references `typecheck` / `tsc --noEmit` (only worktree checkouts and archived `docs/superpowers/plans/*` do — left alone, they're historical plan text).
+
+### Branch commits (off `main` @ `e99982d`)
+`c709194` chore(desktop): drop redundant `tsc --noEmit` typecheck script (#394) → then this docs/handoff commit.
+
+### Acceptance (verified this session, from `desktop/`)
+```bash
+cd /Users/hherb/src/secretary/desktop
+pnpm test             # → Test Files 76 passed (76); Tests 604 passed (604)
+pnpm run svelte-check # → 332 FILES 0 ERRORS 0 WARNINGS
+pnpm run lint         # → clean
+pnpm typecheck        # → ERR_PNPM_RECURSIVE_EXEC_FIRST_FAIL "typecheck" not found (script correctly gone)
+```
+
+## (2) What's next
+
+Menu (unchanged minus #394, now shipped):
+
+1. **#376 remainder** — `trash_block` secure-overwrite fallback + legacy `fingerprint == None` trash-entry migration decisions (design-heavy → brainstorm first, no code). **Recommended next** if you want a meaty core slice. (Issue #376 OPEN: "trash_block best-effort rename: lingering decryptable ciphertext + lost EXDEV signal".)
+2. **#379** — desktop `errors.rs` 726-line split (enum / `map_ffi_error` / serde tests). Pure refactor, under the 500-line guideline. Self-contained, TDD-friendly. (OPEN.)
+3. **Manual GUI smoke of the #374 consent flow** (human-only, still carried): `pnpm tauri dev` against a **temp copy** ([[feedback_smoke_test_temp_copy_golden_vault]]) of a vault with staged crashed-share residue (`core/tests/crash_recovery.rs::stage_crashed_share`). Confirm unlock → "Repair now?" → consent dialog renders the added recipient + grouped fingerprint → Cancel leaves vault untouched → Grant adopts the widened set. Also spot-check VoiceOver announces each dialog's title on open (#389 shipped).
+4. **Housekeeping:** #387 (`:kit` NewApi lint on `StrongBoxUnavailableException`, min SDK 26 / API 28), #290 (`spec_test_name_freshness.py` 3 pre-existing D.4 design-concept false-positives — Python, your strong area).
+5. **Carried mobile (on-device / human-only):** iOS Face ID spot-check; Android #338 on-device biometric cloud-open, #331 SAF custom-ROM, #334 native cloud-provider epic (ADR + threat-model first).
+
+## (3) Open decisions and risks
+
+- **None introduced this session.** Removed a redundant, already-failing dev script + a doc line — no `core`, no FFI surface, no spec, no error type, no runtime code touched. svelte-check (which stays green) fully subsumes the removed script's coverage, proven empirically above.
+- **#383 stays OPEN** (unchanged): drop RUSTSEC-2026-0194/0195 from `.cargo/audit.toml` only when `cargo tree -i quick-xml --target all` shows a single quick-xml ≥0.41 (both plist AND wayland-scanner moved). Re-check on every Tauri upgrade / any `cargo update` touching plist or the arboard/wayland clipboard chain. Do NOT `cargo update -p plist` in isolation.
+
+## (4) Exact commands to resume
+```bash
+cd /Users/hherb/src/secretary
+git fetch --prune origin && git checkout main && git pull --ff-only origin main
+# After this PR merges, drop the merged branch (squash-merge leaves it "not fully merged"):
+#   git branch -D feature/drop-desktop-typecheck-script-394
+git worktree list && git status -s
+# Re-run the desktop suite any time:
+cd desktop && pnpm test && pnpm run svelte-check && pnpm run lint
+```
+
+## (5) Handoff file model
+`NEXT_SESSION.md` is a **relative symlink** to this file in `docs/handoffs/`. Authored once here; the symlink is retargeted in the same commit on the feature branch (new path → no add/add conflict; `main` updates cleanly on merge). Per the baton convention the handoff rides inside the PR — do **not** sync to `main` during the pause window.
+
+## Closing inventory
+- **State on close:** PR opening on `feature/drop-desktop-typecheck-script-394` (2 commits: `c709194` code + this docs/handoff commit). No worktree used (2-line desktop change, edited on a branch in the main checkout off `main` @ `e99982d`). #394 closes on merge. Merged-#389 local branch cleaned up.
+- **Acceptance:** `pnpm test` → 604 passed; `pnpm run svelte-check` → 0 errors; `pnpm run lint` → clean; `pnpm typecheck` → correctly not found.
+- **README / ROADMAP:** no root-doc update needed — dev-tooling cleanup below the per-slice/milestone granularity those docs track (same call as the #388/#389 housekeeping items). The desktop-local README **was** updated (it's the one place that listed the script).
+- **NEXT_SESSION.md:** symlink → `docs/handoffs/2026-07-07-drop-desktop-typecheck-script-394-shipped.md`.


### PR DESCRIPTION
Closes #394.

## What

Removes the broken, redundant `typecheck` script (`tsc --noEmit`) from `desktop/package.json` and points the desktop README's type-check line at `pnpm svelte-check`.

## Why

Bare `tsc` cannot resolve a Svelte component's `<script module lang="ts">` named exports (e.g. `groupHex` from `RepairConsentDialog.svelte`, imported by its test), so `pnpm typecheck` failed with `TS2614` — a false alarm, not a real type error. It was never a CI gate (desktop CI runs only vitest).

`svelte-check` is the correct type checker for a Svelte + TS project and is a **strict superset** of what bare `tsc` provided — verified empirically before removing anything:

- **type-checks the `.ts` test files** — a planted `const x: number = "s"` in a `*.test.ts` was caught (`Type 'string' is not assignable to type 'number'`);
- **enforces the same strict tsconfig** — the same probe also tripped `noUnusedLocals`;
- **understands component module-context exports** — which bare `tsc` cannot (the whole `groupHex` failure).

`desktop/tsconfig.json` is retained unchanged — it's the config `svelte-check --tsconfig ./tsconfig.json` and the IDE both consume; only the redundant `tsc` entry point is gone.

## Verification (from `desktop/`)

```
pnpm test             # → 604 passed (604)
pnpm run svelte-check # → 332 FILES 0 ERRORS 0 WARNINGS
pnpm run lint         # → clean
pnpm typecheck        # → "typecheck" not found (script correctly gone)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)