### PR TITLE
feat(core): observable trash relocation (#376)

### DIFF
--- a/NEXT_SESSION.md
+++ b/NEXT_SESSION.md
@@ -1,1 +1,1 @@
-docs/handoffs/2026-07-07-split-desktop-errors-379-shipped.md
+docs/handoffs/2026-07-07-trash-relocation-observability-376-shipped.md

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -64,12 +64,13 @@ rand_core = "0.6"
 # `cargo update` silently move the resolved version within the 3.x
 # range; that auto-bump is exactly what we don't want here.
 tempfile = "=3.27.0"
-# `tracing` is used by `sync::ingest` to log silent-rejection
-# diagnostics at `tracing::debug!` when a candidate conflict-copy
-# fails one of the five MUST authentication rules. Caret-range pin is
-# acceptable here: tracing is a logging facade, not on the
-# security-critical path (the on-disk byte format and crypto
-# primitives are unchanged whether logs are captured or not).
+# `tracing` is used by `sync::ingest` (silent-rejection diagnostics at
+# `tracing::debug!` when a candidate conflict-copy fails one of the five
+# MUST authentication rules) and by `vault::trash_relocation` (#376:
+# `tracing::warn!` when a best-effort blocks/ → trash/ move fails). Caret-
+# range pin is acceptable here: tracing is a logging facade, not on the
+# security-critical path (the on-disk byte format and crypto primitives
+# are unchanged whether logs are captured or not).
 tracing = "0.1"
 
 [features]

--- a/core/src/vault/mod.rs
+++ b/core/src/vault/mod.rs
@@ -30,6 +30,7 @@ pub mod manifest;
 pub(crate) mod orchestrators;
 pub mod record;
 mod repair;
+pub(crate) mod trash_relocation;
 
 pub use block::{
     decode_block_file, decrypt_block, encode_block_file, encrypt_block, verify_block_signature,

--- a/core/src/vault/orchestrators.rs
+++ b/core/src/vault/orchestrators.rs
@@ -38,7 +38,7 @@ use crate::identity::fingerprint::{fingerprint, Fingerprint};
 use crate::unlock::{
     self, bundle::IdentityBundle, mnemonic::Mnemonic, vault_toml, UnlockedIdentity,
 };
-use crate::vault::trash_relocation::log_relocation;
+use crate::vault::trash_relocation::relocate_and_log;
 
 use super::ids::{BlockUuid, DeviceUuid, RecipientUuid};
 use super::{block, io, manifest};
@@ -2157,16 +2157,12 @@ pub fn trash_block(
     let dst = folder
         .join(TRASH_SUBDIR)
         .join(format!("{uuid_hex}{BLOCK_FILE_EXTENSION}.{now_ms}"));
-    // #376: no longer swallowed silently — log_relocation emits a structured
+    // #376: no longer swallowed silently — relocate_and_log emits a structured
     // warn! on persistent failure (EXDEV cross-mount trash/ distinguished from
     // other I/O errors) and returns the outcome, which we drop. The move stays
     // best-effort; every outcome leaves the vault correct and the block
     // restorable.
-    let _ = log_relocation(
-        &block_uuid,
-        std::fs::create_dir_all(folder.join(TRASH_SUBDIR))
-            .and_then(|()| std::fs::rename(&src, &dst)),
-    );
+    let _ = relocate_and_log(&block_uuid, &folder.join(TRASH_SUBDIR), &src, &dst);
 
     Ok(())
 }

--- a/core/src/vault/orchestrators.rs
+++ b/core/src/vault/orchestrators.rs
@@ -38,6 +38,7 @@ use crate::identity::fingerprint::{fingerprint, Fingerprint};
 use crate::unlock::{
     self, bundle::IdentityBundle, mnemonic::Mnemonic, vault_toml, UnlockedIdentity,
 };
+use crate::vault::trash_relocation::log_relocation;
 
 use super::ids::{BlockUuid, DeviceUuid, RecipientUuid};
 use super::{block, io, manifest};
@@ -2075,7 +2076,10 @@ pub(crate) const TRASH_SUBDIR: &str = "trash";
 /// into `trash/` so it doesn't linger indefinitely, but correctness does
 /// not depend on that sweep running. `EXDEV` is therefore no longer a
 /// `trash_block` abort condition — it degrades to the same best-effort
-/// residue as any other rename failure.
+/// residue as any other rename failure. Since #376 the failure is no longer
+/// silent: `log_relocation` emits a `tracing::warn!` (EXDEV distinguished
+/// from other I/O errors) so an operator can observe the lingering-orphan
+/// state; the relocation itself stays best-effort.
 pub fn trash_block(
     folder: &Path,
     open: &mut OpenVault,
@@ -2153,8 +2157,16 @@ pub fn trash_block(
     let dst = folder
         .join(TRASH_SUBDIR)
         .join(format!("{uuid_hex}{BLOCK_FILE_EXTENSION}.{now_ms}"));
-    let _ = std::fs::create_dir_all(folder.join(TRASH_SUBDIR))
-        .and_then(|()| std::fs::rename(&src, &dst));
+    // #376: no longer swallowed silently — log_relocation emits a structured
+    // warn! on persistent failure (EXDEV cross-mount trash/ distinguished from
+    // other I/O errors) and returns the outcome, which we drop. The move stays
+    // best-effort; every outcome leaves the vault correct and the block
+    // restorable.
+    let _ = log_relocation(
+        &block_uuid,
+        std::fs::create_dir_all(folder.join(TRASH_SUBDIR))
+            .and_then(|()| std::fs::rename(&src, &dst)),
+    );
 
     Ok(())
 }

--- a/core/src/vault/repair/sweep.rs
+++ b/core/src/vault/repair/sweep.rs
@@ -5,7 +5,7 @@ use crate::vault::manifest::Manifest;
 use crate::vault::orchestrators::{
     format_uuid_hyphenated, BLOCKS_SUBDIR, BLOCK_FILE_EXTENSION, TRASH_SUBDIR,
 };
-use crate::vault::trash_relocation::log_relocation;
+use crate::vault::trash_relocation::relocate_and_log;
 
 /// Best-effort completion of trash renames interrupted between
 /// `trash_block`'s manifest commit and its physical move (#350).
@@ -65,10 +65,6 @@ pub(crate) fn complete_pending_trash_renames(folder: &Path, manifest: &Manifest)
         // instead of swallowing it. Best-effort is unchanged — a vault that
         // cannot complete the move stays in the benign orphan state that
         // restore_block resumes from.
-        let _ = log_relocation(
-            &entry.block_uuid,
-            std::fs::create_dir_all(&trash_dir)
-                .and_then(|()| std::fs::rename(&blocks_path, &trash_path)),
-        );
+        let _ = relocate_and_log(&entry.block_uuid, &trash_dir, &blocks_path, &trash_path);
     }
 }

--- a/core/src/vault/repair/sweep.rs
+++ b/core/src/vault/repair/sweep.rs
@@ -5,6 +5,7 @@ use crate::vault::manifest::Manifest;
 use crate::vault::orchestrators::{
     format_uuid_hyphenated, BLOCKS_SUBDIR, BLOCK_FILE_EXTENSION, TRASH_SUBDIR,
 };
+use crate::vault::trash_relocation::log_relocation;
 
 /// Best-effort completion of trash renames interrupted between
 /// `trash_block`'s manifest commit and its physical move (#350).
@@ -17,14 +18,22 @@ use crate::vault::orchestrators::{
 /// Rename-only: no manifest mutation, no signing, no trust-state
 /// change — the gate is the *signed* content commitment, so an attacker
 /// who plants an arbitrary `blocks/` file cannot steer the sweep.
-/// Idempotent; every I/O failure is swallowed (a vault that cannot
-/// complete the move, e.g. cross-filesystem trash/, stays in the benign
-/// orphan state that `restore_block` resumes from).
+/// Idempotent; every I/O failure is logged at `tracing::warn!` (#376, via
+/// `log_relocation`, EXDEV distinguished) and otherwise tolerated — a vault
+/// that cannot complete the move, e.g. cross-filesystem trash/, stays in the
+/// benign orphan state that `restore_block` resumes from.
 pub(crate) fn complete_pending_trash_renames(folder: &Path, manifest: &Manifest) {
     let trash_dir = folder.join(TRASH_SUBDIR);
     let blocks_dir = folder.join(BLOCKS_SUBDIR);
     for entry in &manifest.trash {
-        // Legacy pre-#293 entry: no signed commitment → no safe gate.
+        // Legacy pre-#293 entry: no signed content commitment, so there is no
+        // safe gate against a planted blocks/ file — the sweep cannot relocate
+        // it. Deliberately NOT migrated (#376): no tagged release ever wrote a
+        // fingerprint==None entry, so no such vault exists in the wild; and
+        // because relocation is organizational-only, a never-swept legacy
+        // orphan is harmless — restore_block still recovers it via the §6.1
+        // hybrid-verify + suffix-equality fallback the spec documents for
+        // legacy entries.
         let Some(committed_fp) = entry.fingerprint else {
             continue;
         };
@@ -52,7 +61,14 @@ pub(crate) fn complete_pending_trash_renames(folder: &Path, manifest: &Manifest)
         if *blake3_hash(&bytes).as_bytes() != committed_fp {
             continue; // not the committed bytes — planted or clobbered
         }
-        let _ = std::fs::create_dir_all(&trash_dir)
-            .and_then(|()| std::fs::rename(&blocks_path, &trash_path));
+        // #376: log a persistent relocation failure (EXDEV / permissions)
+        // instead of swallowing it. Best-effort is unchanged — a vault that
+        // cannot complete the move stays in the benign orphan state that
+        // restore_block resumes from.
+        let _ = log_relocation(
+            &entry.block_uuid,
+            std::fs::create_dir_all(&trash_dir)
+                .and_then(|()| std::fs::rename(&blocks_path, &trash_path)),
+        );
     }
 }

--- a/core/src/vault/trash_relocation.rs
+++ b/core/src/vault/trash_relocation.rs
@@ -8,11 +8,13 @@
 //! turns that swallow into a structured `tracing::warn!` so a mis-configured
 //! vault is observable to an operator, while keeping the move best-effort.
 
+use std::path::Path;
+
 use crate::vault::orchestrators::format_uuid_hyphenated;
 
 /// Outcome of a best-effort `blocks/ → trash/` relocation, for logging only.
 ///
-/// `Relocated` covers success (and the already-relocated no-op). `CrossDevice`
+/// `Relocated` is a successful move. `CrossDevice`
 /// is EXDEV — `trash/` on a different filesystem than `blocks/`, an actionable
 /// mis-config. `OtherFailure` is any other I/O error (permissions, transient
 /// FS error). All three leave the vault correct and the block restorable.
@@ -23,10 +25,29 @@ pub(crate) enum RelocationOutcome {
     OtherFailure,
 }
 
+/// Perform the best-effort `blocks/ → trash/` move and log its outcome.
+///
+/// Single source of truth for the move idiom shared by `trash_block` and the
+/// open-time sweep: `create_dir_all(trash_dir)` then `rename(src, dst)`,
+/// routed through [`log_relocation`]. Best-effort — the returned outcome is
+/// informational (callers drop it); every outcome leaves the vault correct
+/// and the block restorable.
+pub(crate) fn relocate_and_log(
+    block_uuid: &[u8; 16],
+    trash_dir: &Path,
+    src: &Path,
+    dst: &Path,
+) -> RelocationOutcome {
+    log_relocation(
+        block_uuid,
+        std::fs::create_dir_all(trash_dir).and_then(|()| std::fs::rename(src, dst)),
+    )
+}
+
 /// Emit the operator-facing `warn!` for a relocation attempt and return its
-/// outcome. Callers drop the return value; it exists so the kind → message
-/// routing is unit-testable without capturing a `tracing` subscriber. Single
-/// source of truth for the mapping — matched exactly once.
+/// outcome. The return value is the test seam — it exists so the kind →
+/// message routing is unit-testable without capturing a `tracing` subscriber.
+/// Single source of truth for the mapping — matched exactly once.
 pub(crate) fn log_relocation(
     block_uuid: &[u8; 16],
     result: Result<(), std::io::Error>,

--- a/core/src/vault/trash_relocation.rs
+++ b/core/src/vault/trash_relocation.rs
@@ -62,7 +62,10 @@ mod tests {
     const UUID: [u8; 16] = [0x11; 16];
 
     #[test]
-    fn ok_result_is_relocated_and_emits_nothing() {
+    fn ok_result_maps_to_relocated() {
+        // The Ok arm returns `Relocated` and emits no warn! — the latter is
+        // true by inspection of the arm (no subscriber is installed here, so
+        // emission is not asserted); the name reflects only what is asserted.
         assert_eq!(log_relocation(&UUID, Ok(())), RelocationOutcome::Relocated);
     }
 

--- a/core/src/vault/trash_relocation.rs
+++ b/core/src/vault/trash_relocation.rs
@@ -27,16 +27,6 @@ pub(crate) enum RelocationOutcome {
 /// outcome. Callers drop the return value; it exists so the kind → message
 /// routing is unit-testable without capturing a `tracing` subscriber. Single
 /// source of truth for the mapping — matched exactly once.
-#[cfg_attr(
-    not(test),
-    expect(
-        dead_code,
-        reason = "consumed by the trash_block and open-time-sweep call \
-                  sites landing in the next two commits of #376; only the \
-                  unit tests exercise it so far, and cfg(test) builds call \
-                  it directly so no expectation applies there"
-    )
-)]
 pub(crate) fn log_relocation(
     block_uuid: &[u8; 16],
     result: Result<(), std::io::Error>,

--- a/core/src/vault/trash_relocation.rs
+++ b/core/src/vault/trash_relocation.rs
@@ -1,0 +1,96 @@
+//! Observability for the best-effort `blocks/ → trash/` relocation (#376).
+//!
+//! The physical move is organizational, not a security boundary: a trashed
+//! block's ciphertext is equally decryptable in `trash/` as in `blocks/`
+//! (same bytes, same recipient wraps), and every relocation outcome leaves a
+//! correct, restorable vault. Before #376 a persistent failure (EXDEV
+//! cross-mount `trash/`, permissions) was silently swallowed. This module
+//! turns that swallow into a structured `tracing::warn!` so a mis-configured
+//! vault is observable to an operator, while keeping the move best-effort.
+
+use crate::vault::orchestrators::format_uuid_hyphenated;
+
+/// Outcome of a best-effort `blocks/ → trash/` relocation, for logging only.
+///
+/// `Relocated` covers success (and the already-relocated no-op). `CrossDevice`
+/// is EXDEV — `trash/` on a different filesystem than `blocks/`, an actionable
+/// mis-config. `OtherFailure` is any other I/O error (permissions, transient
+/// FS error). All three leave the vault correct and the block restorable.
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) enum RelocationOutcome {
+    Relocated,
+    CrossDevice,
+    OtherFailure,
+}
+
+/// Emit the operator-facing `warn!` for a relocation attempt and return its
+/// outcome. Callers drop the return value; it exists so the kind → message
+/// routing is unit-testable without capturing a `tracing` subscriber. Single
+/// source of truth for the mapping — matched exactly once.
+#[cfg_attr(
+    not(test),
+    expect(
+        dead_code,
+        reason = "consumed by the trash_block and open-time-sweep call \
+                  sites landing in the next two commits of #376; only the \
+                  unit tests exercise it so far, and cfg(test) builds call \
+                  it directly so no expectation applies there"
+    )
+)]
+pub(crate) fn log_relocation(
+    block_uuid: &[u8; 16],
+    result: Result<(), std::io::Error>,
+) -> RelocationOutcome {
+    match &result {
+        Ok(()) => RelocationOutcome::Relocated,
+        Err(e) if e.kind() == std::io::ErrorKind::CrossesDevices => {
+            tracing::warn!(
+                block_uuid = %format_uuid_hyphenated(block_uuid),
+                "trash relocation skipped: trash/ is on a different filesystem than blocks/ \
+                 (EXDEV); the trashed ciphertext remains a benign, still-restorable orphan in \
+                 blocks/ — co-locate trash/ on the same mount to enable relocation"
+            );
+            RelocationOutcome::CrossDevice
+        }
+        Err(e) => {
+            tracing::warn!(
+                block_uuid = %format_uuid_hyphenated(block_uuid),
+                error = %e,
+                "trash relocation failed; trashed ciphertext remains a benign, still-restorable \
+                 orphan in blocks/"
+            );
+            RelocationOutcome::OtherFailure
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::{Error, ErrorKind};
+
+    const UUID: [u8; 16] = [0x11; 16];
+
+    #[test]
+    fn ok_result_is_relocated_and_emits_nothing() {
+        assert_eq!(log_relocation(&UUID, Ok(())), RelocationOutcome::Relocated);
+    }
+
+    #[test]
+    fn cross_device_error_maps_to_cross_device() {
+        let err = Error::from(ErrorKind::CrossesDevices);
+        assert_eq!(
+            log_relocation(&UUID, Err(err)),
+            RelocationOutcome::CrossDevice
+        );
+    }
+
+    #[test]
+    fn other_io_error_maps_to_other_failure() {
+        let err = Error::from(ErrorKind::PermissionDenied);
+        assert_eq!(
+            log_relocation(&UUID, Err(err)),
+            RelocationOutcome::OtherFailure
+        );
+    }
+}

--- a/docs/handoffs/2026-07-07-trash-relocation-observability-376-shipped.md
+++ b/docs/handoffs/2026-07-07-trash-relocation-observability-376-shipped.md
@@ -1,0 +1,74 @@
+# NEXT_SESSION.md — #376 observable trash relocation ✅ SHIPPED (PR opening)
+
+**Session date:** 2026-07-07. Closes **#376** ("trash_block best-effort rename: lingering decryptable ciphertext + lost EXDEV signal"). Branch `feature/trash-relocation-observability-376` cut from `main` @ `f15753f` (which already carries #379 via PR #398). Housekeeping first: confirmed #379/#398 merged, pulled `main`, force-deleted the stale merged local branch `feature/split-desktop-errors-379`.
+
+Design-first slice: brainstormed → spec → plan → subagent-driven execution (3 implementer/reviewer rounds + a final opus whole-branch review). The scope was deliberately narrowed during brainstorming (see "Design decisions" below) — the issue named three concerns; only one warranted code.
+
+## (1) What we shipped this session
+
+**#376 — restore the operator signal on a failed best-effort `blocks/ → trash/` relocation, without reintroducing an abort.** Since #350 the relocation is manifest-first and its `rename` result was *silently swallowed* (`let _ = create_dir_all(...).and_then(rename)`) at both `trash_block` and the open-time sweep. This session replaces the swallow with a structured `tracing::warn!` that distinguishes EXDEV (mis-configured cross-mount `trash/`, actionable) from other I/O failures. **On-disk behavior is unchanged** — relocation stays best-effort; every outcome still leaves a correct, restorable vault.
+
+New `pub(crate)` module [core/src/vault/trash_relocation.rs](core/src/vault/trash_relocation.rs) (~90 lines) exposing:
+- `enum RelocationOutcome { Relocated, CrossDevice, OtherFailure }`
+- `fn log_relocation(block_uuid: &[u8; 16], result: Result<(), std::io::Error>) -> RelocationOutcome` — matches the `Result` exactly once, emits the appropriate `warn!`, returns the outcome. EXDEV detection via the **stable** `std::io::ErrorKind::CrossesDevices` (no platform errno magic-number). The **return value is the test seam** — the 3 unit tests assert kind→outcome routing without a `tracing` subscriber.
+
+Both call sites rewired to it: [orchestrators.rs](core/src/vault/orchestrators.rs) `trash_block` step 6, [repair/sweep.rs](core/src/vault/repair/sweep.rs) `complete_pending_trash_renames`. Doc comments at both sites updated (swallow → logged at `warn!`); the sweep's legacy `fingerprint == None` arm gained the YAGNI rationale comment (below). `core/Cargo.toml` tracing-pin comment broadened to name the second consumer.
+
+### Design decisions (the two concerns we deliberately did NOT code)
+- **Concern #1 (secure-overwrite of lingering ciphertext) — category error, not done.** A trashed block is *equally decryptable* in `trash/` as in `blocks/` (same bytes, same recipient wraps); the move is organizational, not a security boundary. Secure-overwrite would destroy `restore_block` recoverability with zero exposure reduction. It belongs to a future *purge* op — filed as **#399** (which also records that purge's real "make unrecoverable" story is cryptographic crypto-shred of an owner-only block, not filesystem overwrite, which is unreliable on SSD/CoW).
+- **Concern #3 (legacy `fingerprint == None` migration) — YAGNI, not done.** `git tag` is empty → no released client ever wrote such an entry → no such vault exists. Relocation is organizational-only, so a never-swept legacy orphan is harmless and `restore_block` still recovers it via the §6.1 hybrid-verify + suffix-equality fallback the spec already documents. Reduced to a documented comment in the sweep's legacy arm.
+
+The final opus whole-branch review independently confirmed the "organizational, not a security boundary" argument is correct, EXDEV detection is portable on both primary targets (Linux+macOS), the manifest-first `Ok(())` contract is preserved, the sweep's signed-fingerprint gate is untouched, and nothing sensitive is logged (block UUID is manifest-public; `io::Error` from `rename` carries no path).
+
+### Branch commits (off `main` @ `f15753f`)
+- `23573f8` docs(core): design doc
+- `662fcf6` docs(core): implementation plan
+- `5c5b47a` feat(core): trash_relocation helper + 3 unit tests
+- `dbdff3c` feat(core): trash_block logs relocation failure
+- `3270715` feat(core): sweep logs relocation failure; document legacy arm; Cargo.toml comment
+- `31f5299` test(core): rename over-promising Ok test (final-review Minor)
+- → then this docs/handoff commit.
+
+### Acceptance (verified this session, from repo root)
+```bash
+cargo test --release --workspace                                  # → 84/84 suites, 0 failed
+cargo test --release -p secretary-core trash_relocation           # → 3 passed
+cargo clippy --release --workspace --tests -- -D warnings         # → clean (exit 0)
+cargo fmt --all --check                                           # → clean
+RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --workspace        # → clean (exit 0)
+```
+
+## (2) What's next
+
+Menu (unchanged minus #376, now shipped):
+
+1. **#399 (NEW) — design a purge / empty-trash operation.** Crypto-shred (owner-only blocks) vs best-effort overwrite (shared blocks = local cleanup only, with honest SSD/CoW caveats). **Design-heavy → brainstorm first, frozen-format constraints apply.** New lifecycle verb + spec section + FFI + UI. The natural sequel to #376.
+2. **Manual GUI smoke of the #374 consent flow** (human-only, still carried): `pnpm tauri dev` against a **temp copy** ([[feedback_smoke_test_temp_copy_golden_vault]]) of a vault with staged crashed-share residue (`core/tests/crash_recovery.rs::stage_crashed_share`). Unlock → "Repair now?" → consent dialog renders added recipient + grouped fingerprint → Cancel leaves vault untouched → Grant adopts the widened set. Spot-check VoiceOver announces each dialog title (#389 shipped).
+3. **Housekeeping:** #387 (`:kit` NewApi lint on `StrongBoxUnavailableException`, min SDK 26 / API 28), #290 (`spec_test_name_freshness.py` 3 D.4 design-concept false-positives — Python, your strong area), #383 (drop RUSTSEC-2026-0194/0195 from `.cargo/audit.toml` **only** when `cargo tree -i quick-xml --target all` shows a single quick-xml ≥0.41).
+4. **Carried mobile (on-device / human-only):** iOS Face ID spot-check; Android #338 on-device biometric cloud-open, #331 SAF custom-ROM, #334 native cloud-provider epic (ADR + threat-model first).
+
+## (3) Open decisions and risks
+
+- **None introduced this session.** Pure observability add on `core`; no crypto/on-disk-format/FFI/spec-byte change, no new error variant, no manifest/CRDT touch. `tracing` was already a `core` dep. The final review returned **Ready to merge: Yes**, 0 Critical/Important.
+- **Two final-review Minors:** #1 (test name over-promised "emits nothing") FIXED (`31f5299`). #2 (return-value seam doesn't assert `warn!` body/level — no subscriber capture) is an **accepted design tradeoff** on record: the seam is deliberate (avoids a global-subscriber harness for a non-security-critical log). `tracing-test` is the low-friction upgrade path if ever wanted; not worth a dev-dep here.
+- **#383 stays OPEN** (unchanged): re-check on every Tauri upgrade / any `cargo update` touching plist or the arboard/wayland clipboard chain. Do NOT `cargo update -p plist` in isolation.
+
+## (4) Exact commands to resume
+```bash
+cd /Users/hherb/src/secretary
+git fetch --prune origin && git checkout main && git pull --ff-only origin main
+# After this PR merges, drop the merged branch (squash-merge leaves it "not fully merged"):
+#   git branch -D feature/trash-relocation-observability-376
+git worktree list && git status -s
+# Re-run the core suite any time:
+cargo test --release -p secretary-core && cargo clippy --release --workspace --tests -- -D warnings
+```
+
+## (5) Handoff file model
+`NEXT_SESSION.md` is a **relative symlink** to this file in `docs/handoffs/`. Authored once here; the symlink retargeted in the same commit on the feature branch (new path → no add/add conflict; `main` updates cleanly on merge). Per the baton convention the handoff rides inside the PR — do **not** sync to `main` during the pause window.
+
+## Closing inventory
+- **State on close:** PR opening on `feature/trash-relocation-observability-376` (7 commits: `23573f8` design, `662fcf6` plan, `5c5b47a`+`dbdff3c`+`3270715` code, `31f5299` review-fix, + this docs/handoff commit). No worktree used (isolated `core` module add, edited on a branch in the main checkout off `main` @ `f15753f`). #376 closes on merge; comment on close recording the deliberate non-actions (#1 category error → #399; #3 YAGNI). Merged-#379 local branch cleaned up.
+- **Acceptance:** full workspace 84/84 suites green (0 failed); `trash_relocation` 3/3; clippy `-D warnings`, `cargo fmt --all --check`, rustdoc `-D warnings` all clean. Final opus whole-branch review: Ready to merge = Yes.
+- **README / ROADMAP:** no root-doc update needed — README/ROADMAP describe #350's manifest-first + best-effort-sweep *behavior*, which is preserved verbatim; adding a `warn!` is below their per-slice granularity and #376 isn't referenced. Same call as the #388/#389/#394 housekeeping items.
+- **NEXT_SESSION.md:** symlink → `docs/handoffs/2026-07-07-trash-relocation-observability-376-shipped.md`.

--- a/docs/superpowers/plans/2026-07-07-trash-relocation-observability.md
+++ b/docs/superpowers/plans/2026-07-07-trash-relocation-observability.md
@@ -1,0 +1,373 @@
+# Observable Trash Relocation (#376) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the silently-swallowed best-effort `blocks/ → trash/` relocation result at both `trash_block` and the open-time sweep with a structured `tracing::warn!` that distinguishes EXDEV (mis-configured cross-mount `trash/`) from other I/O failures.
+
+**Architecture:** One new `pub(crate)` module `core/src/vault/trash_relocation.rs` exposing `log_relocation(block_uuid, result) -> RelocationOutcome`. It matches the relocation `Result` once, emits the appropriate `warn!`, and returns the outcome (the return value is the test seam, so routing is asserted without a tracing subscriber). Two call sites swap `let _ = <reloc>` for `let _ = log_relocation(&uuid, <reloc>)`. On-disk behavior is unchanged — relocation stays best-effort; only observability is added.
+
+**Tech Stack:** Rust (stable, rustc ≥ 1.85 for `io::ErrorKind::CrossesDevices`; project tracks rolling stable at 1.96), `tracing` (already a `core` dep).
+
+## Global Constraints
+
+- Workspace is `#![forbid(unsafe_code)]` — no `unsafe`.
+- Clippy must stay clean: `cargo clippy --release --workspace --tests -- -D warnings`.
+- `cargo fmt --all --check` must be clean.
+- Rustdoc must be warning-clean: `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps -p secretary-core`.
+- No magic numbers: EXDEV detection via `std::io::ErrorKind::CrossesDevices`, never a raw OS errno constant.
+- No `core` crypto / on-disk-format / FFI / spec-byte change. No new `VaultError`/`FfiVaultError` variant.
+- Match the existing helper convention: `format_uuid_hyphenated` takes `&[u8; 16]` (a literal, not a `UUID_LEN` import — `UUID_LEN` is private).
+- Build/test always `--release` (crypto crates are slow in debug).
+- Commit message trailer: `Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>`.
+
+---
+
+### Task 1: New `trash_relocation` module (pure logging helper + unit tests)
+
+**Files:**
+- Create: `core/src/vault/trash_relocation.rs`
+- Modify: `core/src/vault/mod.rs` (add module declaration, after `mod repair;` at line 32)
+- Test: same file, `#[cfg(test)] mod tests`
+
+**Interfaces:**
+- Consumes: `crate::vault::orchestrators::format_uuid_hyphenated` (`pub(crate)`, `fn(&[u8; 16]) -> String`).
+- Produces:
+  - `pub(crate) enum RelocationOutcome { Relocated, CrossDevice, OtherFailure }` (derives `Debug, PartialEq, Eq`).
+  - `pub(crate) fn log_relocation(block_uuid: &[u8; 16], result: Result<(), std::io::Error>) -> RelocationOutcome`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `core/src/vault/trash_relocation.rs` with the test module only (the impl comes in Step 3, so this compiles-and-fails on the missing items):
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::{Error, ErrorKind};
+
+    const UUID: [u8; 16] = [0x11; 16];
+
+    #[test]
+    fn ok_result_is_relocated_and_emits_nothing() {
+        assert_eq!(log_relocation(&UUID, Ok(())), RelocationOutcome::Relocated);
+    }
+
+    #[test]
+    fn cross_device_error_maps_to_cross_device() {
+        let err = Error::from(ErrorKind::CrossesDevices);
+        assert_eq!(log_relocation(&UUID, Err(err)), RelocationOutcome::CrossDevice);
+    }
+
+    #[test]
+    fn other_io_error_maps_to_other_failure() {
+        let err = Error::from(ErrorKind::PermissionDenied);
+        assert_eq!(log_relocation(&UUID, Err(err)), RelocationOutcome::OtherFailure);
+    }
+}
+```
+
+Add the module declaration to `core/src/vault/mod.rs` immediately after `mod repair;` (line 32):
+
+```rust
+pub(crate) mod trash_relocation;
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cargo test --release -p secretary-core trash_relocation`
+Expected: FAIL — compile error, `cannot find function log_relocation` / `cannot find type RelocationOutcome`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Prepend the impl above the test module in `core/src/vault/trash_relocation.rs`:
+
+```rust
+//! Observability for the best-effort `blocks/ → trash/` relocation (#376).
+//!
+//! The physical move is organizational, not a security boundary: a trashed
+//! block's ciphertext is equally decryptable in `trash/` as in `blocks/`
+//! (same bytes, same recipient wraps), and every relocation outcome leaves a
+//! correct, restorable vault. Before #376 a persistent failure (EXDEV
+//! cross-mount `trash/`, permissions) was silently swallowed. This module
+//! turns that swallow into a structured `tracing::warn!` so a mis-configured
+//! vault is observable to an operator, while keeping the move best-effort.
+
+use crate::vault::orchestrators::format_uuid_hyphenated;
+
+/// Outcome of a best-effort `blocks/ → trash/` relocation, for logging only.
+///
+/// `Relocated` covers success (and the already-relocated no-op). `CrossDevice`
+/// is EXDEV — `trash/` on a different filesystem than `blocks/`, an actionable
+/// mis-config. `OtherFailure` is any other I/O error (permissions, transient
+/// FS error). All three leave the vault correct and the block restorable.
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) enum RelocationOutcome {
+    Relocated,
+    CrossDevice,
+    OtherFailure,
+}
+
+/// Emit the operator-facing `warn!` for a relocation attempt and return its
+/// outcome. Callers drop the return value; it exists so the kind → message
+/// routing is unit-testable without capturing a `tracing` subscriber. Single
+/// source of truth for the mapping — matched exactly once.
+pub(crate) fn log_relocation(
+    block_uuid: &[u8; 16],
+    result: Result<(), std::io::Error>,
+) -> RelocationOutcome {
+    match &result {
+        Ok(()) => RelocationOutcome::Relocated,
+        Err(e) if e.kind() == std::io::ErrorKind::CrossesDevices => {
+            tracing::warn!(
+                block_uuid = %format_uuid_hyphenated(block_uuid),
+                "trash relocation skipped: trash/ is on a different filesystem than blocks/ \
+                 (EXDEV); the trashed ciphertext remains a benign, still-restorable orphan in \
+                 blocks/ — co-locate trash/ on the same mount to enable relocation"
+            );
+            RelocationOutcome::CrossDevice
+        }
+        Err(e) => {
+            tracing::warn!(
+                block_uuid = %format_uuid_hyphenated(block_uuid),
+                error = %e,
+                "trash relocation failed; trashed ciphertext remains a benign, still-restorable \
+                 orphan in blocks/"
+            );
+            RelocationOutcome::OtherFailure
+        }
+    }
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cargo test --release -p secretary-core trash_relocation`
+Expected: PASS — 3 tests (`ok_result_is_relocated_and_emits_nothing`, `cross_device_error_maps_to_cross_device`, `other_io_error_maps_to_other_failure`).
+
+- [ ] **Step 5: Lint + format the new module**
+
+Run: `cargo clippy --release -p secretary-core --tests -- -D warnings && cargo fmt --all --check`
+Expected: clean (no warnings, no diff).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add core/src/vault/trash_relocation.rs core/src/vault/mod.rs
+git commit -m "feat(core): observable trash relocation helper (#376)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: Wire `log_relocation` into `trash_block`
+
+**Files:**
+- Modify: `core/src/vault/orchestrators.rs` (the `trash_block` step-6 relocation at ~line 2156, and its `# Crash consistency` doc paragraph at ~line 2059-2078)
+
+**Interfaces:**
+- Consumes: `crate::vault::trash_relocation::log_relocation` (from Task 1).
+- Produces: nothing new (behavior-preserving call-site change).
+
+- [ ] **Step 1: Add the import**
+
+At the top of `core/src/vault/orchestrators.rs`, in the existing `use crate::vault::...` cluster, add:
+
+```rust
+use crate::vault::trash_relocation::log_relocation;
+```
+
+- [ ] **Step 2: Swap the swallow for the logging helper**
+
+Replace the step-6 block (currently):
+
+```rust
+    let _ = std::fs::create_dir_all(folder.join(TRASH_SUBDIR))
+        .and_then(|()| std::fs::rename(&src, &dst));
+
+    Ok(())
+```
+
+with:
+
+```rust
+    // #376: no longer swallowed silently — log_relocation emits a structured
+    // warn! on persistent failure (EXDEV cross-mount trash/ distinguished from
+    // other I/O errors) and returns the outcome, which we drop. The move stays
+    // best-effort; every outcome leaves the vault correct and the block
+    // restorable.
+    let _ = log_relocation(
+        &block_uuid,
+        std::fs::create_dir_all(folder.join(TRASH_SUBDIR))
+            .and_then(|()| std::fs::rename(&src, &dst)),
+    );
+
+    Ok(())
+```
+
+- [ ] **Step 3: Update the `# Crash consistency` doc paragraph**
+
+In the `trash_block` doc comment, find the sentence ending `it degrades to the same best-effort residue as any other rename failure.` and append one sentence:
+
+```rust
+/// residue as any other rename failure. Since #376 the failure is no longer
+/// silent: [`log_relocation`](crate::vault::trash_relocation::log_relocation)
+/// emits a `tracing::warn!` (EXDEV distinguished from other I/O errors) so an
+/// operator can observe the lingering-orphan state; the relocation itself
+/// stays best-effort.
+```
+
+- [ ] **Step 4: Build + run the trash_block suite to confirm no behavior change**
+
+Run: `cargo test --release --workspace --test crash_recovery && cargo test --release -p secretary-core trash_block`
+Expected: PASS — all existing trash/restore/sweep tests green (on-disk outcome unchanged).
+
+- [ ] **Step 5: Lint, format, doc**
+
+Run: `cargo clippy --release -p secretary-core --tests -- -D warnings && cargo fmt --all --check && RUSTDOCFLAGS="-D warnings" cargo doc --no-deps -p secretary-core`
+Expected: clean (the intra-doc link to `log_relocation` resolves — it is `pub(crate)`, and rustdoc links to crate-private items are permitted when the linking item is itself crate-internal; if `private-intra-doc-links` warns, demote to a plain code span).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add core/src/vault/orchestrators.rs
+git commit -m "feat(core): trash_block logs relocation failure instead of swallowing (#376)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 3: Wire `log_relocation` into the open-time sweep + document the legacy arm
+
+**Files:**
+- Modify: `core/src/vault/repair/sweep.rs` (the relocation at lines 55-56, the doc line at ~22, and the legacy `fingerprint == None` arm at lines 27-30)
+
+**Interfaces:**
+- Consumes: `crate::vault::trash_relocation::log_relocation` (from Task 1).
+- Produces: nothing new (behavior-preserving call-site change + doc).
+
+- [ ] **Step 1: Add the import**
+
+In `core/src/vault/repair/sweep.rs`, extend the existing `use crate::vault::...` imports with:
+
+```rust
+use crate::vault::trash_relocation::log_relocation;
+```
+
+- [ ] **Step 2: Swap the swallow for the logging helper**
+
+Replace (lines 55-56):
+
+```rust
+        let _ = std::fs::create_dir_all(&trash_dir)
+            .and_then(|()| std::fs::rename(&blocks_path, &trash_path));
+```
+
+with:
+
+```rust
+        // #376: log a persistent relocation failure (EXDEV / permissions)
+        // instead of swallowing it. Best-effort is unchanged — a vault that
+        // cannot complete the move stays in the benign orphan state that
+        // restore_block resumes from.
+        let _ = log_relocation(
+            &entry.block_uuid,
+            std::fs::create_dir_all(&trash_dir)
+                .and_then(|()| std::fs::rename(&blocks_path, &trash_path)),
+        );
+```
+
+- [ ] **Step 3: Update the module doc line**
+
+In the `complete_pending_trash_renames` doc comment, replace:
+
+```rust
+/// Idempotent; every I/O failure is swallowed (a vault that cannot
+/// complete the move, e.g. cross-filesystem trash/, stays in the benign
+/// orphan state that `restore_block` resumes from).
+```
+
+with:
+
+```rust
+/// Idempotent; every I/O failure is logged at `tracing::warn!` (#376, via
+/// `log_relocation`, EXDEV distinguished) and otherwise tolerated — a vault
+/// that cannot complete the move, e.g. cross-filesystem trash/, stays in the
+/// benign orphan state that `restore_block` resumes from.
+```
+
+- [ ] **Step 4: Expand the legacy `fingerprint == None` arm comment**
+
+Replace (lines 27-30):
+
+```rust
+        // Legacy pre-#293 entry: no signed commitment → no safe gate.
+        let Some(committed_fp) = entry.fingerprint else {
+            continue;
+        };
+```
+
+with:
+
+```rust
+        // Legacy pre-#293 entry: no signed content commitment, so there is no
+        // safe gate against a planted blocks/ file — the sweep cannot relocate
+        // it. Deliberately NOT migrated (#376): no tagged release ever wrote a
+        // fingerprint==None entry, so no such vault exists in the wild; and
+        // because relocation is organizational-only, a never-swept legacy
+        // orphan is harmless — restore_block still recovers it via the §6.1
+        // hybrid-verify + suffix-equality fallback the spec documents for
+        // legacy entries.
+        let Some(committed_fp) = entry.fingerprint else {
+            continue;
+        };
+```
+
+- [ ] **Step 5: Run the sweep suite to confirm no behavior change**
+
+Run: `cargo test --release --workspace --test crash_recovery`
+Expected: PASS — including `sweep_skips_legacy_entry_without_fingerprint`, `open_vault_sweep_relocates_interrupted_trash`, `sweep_skips_orphan_with_wrong_fingerprint`, `sweep_skips_live_uuid`.
+
+- [ ] **Step 6: Lint, format, doc**
+
+Run: `cargo clippy --release -p secretary-core --tests -- -D warnings && cargo fmt --all --check && RUSTDOCFLAGS="-D warnings" cargo doc --no-deps -p secretary-core`
+Expected: clean.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add core/src/vault/repair/sweep.rs
+git commit -m "feat(core): open-time sweep logs relocation failure; document legacy arm (#376)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 4: Full-workspace verification
+
+**Files:** none (verification only).
+
+- [ ] **Step 1: Full workspace test**
+
+Run: `cargo test --release --workspace`
+Expected: PASS — entire suite green.
+
+- [ ] **Step 2: Full workspace lint + format + doc gates**
+
+Run: `cargo clippy --release --workspace --tests -- -D warnings && cargo fmt --all --check && RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --workspace`
+Expected: all clean.
+
+- [ ] **Step 3: Confirm no unintended surface change**
+
+Run: `git diff --stat main...HEAD`
+Expected: only `core/src/vault/trash_relocation.rs` (new), `core/src/vault/mod.rs`, `core/src/vault/orchestrators.rs`, `core/src/vault/repair/sweep.rs`, and the two `docs/superpowers/` files. No FFI, no `docs/vault-format.md`, no `docs/crypto-design.md`, no manifest/format code.
+
+---
+
+## Post-plan wrap (handled outside task execution)
+
+- README / ROADMAP: no change expected — an internal observability fix below the per-slice/milestone granularity those docs track. Confirm no reference to trash relocation logging exists that would need updating.
+- Close #376 on merge with a comment recording the deliberate non-actions: concern #1 (secure-overwrite = category error, tracked for a future purge op as #399) and concern #3 (legacy migration = YAGNI).
+- Update the handoff doc + retarget `NEXT_SESSION.md` symlink, commit on this branch before opening the PR.

--- a/docs/superpowers/specs/2026-07-07-trash-relocation-observability-design.md
+++ b/docs/superpowers/specs/2026-07-07-trash-relocation-observability-design.md
@@ -1,0 +1,151 @@
+# Design: observable trash relocation (#376)
+
+**Date:** 2026-07-07
+**Issue:** #376 — *trash_block best-effort rename: lingering decryptable ciphertext + lost EXDEV signal*
+**Refs:** #350 (manifest-first `trash_block`), #375, #351 (restore resume), #293 (signed content commitment)
+**Scope:** `core` only. No crypto / on-disk-format / FFI / spec-byte change.
+
+## Problem
+
+Since #350, `trash_block` is manifest-first: the signed-manifest write is the commit point and
+the physical `blocks/ → trash/` rename is best-effort, with **all** failures swallowed
+(`let _ = create_dir_all(...).and_then(rename)`). The open-time sweep
+`complete_pending_trash_renames` swallows identically. The #375/#350 review flagged three
+residual concerns. This design resolves each explicitly:
+
+1. **Decryptable ciphertext lingers in `blocks/`** on cross-filesystem (`EXDEV`) or persistent
+   permission failure.
+2. **Lost operator signal.** The pre-#350 `trash_block` returned a typed `EXDEV` `Io` error
+   signalling a mis-configured vault (`trash/` on a different mount). That signal is now
+   silently discarded.
+3. **Legacy `fingerprint == None` trash entries** are skipped by the sweep at the first check
+   (no signed commitment ⇒ no safe gate), so such an orphan can never be swept.
+
+## Decisions
+
+### Concern #1 (secure-overwrite) — **not done, by design (category error).**
+
+Trash is restorable by design: `restore_block` resumes from exactly the orphaned `blocks/` file.
+A trashed block's ciphertext is **equally decryptable** whether it sits in `blocks/` or in
+`trash/` — both are the same bytes wrapped to the same recipients. The `blocks/ → trash/` move is
+*organizational*, not a security boundary. A "secure-overwrite fallback for the un-relocatable
+ciphertext" would therefore destroy the block's restorability while providing **no** exposure
+reduction over a correctly-relocated `trash/` file. Secure overwrite belongs to a hypothetical
+future *purge / empty-trash* operation (which does not exist in the codebase today), not to
+`trash_block`. Recorded in the issue on close.
+
+### Concern #2 (lost operator signal) — **the fix.**
+
+Replace the silent swallow at both call sites with a structured `tracing::warn!`, distinguishing
+cross-device (`EXDEV`, actionable — operator should co-locate `trash/`) from other I/O failures.
+`tracing` is already a `core` dependency (used by `sync::ingest` as a logging facade). Detection
+uses `std::io::ErrorKind::CrossesDevices` (stable on the project's rolling-stable toolchain, rustc
+1.96) — **no platform magic-number `EXDEV` constant**. Control flow is unchanged: relocation stays
+best-effort, every outcome still leaves a correct, restorable vault.
+
+### Concern #3 (legacy migration) — **not done, by design (YAGNI + documented).**
+
+No tagged release exists (`git tag` is empty); no v1 client has ever written a `fingerprint == None`
+trash entry, so no such vault exists in the wild. Because relocation is organizational-only
+(see #1), a never-swept legacy orphan is a harmless benign orphan, and `restore_block` still works
+via the §6.1 hybrid-verify + suffix-equality fallback the spec already documents for legacy
+entries. The sweep's legacy arm gets an expanded comment recording this rationale; **no migration
+code**. Recorded in the issue on close.
+
+## Architecture
+
+One new small module, one concept: *make a best-effort relocation observable*.
+
+**New file `core/src/vault/trash_relocation.rs`** (~70 lines incl. docs + tests), registered
+`pub(crate) mod trash_relocation;` in `core/src/vault/mod.rs`. Shared by the two call sites that
+today swallow the relocation result.
+
+```rust
+/// Outcome of a best-effort blocks/ → trash/ relocation, for logging only.
+/// Relocation is organizational (§7): every outcome leaves a correct,
+/// restorable vault. This exists so a *persistent* failure is observable
+/// instead of silently swallowed (#376).
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) enum RelocationOutcome { Relocated, CrossDevice, OtherFailure }
+
+/// Emit the operator-facing warn! for a relocation attempt and return the
+/// outcome. Callers drop the return; the return value is the test seam so
+/// routing is asserted without capturing a tracing subscriber. Single
+/// source of truth for the kind → message mapping.
+pub(crate) fn log_relocation(
+    block_uuid: &[u8; UUID_LEN],
+    result: Result<(), std::io::Error>,
+) -> RelocationOutcome {
+    match &result {
+        Ok(()) => RelocationOutcome::Relocated,
+        Err(e) if e.kind() == std::io::ErrorKind::CrossesDevices => {
+            tracing::warn!(block_uuid = %format_uuid_hyphenated(block_uuid),
+                "trash relocation skipped: trash/ is on a different filesystem than blocks/ \
+                 (EXDEV); the trashed ciphertext remains a benign, still-restorable orphan in \
+                 blocks/ — co-locate trash/ on the same mount to enable relocation");
+            RelocationOutcome::CrossDevice
+        }
+        Err(e) => {
+            tracing::warn!(block_uuid = %format_uuid_hyphenated(block_uuid), error = %e,
+                "trash relocation failed; trashed ciphertext remains a benign, still-restorable \
+                 orphan in blocks/");
+            RelocationOutcome::OtherFailure
+        }
+    }
+}
+```
+
+One function, matched once — no duplicated classification, no `unwrap`, no `unreachable!`. The
+kind → outcome decision is fully covered by the return value. Imports `format_uuid_hyphenated`
+(`pub(crate)` in `orchestrators`) and `UUID_LEN`.
+
+## Call-site changes (behavior-preserving)
+
+- **`core/src/vault/orchestrators.rs` `trash_block` step 6:**
+  `let _ = create_dir_all(...).and_then(rename)` →
+  `let _ = log_relocation(&block_uuid, create_dir_all(...).and_then(rename));`.
+  Update the `# Crash consistency` doc paragraph: swallow → "logged at `warn!` (EXDEV
+  distinguished)".
+- **`core/src/vault/repair/sweep.rs`:** same swap using `entry.block_uuid`. Update the doc line
+  "every I/O failure is swallowed" → "logged at `warn!`". Expand the legacy `fingerprint == None`
+  arm's comment with the YAGNI rationale above.
+
+## Testing (TDD — tests first)
+
+Unit tests in `trash_relocation.rs` `#[cfg(test)]`, no filesystem needed:
+
+1. `Ok(())` → `Relocated`
+2. `Err(io::Error::from(ErrorKind::CrossesDevices))` → `CrossDevice`
+3. `Err(io::Error::from(ErrorKind::PermissionDenied))` → `OtherFailure`
+
+The existing `core/tests/crash_recovery.rs` sweep tests
+(`open_vault_sweep_relocates_interrupted_trash`, `sweep_skips_legacy_entry_without_fingerprint`,
+`sweep_skips_orphan_with_wrong_fingerprint`, `sweep_skips_live_uuid`) and the full
+`trash_block` / `restore_block` suite must stay green — they assert the on-disk outcome, which is
+unchanged. The `warn!` emits into the void without a subscriber, so no test flakes.
+
+## Non-goals / guardrails
+
+- No secure-overwrite; no purge operation (out of scope — tracked as #399, which also records
+  why a purge's real "make unrecoverable" story is cryptographic (crypto-shred an owner-only
+  block) rather than filesystem overwrite, and why overwrite is unreliable on SSD/CoW storage).
+- No legacy migration; no manifest re-sign.
+- No `docs/vault-format.md` change: §7 (lines 459, 468) documents the best-effort move and
+  EXDEV-pending state but makes no normative claim that the failure is *silent*; logging is an
+  observability concern, not on-disk format.
+- No new `FfiVaultError`/`VaultError` variant; no FFI surface touched.
+
+## Acceptance
+
+```bash
+cd /Users/hherb/src/secretary
+cargo test --release --workspace --test crash_recovery          # sweep suite green
+cargo test --release -p secretary-core trash_relocation         # new unit tests pass
+cargo test --release --workspace                                # full suite green
+cargo clippy --release --workspace --tests -- -D warnings       # clean
+cargo fmt --all --check                                         # clean
+RUSTDOCFLAGS="-D warnings" cargo doc --no-deps -p secretary-core # clean
+```
+
+Close #376 with a comment recording the deliberate non-actions on concerns #1 (category error)
+and #3 (YAGNI).


### PR DESCRIPTION
Closes #376.

## What

Restores the operator signal on a failed best-effort `blocks/ → trash/` relocation, without reintroducing an abort. Since #350 the relocation is manifest-first and its `rename` result was **silently swallowed** at both `trash_block` and the open-time sweep. This replaces the swallow with a structured `tracing::warn!` that distinguishes EXDEV (mis-configured cross-mount `trash/`, actionable) from other I/O failures.

**On-disk behavior is unchanged** — relocation stays best-effort; every outcome still leaves a correct, restorable vault. No crypto / on-disk-format / FFI / spec-byte change; no new error variant.

- New `pub(crate)` module `core/src/vault/trash_relocation.rs`: `log_relocation(block_uuid, result) -> RelocationOutcome`, matched once, returns the outcome (the return value is the unit-test seam — no `tracing` subscriber needed). EXDEV via the stable `io::ErrorKind::CrossesDevices` (no errno magic-number).
- Both call sites (`trash_block` step 6, `complete_pending_trash_renames`) rewired; doc comments updated; the sweep's legacy `fingerprint == None` arm gained a YAGNI rationale comment; `core/Cargo.toml` tracing-pin comment broadened to name the second consumer.

## Scope decisions (two issue concerns deliberately NOT coded)

- **Secure-overwrite (concern #1) — category error, not done.** A trashed block is equally decryptable in `trash/` as in `blocks/` (same bytes, same recipient wraps); the move is organizational, not a security boundary. Overwrite would destroy `restore_block` recoverability with zero exposure reduction. Belongs to a future purge op — filed as #399.
- **Legacy `fingerprint == None` migration (concern #3) — YAGNI, not done.** No tagged release exists → no such vault exists. Reduced to a documented comment; restore still recovers such entries via the spec's §6.1 hybrid-verify + suffix-equality fallback.

## Process

Brainstorm → spec → plan → subagent-driven execution (3 implementer/reviewer rounds + a final Opus whole-branch review, which returned **Ready to merge: Yes**, 0 Critical/Important, and independently confirmed the security reasoning). Design + plan under `docs/superpowers/`.

## Test plan

- `cargo test --release --workspace` → 84/84 suites, 0 failed
- `cargo test --release -p secretary-core trash_relocation` → 3 passed
- `cargo clippy --release --workspace --tests -- -D warnings` → clean
- `cargo fmt --all --check` → clean
- `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --workspace` → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)